### PR TITLE
Refactor: replace cpu_sim hooks with hardware-semantic hooks

### DIFF
--- a/include/pto/common/cpu_stub.hpp
+++ b/include/pto/common/cpu_stub.hpp
@@ -16,7 +16,6 @@ See LICENSE in the root of the software repository for the full text of the Lice
 #include <cstring>
 #include <cassert>
 #include <cstdio>
-#include <dlfcn.h>
 
 #define __global__
 #define AICORE
@@ -85,42 +84,25 @@ typedef int event_t;
 #define EVENT_ID0 0
 
 namespace pto::cpu_sim {
-using SetExecutionContextHookFn = void (*)(uint32_t block_idx, uint32_t subblock_id, uint32_t subblock_dim);
-using GetExecutionContextHookFn = void (*)(uint32_t *block_idx, uint32_t *subblock_id, uint32_t *subblock_dim);
-using GetSharedStorageHookFn = void *(*)(const char *key, size_t size);
-using GetTaskCookieHookFn = uint64_t (*)();
+using GetSubblockIdHookFn = uint32_t (*)();
+using GetPipeSharedStateHookFn = void *(*)(uint64_t pipe_key, size_t size);
 
-inline SetExecutionContextHookFn ResolveSetExecutionContextHook()
+inline GetSubblockIdHookFn &get_subblock_id_hook()
 {
-    static auto hook =
-        reinterpret_cast<SetExecutionContextHookFn>(dlsym(RTLD_DEFAULT, "pto_cpu_sim_set_execution_context"));
-    return hook;
+    static GetSubblockIdHookFn fn = nullptr;
+    return fn;
 }
 
-inline GetExecutionContextHookFn ResolveExecutionContextHook()
+inline GetPipeSharedStateHookFn &get_pipe_shared_state_hook()
 {
-    static auto hook =
-        reinterpret_cast<GetExecutionContextHookFn>(dlsym(RTLD_DEFAULT, "pto_cpu_sim_get_execution_context"));
-    return hook;
-}
-
-inline GetSharedStorageHookFn ResolveSharedStorageHook()
-{
-    static auto hook = reinterpret_cast<GetSharedStorageHookFn>(dlsym(RTLD_DEFAULT, "pto_cpu_sim_get_shared_storage"));
-    return hook;
-}
-
-inline GetTaskCookieHookFn ResolveTaskCookieHook()
-{
-    static auto hook = reinterpret_cast<GetTaskCookieHookFn>(dlsym(RTLD_DEFAULT, "pto_cpu_sim_get_task_cookie"));
-    return hook;
+    static GetPipeSharedStateHookFn fn = nullptr;
+    return fn;
 }
 
 struct ExecutionContext {
     uint32_t block_idx = 0;
     uint32_t subblock_id = 0;
     uint32_t subblock_dim = 1;
-    uint64_t task_cookie = 0;
 };
 
 inline thread_local ExecutionContext execution_context{};
@@ -130,19 +112,11 @@ inline void set_execution_context(uint32_t block_idx, uint32_t subblock_id, uint
     execution_context.block_idx = block_idx;
     execution_context.subblock_id = subblock_id;
     execution_context.subblock_dim = (subblock_dim == 0) ? 1 : subblock_dim;
-    if (auto hook = ResolveSetExecutionContextHook(); hook != nullptr) {
-        hook(execution_context.block_idx, execution_context.subblock_id, execution_context.subblock_dim);
-    }
 }
 
 inline void reset_execution_context()
 {
     execution_context = {};
-}
-
-inline void set_task_cookie(uint64_t task_cookie)
-{
-    execution_context.task_cookie = task_cookie;
 }
 
 class ScopedExecutionContext {
@@ -163,48 +137,53 @@ private:
 };
 } // namespace pto::cpu_sim
 
