### PR TITLE
fix: make NPUMemoryModel thread-local to eliminate concurrent simulation data races

### DIFF
--- a/include/pto/cpu/NPUMemoryModel.hpp
+++ b/include/pto/cpu/NPUMemoryModel.hpp
@@ -14,6 +14,10 @@
  * Provides UB, L1, L0A, L0B, L0C memory buffers sized per NPU architecture.
  * TASSIGN maps tiles to offsets within these buffers based on TileType.
  *
+ * Each thread gets its own independent NPUMemoryModel instance via
+ * thread_local storage, accurately modeling the hardware where each
+ * AICore has physically separate UB/L0 memory.
+ *
  * Memory mapping:
  *   - Vec tiles   → UB (Unified Buffer)
  *   - Mat tiles   → L1
@@ -76,13 +80,22 @@ enum class MemoryRegion
 
 class NPUMemoryModel {
 public:
+    // Each thread gets its own NPUMemoryModel instance, accurately modeling
+    // the hardware where each AICore has physically separate memory.
     static NPUMemoryModel &Instance()
     {
-        static NPUMemoryModel instance;
+        thread_local NPUMemoryModel instance;
         return instance;
     }
 
-    // Initialize with specific architecture (call once at startup)
+    // Set the default architecture for all threads.
+    // Call once before any thread uses Instance().
+    static void SetDefaultArch(NPUArch arch)
+    {
+        defaultArch_ = arch;
+    }
+
+    // Initialize with specific architecture (call once per thread at startup)
     void Initialize(NPUArch arch)
     {
         switch (arch) {
@@ -108,7 +121,7 @@ public:
     void EnsureInitialized()
     {
         if (!initialized_) {
-            Initialize(NPUArch::A2A3);
+            Initialize(defaultArch_);
         }
     }
 
@@ -213,6 +226,10 @@ public:
 private:
     NPUMemoryModel() = default;
 
+    // Shared default architecture — set once, read by all threads during auto-init
+    static inline NPUArch defaultArch_ = NPUArch::A2A3;
+
+    // Per-thread memory buffers (thread_local instance owns these)
     std::vector<char> ubBuffer_;
     std::vector<char> l1Buffer_;
     std::vector<char> l0aBuffer_;

--- a/include/pto/cpu/TAssign.hpp
+++ b/include/pto/cpu/TAssign.hpp
@@ -65,9 +65,11 @@ PTO_INTERNAL void TASSIGN_IMPL(T &obj, AddrType addr)
 
 #ifdef __CPU_SIM
 // Initialize NPU memory model with specific architecture
-// Call once at program start (optional, defaults to A2A3)
+// Sets the default arch for all threads, and initializes the calling thread's instance.
+// Other threads auto-initialize via EnsureInitialized() on first use.
 inline void NPU_MEMORY_INIT(NPUArch arch = NPUArch::A2A3)
 {
+    NPUMemoryModel::SetDefaultArch(arch);
     NPUMemoryModel::Instance().Initialize(arch);
 }
 


### PR DESCRIPTION
## Summary

- **Root cause**: `NPUMemoryModel::Instance()` used a process-level `static` singleton, so all
  simulated AICore threads shared a single set of UB/L1/L0 memory buffers. Concurrent kernel
  tasks (via `TASSIGN`/`TLOAD`) overwrote each other's data, causing deterministic failures
  under multi-threaded simulation (e.g. paged_attention: low pass rate at block_dim=24).
- **Fix**: Change `static NPUMemoryModel instance` → `thread_local NPUMemoryModel instance`,
  giving each simulated AICore its own isolated memory — accurately modeling real hardware
  where each AICore has physically separate UB/L0 memory.
- **Supporting change**: Add `NPUMemoryModel::SetDefaultArch()` so the architecture can be
  configured once in the main thread while each worker thread auto-initializes its own
  instance on first use via `EnsureInitialized()`.

## Problem

On real Ascend hardware, each AICore has physically independent memory. 
The CPU simulation (`__CPU_SIM`) modeled all cores with a single shared
`NPUMemoryModel` instance. When the runtime scheduler ran concurrent kernel tasks on
different threads (which is correct behavior — e.g. `ONLINE_UPDATE(block N)` overlapping
with `SOFTMAX_PREPARE(block N+1)`), their `TASSIGN`-mapped tile pointers aliased to the same
buffer offsets, causing silent data corruption.


## Test

- [x] Run paged_attention simulation with original multi-threaded config (4 threads, block_dim=24) — verify pass rate recovers to ~100%
- [x] Verify on-device tests remain passing

Related issue: https://github.com/PTO-ISA/pto-isa/issues/7