### PR TITLE
fix: preserve compatibility with old-style A2A3 TPipe local slot arg

### DIFF
--- a/include/pto/npu/a2a3/TPush.hpp
+++ b/include/pto/npu/a2a3/TPush.hpp
@@ -25,8 +25,9 @@ enum TSyncCVMode : uint8_t
     CV_CORES_SYNC = 2
 };
 
-template <uint8_t FlagID, uint8_t DirType, uint32_t SlotSize, uint32_t SlotNum, bool IsNoSplit = false,
-          uint32_t LocalSlotNum = 2, bool EN_UNIT_FLAG = false>
+template <uint8_t FlagID, uint8_t DirType, uint32_t SlotSize, uint32_t SlotNum,
+          uint32_t CompatLocalSlotNumOrIsNoSplit = 0, uint32_t LocalSlotNum = 2,
+          bool EN_UNIT_FLAG = false>
 struct TPipe {
     static constexpr uint8_t DIR_MASK = 0x7;
     static constexpr uint8_t DIR_TYPE = DIR_MASK & DirType;
@@ -34,10 +35,14 @@ struct TPipe {
     static constexpr bool is_v2c = (DIR_TYPE == Direction::DIR_V2C);           // 2
     static constexpr bool is_both = (DIR_TYPE == Direction::DIR_BOTH);         // 3
     static constexpr bool is_v2c_ctrl = (DIR_TYPE == Direction::DIR_V2C_CTRL); // 4
+    static constexpr bool IsNoSplit =
+        CompatLocalSlotNumOrIsNoSplit <= 1 && static_cast<bool>(CompatLocalSlotNumOrIsNoSplit);
+    static constexpr uint32_t EffectiveLocalSlotNum =
+        CompatLocalSlotNumOrIsNoSplit <= 1 ? LocalSlotNum : CompatLocalSlotNumOrIsNoSplit;
     static_assert(is_c2v || is_v2c || is_both || is_v2c_ctrl,
                   "Fix: TPipe only supports C2V or V2C or Both or V2C_CTRL communication on A2A3.");
 
-    using RingFiFo = RingFIFO<SlotSize, SlotNum, LocalSlotNum>;
+    using RingFiFo = RingFIFO<SlotSize, SlotNum, EffectiveLocalSlotNum>;
 
     PTO_INTERNAL static uint64_t getFFTSMsgCfg(TSyncCVMode mode, uint16_t flagID, uint16_t base_const = 0x1)
     {


### PR DESCRIPTION
## Summary
- make `include/pto/npu/a2a3/TPush.hpp` accept both old-style and new-style `TPipe` template argument layouts
- interpret the 5th template argument as `IsNoSplit` only for `0/1`, otherwise treat it as `LocalSlotNum`
- keep current behavior for new call sites while restoring compatibility with current `ptoas v0.24` output

## Problem
Current generated code from `ptoas v0.24` may emit:

```cpp
TPipe<0, Direction::DIR_C2V, 4096, 8, 8>
```

but the current A2A3 header declares the 5th template parameter as `bool IsNoSplit`, which makes that form fail to compile.

## Fix
Use a compatibility parameter in the 5th position and derive:
- `IsNoSplit` from `0/1`
- the effective local slot count from values `>1`

This preserves support for both:
- `TPipe<..., SlotNum, LocalSlotNum>`
- `TPipe<..., SlotNum, IsNoSplit, LocalSlotNum>`

## Validation
- confirmed `hw-native-sys/ptoas` latest release is `v0.24`
- confirmed current `hw-native-sys/pto-isa:main` still had the incompatible A2A3 signature
- verified the patch matches the downstream compatibility workaround that unblocked `ptoas v0.24` generated A2A3 kernels

Closes #67