+/**
+ * Register simulation hook function pointers for this SO.
+ *
+ * Called by the sim platform (DeviceRunner) after dlopen'ing each kernel SO.
+ * Each SO has its own copy of the inline static function pointers, so every
+ * SO that uses TPUSH/TPOP must be registered.
+ *
+ * Pass nullptr to clear hooks (fallback to thread_local execution context).
+ */
+extern "C" __attribute__((visibility("default"), used)) inline void pto_sim_register_hooks(void *get_subblock_id,
+                                                                                           void *get_pipe_shared_state)
+{
+    pto::cpu_sim::get_subblock_id_hook() = reinterpret_cast<pto::cpu_sim::GetSubblockIdHookFn>(get_subblock_id);
+    pto::cpu_sim::get_pipe_shared_state_hook() =
+        reinterpret_cast<pto::cpu_sim::GetPipeSharedStateHookFn>(get_pipe_shared_state);
+}
+
+/**
+ * Set the execution context (block_idx, subblock_id, subblock_dim) for this SO.
+ *
+ * Each dlopen'd kernel SO has its own thread_local execution_context. The sim
+ * platform must dlsym this symbol after dlopen and call it before each kernel
+ * dispatch so that get_block_idx() / get_subblockdim() return correct values.
+ */
+extern "C" __attribute__((visibility("default"), used)) inline void pto_sim_set_execution_context(uint32_t block_idx,
+                                                                                                  uint32_t subblock_id,
+                                                                                                  uint32_t subblock_dim)
+{
+    pto::cpu_sim::set_execution_context(block_idx, subblock_id, subblock_dim);
+}
+
 inline uint32_t get_block_idx()
 {
-    if (auto hook = pto::cpu_sim::ResolveExecutionContextHook(); hook != nullptr) {
-        uint32_t block_idx = 0;
-        uint32_t subblock_id = 0;
-        uint32_t subblock_dim = 1;
-        hook(&block_idx, &subblock_id, &subblock_dim);
-        return block_idx;
-    }
     return pto::cpu_sim::execution_context.block_idx;
 }
 
 inline uint32_t get_subblockid()
 {
-    if (auto hook = pto::cpu_sim::ResolveExecutionContextHook(); hook != nullptr) {
-        uint32_t block_idx = 0;
-        uint32_t subblock_id = 0;
-        uint32_t subblock_dim = 1;
-        hook(&block_idx, &subblock_id, &subblock_dim);
-        return subblock_id;
+    if (auto hook = pto::cpu_sim::get_subblock_id_hook(); hook != nullptr) {
+        return hook();
     }
     return pto::cpu_sim::execution_context.subblock_id;
 }
 
 inline uint32_t get_subblockdim()
 {
-    if (auto hook = pto::cpu_sim::ResolveExecutionContextHook(); hook != nullptr) {
-        uint32_t block_idx = 0;
-        uint32_t subblock_id = 0;
-        uint32_t subblock_dim = 1;
-        hook(&block_idx, &subblock_id, &subblock_dim);
-        return subblock_dim;
-    }
     return pto::cpu_sim::execution_context.subblock_dim;
-}
-
-inline uint64_t get_task_cookie()
-{
-    if (auto hook = pto::cpu_sim::ResolveTaskCookieHook(); hook != nullptr) {
-        return hook();
-    }
-    return pto::cpu_sim::execution_context.task_cookie;
 }
 
 #endif

--- a/include/pto/cpu/TPush.hpp
+++ b/include/pto/cpu/TPush.hpp
@@ -152,12 +152,12 @@ struct TPipe {
 
     PTO_INTERNAL static SharedState &GetSharedState()
     {
-        if (auto hook = cpu_sim::ResolveSharedStorageHook(); hook != nullptr) {
-            char key[128] = {};
-            std::snprintf(key, sizeof(key), "pto-pipe-%llu-%u-%u-%u-%u-%u-%u",
-                          static_cast<unsigned long long>(get_task_cookie()), get_block_idx(), FlagID, DirType,
-                          SlotSize, SlotNum, LocalSlotNum);
-            auto *storage = reinterpret_cast<SharedStateStorage *>(hook(key, sizeof(SharedStateStorage)));
+        if (auto hook = cpu_sim::get_pipe_shared_state_hook(); hook != nullptr) {
+            static_assert(SlotNum <= 0xFF && LocalSlotNum <= 0xFF,
+                          "pipe_key packs SlotNum/LocalSlotNum into 8 bits each; values must be <= 255");
+            uint64_t pipe_key = (uint64_t(FlagID) << 56) | (uint64_t(DirType) << 48) | (uint64_t(SlotNum) << 40) |
+                                (uint64_t(LocalSlotNum) << 32) | uint64_t(SlotSize);
+            auto *storage = reinterpret_cast<SharedStateStorage *>(hook(pipe_key, sizeof(SharedStateStorage)));
             EnsureSharedStateInitialized(*storage);
             return *std::launder(reinterpret_cast<SharedState *>(storage->payload));
         }
@@ -392,8 +392,8 @@ PTO_INTERNAL void TPUSH_IMPL(Pipe &pipe, TileProd &tile)
         } else {
             auto &slotStorage = Pipe::GetSharedState().local_slot_storage[slotIndex];
             for (uint32_t splitIndex = 0; splitIndex < cpu_pipe::GetSplitCount<Split>(); ++splitIndex) {
-                auto *slotPtr = reinterpret_cast<T *>(slotStorage.data() +
-                                                      splitIndex * Pipe::RingFiFo::SLOT_SIZE + pipe.prod.entryOffset);
+                auto *slotPtr = reinterpret_cast<T *>(slotStorage.data() + splitIndex * Pipe::RingFiFo::SLOT_SIZE +
+                                                      pipe.prod.entryOffset);
                 const uint32_t rowOffset = (Split == TileSplitAxis::TILE_UP_DOWN) ? splitIndex * consRows : 0;
                 const uint32_t colOffset = (Split == TileSplitAxis::TILE_LEFT_RIGHT) ? splitIndex * consCols : 0;
                 cpu_pipe::CopyTileWindowToLinear(slotPtr, consCols, tile, consRows, rowOffset, colOffset);

--- a/tests/cpu/st/testcase/tisa_coverage/main.cpp
+++ b/tests/cpu/st/testcase/tisa_coverage/main.cpp
@@ -53,7 +53,7 @@ void AssignTileStorage(TileData &tile, size_t &addr)
 }
 
 template <typename... TileData>
-void AssignTileStorage(size_t &addr, TileData &... tiles)
+void AssignTileStorage(size_t &addr, TileData &...tiles)
 {
     (AssignTileStorage(tiles, addr), ...);
 }
@@ -211,8 +211,7 @@ std::set<std::string> CollectCpuListedCases(const std::filesystem::path &repoRoo
     return listed;
 }
 
-class IsaCoverageTest : public testing::Test {
-};
+class IsaCoverageTest : public testing::Test {};
 
 TEST_F(IsaCoverageTest, RepoWideCoverageTouchesEveryIsaEntryPoint)
 {
@@ -783,13 +782,13 @@ TEST_F(IsaCoverageTest, ThistogramWrapperBuildsCumulativeBins)
     SetValue(src, 0, 6, static_cast<uint16_t>(0x4413u));
     SetValue(src, 0, 7, static_cast<uint16_t>(0x2214u));
 
-    THISTOGRAM<true>(dst, src, idx);
+    THISTOGRAM<HistByte::BYTE_1>(dst, src, idx);
     EXPECT_EQ(GetValue(dst, 0, 0x11), 0u);
     EXPECT_EQ(GetValue(dst, 0, 0x12), 3u);
     EXPECT_EQ(GetValue(dst, 0, 0x33), 6u);
     EXPECT_EQ(GetValue(dst, 0, 0x34), 7u);
 
-    THISTOGRAM<false>(dst, src, idx);
+    THISTOGRAM<HistByte::BYTE_0>(dst, src, idx);
     EXPECT_EQ(GetValue(dst, 0, 0x00), 0u);
     EXPECT_EQ(GetValue(dst, 0, 0x01), 1u);
     EXPECT_EQ(GetValue(dst, 0, 0x02), 2u);
@@ -821,8 +820,8 @@ TEST_F(IsaCoverageTest, TdequantAppliesScaleAndOffset)
 
     for (int r = 0; r < dst.GetValidRow(); ++r) {
         for (int c = 0; c < dst.GetValidCol(); ++c) {
-            const float expected = (static_cast<float>(GetValue(src, r, c)) - GetValue(offset, r, c)) *
-                                   GetValue(scale, r, c);
+            const float expected =
+                (static_cast<float>(GetValue(src, r, c)) - GetValue(offset, r, c)) * GetValue(scale, r, c);
             EXPECT_FLOAT_EQ(GetValue(dst, r, c), expected);
         }
     }


### PR DESCRIPTION
## Summary
- Replace 4 old pto_cpu_sim_* dlsym hooks with 2 narrower hooks
  (get_subblock_id_hook, get_pipe_shared_state_hook) injected via
  pto_sim_register_hooks
- No more dlsym(RTLD_DEFAULT, ...) from pto-isa — the sim platform
  explicitly injects function pointers into each kernel SO after dlopen
- Remove task_cookie from ExecutionContext and all related functions
  (set_task_cookie, get_task_cookie)
- GetSharedState() now uses a uint64 pipe configuration key (packing
  FlagID, DirType, SlotNum, LocalSlotNum, and SlotSize) instead of a
  string-formatted key that depended on task_cookie and block_idx
- Export pto_sim_set_execution_context so the sim platform can set
  block_idx/subblock_id/subblock_dim in each dlopen'd kernel SO
- get_block_idx() and get_subblockdim() no longer go through hooks
  (only used by pto-isa's own tests via thread_local)
- Remove #include <dlfcn.h> (no longer needed)
- Fix tisa_coverage test: update THISTOGRAM calls from bool (true/false)
  to HistByte enum (HistByte::BYTE_1 / HistByte::BYTE_0) to match the
  updated THISTOGRAM interface

## Motivation
The old hooks leaked simulation internals into the runtime layer.
The runtime had to explicitly call CPU_SIM_SET_EXECUTION_CONTEXT and
CPU_SIM_SET_TASK_COOKIE before every kernel dispatch, and the onboard
platform had to provide empty stub implementations just to link.
This violated the platform/runtime boundary.

The new design moves all simulation context setup into the sim platform
layer. The runtime no longer knows whether it runs on sim or hardware.
Additionally, using explicit function pointer injection (instead of
dlsym(RTLD_DEFAULT)) eliminates all implicit dependencies.

See simpler PR #484 for the corresponding runtime-side changes.