### PR TITLE
feat(backend): Add CPU-sim split pipe hooks and alias tile support

### DIFF
--- a/include/pto/common/cpu_stub.hpp
+++ b/include/pto/common/cpu_stub.hpp
@@ -15,7 +15,6 @@ See LICENSE in the root of the software repository for the full text of the Lice
 #include <cstdlib>
 #include <cstring>
 #include <cassert>
-#include <cstdio>
 #include <type_traits>
 #include <dlfcn.h>
 
@@ -90,6 +89,11 @@ using SetExecutionContextHookFn = void (*)(uint32_t block_idx, uint32_t subblock
 using GetExecutionContextHookFn = void (*)(uint32_t *block_idx, uint32_t *subblock_id, uint32_t *subblock_dim);
 using GetSharedStorageHookFn = void *(*)(const char *key, size_t size);
 using GetTaskCookieHookFn = uint64_t (*)();
+using GetSubblockIdInjectedHookFn = uint32_t (*)();
+using GetPipeSharedStateInjectedHookFn = void *(*)(uint64_t pipe_key, size_t size);
+
+inline GetSubblockIdInjectedHookFn injected_subblock_id_hook = nullptr;
+inline GetPipeSharedStateInjectedHookFn injected_pipe_shared_state_hook = nullptr;
 
 inline SetExecutionContextHookFn ResolveSetExecutionContextHook()
 {
@@ -117,6 +121,19 @@ inline GetTaskCookieHookFn ResolveTaskCookieHook()
     return hook;
 }
 
+inline GetSubblockIdInjectedHookFn ResolveSubblockIdHook()
+{
+    static auto hook = reinterpret_cast<GetSubblockIdInjectedHookFn>(dlsym(RTLD_DEFAULT, "pto_sim_get_subblock_id"));
+    return hook;
+}
+
+inline GetPipeSharedStateInjectedHookFn ResolvePipeSharedStateHook()
+{
+    static auto hook =
+        reinterpret_cast<GetPipeSharedStateInjectedHookFn>(dlsym(RTLD_DEFAULT, "pto_sim_get_pipe_shared_state"));
+    return hook;
+}
+
 struct ExecutionContext {
     uint32_t block_idx = 0;
     uint32_t subblock_id = 0;
@@ -125,6 +142,12 @@ struct ExecutionContext {
 };
 
 inline thread_local ExecutionContext execution_context{};
+
+inline void register_hooks(void *get_subblock_id, void *get_pipe_shared_state)
+{
+    injected_subblock_id_hook = reinterpret_cast<GetSubblockIdInjectedHookFn>(get_subblock_id);
+    injected_pipe_shared_state_hook = reinterpret_cast<GetPipeSharedStateInjectedHookFn>(get_pipe_shared_state);
+}
 
 inline void set_execution_context(uint32_t block_idx, uint32_t subblock_id, uint32_t subblock_dim = 1)
 {
@@ -178,6 +201,12 @@ inline uint32_t get_block_idx()
 
 inline uint32_t get_subblockid()
 {
+    if (pto::cpu_sim::injected_subblock_id_hook != nullptr) {
+        return pto::cpu_sim::injected_subblock_id_hook();
+    }
+    if (auto hook = pto::cpu_sim::ResolveSubblockIdHook(); hook != nullptr) {
+        return hook();
+    }
     if (auto hook = pto::cpu_sim::ResolveExecutionContextHook(); hook != nullptr) {
         uint32_t block_idx = 0;
         uint32_t subblock_id = 0;

--- a/include/pto/cpu/NPUMemoryModel.hpp
+++ b/include/pto/cpu/NPUMemoryModel.hpp
@@ -186,6 +186,28 @@ public:
         return initialized_;
     }
 
+    // Returns true when rawAddr already points into one of this thread's
+    // simulated on-chip memory buffers. This is needed for patterns like:
+    //   TASSIGN(alias_tile, reinterpret_cast<uintptr_t>(base_tile.data()));
+    // where the "address" is not an offset but an actual host pointer into UB/L1/L0.
+    bool ContainsAddress(std::uintptr_t rawAddr) const
+    {
+        if (!initialized_) {
+            return false;
+        }
+        for (const auto &buf : buffers_) {
+            if (buf.empty()) {
+                continue;
+            }
+            const auto begin = reinterpret_cast<std::uintptr_t>(buf.data());
+            const auto end = begin + buf.size();
+            if (rawAddr >= begin && rawAddr < end) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     // Clear all memory (zero-fill)
     void Clear()
     {

--- a/include/pto/cpu/TAssign.hpp
+++ b/include/pto/cpu/TAssign.hpp
@@ -24,7 +24,13 @@ PTO_INTERNAL void TASSIGN_IMPL(T &obj, AddrType addr)
 {
     if constexpr (is_tile_data_v<T>) {
         static_assert(std::is_integral_v<AddrType>, "Tile can only be assigned with address of int type.");
-        obj.assignData(NPUMemoryModel::Instance().GetPointer<T>(static_cast<std::size_t>(addr)));
+        auto &memory = NPUMemoryModel::Instance();
+        const auto rawAddr = static_cast<std::uintptr_t>(addr);
+        if (memory.ContainsAddress(rawAddr)) {
+            obj.assignData(reinterpret_cast<typename T::TileDType>(rawAddr));
+        } else {
+            obj.assignData(memory.GetPointer<T>(static_cast<std::size_t>(rawAddr)));
+        }
     } else {
         static_assert(is_global_data_v<T>, "Only Tile and GlobalTensor data types are supported.");
         static_assert(std::is_pointer_v<AddrType>, "GlobalTensor can only be assigned with address of pointer type.");

--- a/include/pto/cpu/TPop.hpp
+++ b/include/pto/cpu/TPop.hpp
@@ -18,55 +18,13 @@ namespace pto {
 template <typename Pipe, typename TileCons, TileSplitAxis Split>
 PTO_INTERNAL void TPOP_IMPL(Pipe &pipe, TileCons &tile)
 {
+    // 1. Wait for data
     if (pipe.cons.getWaitStatus()) {
-        pipe.cons.template wait<Split>();
+        pipe.cons.template wait<TileCons, Split>();
     }
 
-    const std::size_t slotIndex = static_cast<std::size_t>(pipe.cons.getTileId() % Pipe::RingFiFo::SLOT_NUM);
-    const std::size_t entryBase =
-        slotIndex * Pipe::RingFiFo::SLOT_SIZE + static_cast<std::size_t>(pipe.cons.entryOffset);
-
-    if (pipe.fifo.GM_SLOT_BUFFER != nullptr) {
-        using T = typename TileCons::DType;
-        constexpr int rows = TileCons::Rows;
-        constexpr int cols = TileCons::Cols;
-        std::size_t subOffset = 0;
-        if constexpr (Split != TileSplitAxis::TILE_NO_SPLIT) {
-            subOffset = static_cast<std::size_t>(get_subblockid()) * rows * cols * sizeof(T);
-        }
-        using GlobalData = GlobalTensor<T, Shape<1, 1, 1, rows, cols>, Stride<1, 1, 1, cols, 1>>;
-        auto *addr = reinterpret_cast<__gm__ T *>(reinterpret_cast<std::uintptr_t>(pipe.fifo.GM_SLOT_BUFFER) +
-                                                  entryBase + subOffset);
-        GlobalData globalData(addr);
-        TLOAD_IMPL(tile, globalData);
-    } else if constexpr (Pipe::is_c2v) {
-        using T = typename TileCons::DType;
-        if constexpr (Split == TileSplitAxis::TILE_NO_SPLIT) {
-            constexpr int rows = TileCons::Rows;
-            constexpr int cols = TileCons::Cols;
-            using SlotTile = Tile<TileType::Vec, T, rows, cols, BLayout::RowMajor, rows, cols>;
-
-            SlotTile slotTile;
-            TASSIGN(slotTile, static_cast<uint64_t>(pipe.fifo.C2V_CONSUMER_BUF + entryBase));
-            TMOV_IMPL(tile, slotTile);
-        } else {
-            constexpr uint32_t splitCount = cpu_pipe::GetSplitCount<Split>();
-            const uint32_t splitIndex = (get_subblockid() < splitCount) ? get_subblockid() : (splitCount - 1);
-            const auto &slotStorage = Pipe::GetSharedState().local_slot_storage[slotIndex];
-            const auto *slotPtr = reinterpret_cast<const T *>(
-                slotStorage.data() + splitIndex * Pipe::RingFiFo::SLOT_SIZE + pipe.cons.entryOffset);
-            cpu_pipe::CopyLinearToTile(tile, slotPtr, static_cast<uint32_t>(tile.GetValidCol()));
-        }
-    } else if constexpr (Pipe::is_v2c) {
-        using T = typename TileCons::DType;
-        constexpr int rows = TileCons::Rows;
-        constexpr int cols = TileCons::Cols;
-        using SlotTile = Tile<TileType::Mat, T, rows, cols, BLayout::RowMajor, rows, cols>;
-
-        SlotTile slotTile;
-        TASSIGN(slotTile, static_cast<uint64_t>(pipe.fifo.V2C_CONSUMER_BUF + entryBase));
-        TMOV_IMPL(tile, slotTile);
-    }
+    // 2. Address calculation + TASSIGN + data transfer
+    pipe.cons.template pop<TileCons, Split>(pipe.fifo, tile);
 }
 
 template <typename TileCons, typename Pipe>

--- a/include/pto/cpu/TPush.hpp
+++ b/include/pto/cpu/TPush.hpp
@@ -16,10 +16,14 @@ See LICENSE in the root of the software repository for the full text of the Lice
 #include <condition_variable>
 #include <cstddef>
 #include <cstdint>
-#include <cstdio>
 #include <mutex>
 #include <new>
 #include <thread>
+#include <type_traits>
+#ifdef __CPU_SIM
+#include <unordered_map>
+#include <vector>
+#endif
 #include <format>
 #include <pto/common/fifo.hpp>
 
@@ -32,10 +36,114 @@ See LICENSE in the root of the software repository for the full text of the Lice
 namespace pto {
 
 namespace cpu_pipe {
+enum class TransferDir : uint8_t
+{
+    None = 0,
+    C2V = 1,
+    V2C = 2,
+};
+
+template <typename TileProd>
+PTO_INTERNAL constexpr bool IsC2VProducerTile()
+{
+    return TileProd::Loc == TileType::Acc;
+}
+
+template <typename TileProd>
+PTO_INTERNAL constexpr bool IsV2CProducerTile()
+{
+    return TileProd::Loc == TileType::Vec;
+}
+
+template <typename TileCons>
+PTO_INTERNAL constexpr bool IsC2VConsumerTile()
+{
+    return TileCons::Loc == TileType::Vec;
+}
+
+template <typename Pipe>
+PTO_INTERNAL constexpr TransferDir GetPipeTransferDir()
+{
+    if constexpr (Pipe::is_c2v && !Pipe::is_v2c) {
+        return TransferDir::C2V;
+    }
+    if constexpr (Pipe::is_v2c && !Pipe::is_c2v) {
+        return TransferDir::V2C;
+    }
+    return TransferDir::None;
+}
+
+template <typename Pipe, typename TileProd>
+PTO_INTERNAL constexpr TransferDir GetProducerTransferDir()
+{
+    constexpr auto pipeDir = GetPipeTransferDir<Pipe>();
+    if constexpr (pipeDir != TransferDir::None) {
+        return pipeDir;
+    }
+    if constexpr (IsC2VProducerTile<TileProd>()) {
+        return TransferDir::C2V;
+    }
+    return TransferDir::V2C;
+}
+
+template <typename Pipe, typename TileCons>
+PTO_INTERNAL constexpr TransferDir GetConsumerTransferDir()
+{
+    constexpr auto pipeDir = GetPipeTransferDir<Pipe>();
+    if constexpr (pipeDir != TransferDir::None) {
+        return pipeDir;
+    }
+    if constexpr (IsC2VConsumerTile<TileCons>()) {
+        return TransferDir::C2V;
+    }
+    return TransferDir::V2C;
+}
+
 template <TileSplitAxis Split>
 PTO_INTERNAL constexpr uint32_t GetSplitCount()
 {
     return (Split == TileSplitAxis::TILE_NO_SPLIT) ? 1u : 2u;
+}
+
+template <TileSplitAxis Split>
+PTO_INTERNAL uint32_t GetSplitLaneId()
+{
+    constexpr uint32_t splitCount = GetSplitCount<Split>();
+    const uint32_t subblockId = get_subblockid();
+    return (subblockId < splitCount) ? subblockId : (splitCount - 1);
+}
+
+template <TileSplitAxis Split>
+PTO_INTERNAL constexpr uint32_t GetSplitLaneMask(uint32_t laneId)
+{
+    return 1u << laneId;
+}
+
+template <TileSplitAxis Split>
+PTO_INTERNAL constexpr uint32_t GetAllSplitLaneMask()
+{
+    return (1u << GetSplitCount<Split>()) - 1u;
+}
+
+template <TileSplitAxis Split>
+PTO_INTERNAL uint32_t GetActiveSplitCount()
+{
+    constexpr uint32_t splitCount = GetSplitCount<Split>();
+    const uint32_t subblockDim = get_subblockdim();
+    if (subblockDim != 0) {
+        return (subblockDim < splitCount) ? subblockDim : splitCount;
+    }
+    if ((cpu_sim::injected_subblock_id_hook != nullptr) || (cpu_sim::injected_pipe_shared_state_hook != nullptr) ||
+        (cpu_sim::ResolveSubblockIdHook() != nullptr) || (cpu_sim::ResolvePipeSharedStateHook() != nullptr)) {
+        return splitCount;
+    }
+    return 1u;
+}
+
+template <TileSplitAxis Split>
+PTO_INTERNAL uint32_t GetActiveSplitLaneMask()
+{
+    return (1u << GetActiveSplitCount<Split>()) - 1u;
 }
 
 template <typename TileData>
@@ -44,6 +152,17 @@ PTO_INTERNAL void FillTile(TileData &tile, typename TileData::DType value)
     for (int r = 0; r < tile.GetValidRow(); ++r) {
         for (int c = 0; c < tile.GetValidCol(); ++c) {
             tile.data()[GetTileElementOffset<TileData>(r, c)] = value;
+        }
+    }
+}
+
+template <typename T>
+PTO_INTERNAL void FillLinearRegion(T *dst, uint32_t dstCols, T value, uint32_t rowStart, uint32_t rowCount,
+                                   uint32_t colStart, uint32_t colCount)
+{
+    for (uint32_t r = rowStart; r < rowStart + rowCount; ++r) {
+        for (uint32_t c = colStart; c < colStart + colCount; ++c) {
+            dst[r * dstCols + c] = value;
         }
     }
 }
@@ -71,6 +190,17 @@ PTO_INTERNAL void InsertTileWindow(DstTileData &dst, SrcTileData &src, uint32_t 
 }
 
 template <typename T, typename SrcTileData>
+PTO_INTERNAL void InsertTileWindowToLinear(T *dst, uint32_t dstCols, SrcTileData &src, uint32_t rowOffset = 0,
+                                           uint32_t colOffset = 0)
+{
+    for (int r = 0; r < src.GetValidRow(); ++r) {
+        for (int c = 0; c < src.GetValidCol(); ++c) {
+            dst[(r + rowOffset) * dstCols + (c + colOffset)] = src.data()[GetTileElementOffset<SrcTileData>(r, c)];
+        }
+    }
+}
+
+template <typename T, typename SrcTileData>
 PTO_INTERNAL void CopyTileWindowToLinear(T *dst, uint32_t dstCols, SrcTileData &src, uint32_t dstRows,
                                          uint32_t srcRowOffset = 0, uint32_t srcColOffset = 0)
 {
@@ -90,6 +220,33 @@ PTO_INTERNAL void CopyLinearToTile(DstTileData &dst, const T *src, uint32_t srcC
         }
     }
 }
+
+#ifdef __CPU_SIM
+template <typename TileData>
+PTO_INTERNAL void EnsureTileStorage(TileData &tile)
+{
+    using TilePtr = std::remove_reference_t<decltype(tile.data())>;
+    static_assert(std::is_pointer_v<TilePtr>, "CPU-sim tile backing helper requires pointer-backed tile storage.");
+
+    if (tile.data() != nullptr) {
+        return;
+    }
+
+    static thread_local std::unordered_map<const void *, std::vector<typename TileData::DType>> buffers;
+    auto &buffer = buffers[static_cast<const void *>(&tile)];
+    const auto numel = static_cast<std::size_t>(TileData::Rows * TileData::Cols);
+    if (buffer.size() != numel) {
+        buffer.resize(numel);
+    }
+    tile.data() = buffer.data();
+}
+#else
+template <typename TileData>
+PTO_INTERNAL void EnsureTileStorage(TileData &tile)
+{
+    (void)tile;
+}
+#endif
 
 template <TileSplitAxis Split, typename TileData>
 PTO_INTERNAL uint32_t GetSplitRowOffset()
@@ -130,7 +287,11 @@ struct TPipe {
         int next_consumer_slot = 0;
         int occupied = 0;
         std::array<std::array<uint8_t, LOCAL_SLOT_STORAGE_SIZE>, SlotNum> local_slot_storage{};
+        std::array<cpu_pipe::TransferDir, SlotNum> transfer_dirs{};
         std::array<uint32_t, SlotNum> remaining_consumers{};
+        std::array<uint32_t, SlotNum> consumers_claimed{};
+        std::array<uint32_t, SlotNum> producers_allocated{};
+        std::array<uint32_t, SlotNum> producers_done{};
     };
 
     struct SharedStateStorage {
@@ -153,6 +314,24 @@ struct TPipe {
 
     PTO_INTERNAL static SharedState &GetSharedState()
     {
+        constexpr uint64_t pipeKey = (static_cast<uint64_t>(FlagID) << 56) | (static_cast<uint64_t>(DirType) << 48) |
+                                     (static_cast<uint64_t>(SlotNum) << 40) |
+                                     (static_cast<uint64_t>(LocalSlotNum) << 32) | static_cast<uint64_t>(SlotSize);
+        if (cpu_sim::injected_pipe_shared_state_hook != nullptr) {
+            auto *storage = reinterpret_cast<SharedStateStorage *>(
+                cpu_sim::injected_pipe_shared_state_hook(pipeKey, sizeof(SharedStateStorage)));
+            if (storage != nullptr) {
+                EnsureSharedStateInitialized(*storage);
+                return *std::launder(reinterpret_cast<SharedState *>(storage->payload));
+            }
+        }
+        if (auto hook = cpu_sim::ResolvePipeSharedStateHook(); hook != nullptr) {
+            auto *storage = reinterpret_cast<SharedStateStorage *>(hook(pipeKey, sizeof(SharedStateStorage)));
+            if (storage != nullptr) {
+                EnsureSharedStateInitialized(*storage);
+                return *std::launder(reinterpret_cast<SharedState *>(storage->payload));
+            }
+        }
         if (auto hook = cpu_sim::ResolveSharedStorageHook(); hook != nullptr) {
             char key[128] = {};
             std::format_to(key, "pto-pipe-%llu-%u-%u-%u-%u-%u-%u", static_cast<unsigned long long>(get_task_cookie()),
@@ -178,6 +357,10 @@ struct TPipe {
             slot.fill(0);
         }
         shared_state.remaining_consumers.fill(0);
+        shared_state.consumers_claimed.fill(0);
+        shared_state.producers_allocated.fill(0);
+        shared_state.producers_done.fill(0);
+        shared_state.transfer_dirs.fill(cpu_pipe::TransferDir::None);
         shared_state.cv.notify_all();
     }
 
@@ -231,29 +414,57 @@ struct TPipe {
             entryOffset = offset;
         }
 
-        template <TileSplitAxis Split = TileSplitAxis::TILE_UP_DOWN>
+        template <typename TileProd, TileSplitAxis Split = TileSplitAxis::TILE_UP_DOWN>
         PTO_INTERNAL void allocate()
         {
             (void)Split;
             auto &shared_state = TPipe::GetSharedState();
             std::unique_lock<std::mutex> lock(shared_state.mutex);
-            shared_state.cv.wait(lock, [&shared_state]() { return shared_state.occupied < RingFiFo::SLOT_NUM; });
+            if constexpr (TPipe::is_v2c && cpu_pipe::IsV2CProducerTile<TileProd>() &&
+                          Split != TileSplitAxis::TILE_NO_SPLIT) {
+                const uint32_t laneId = cpu_pipe::GetSplitLaneId<Split>();
+                const uint32_t laneMask = cpu_pipe::GetSplitLaneMask<Split>(laneId);
+                shared_state.cv.wait(lock, [&shared_state, laneMask]() {
+                    return shared_state.occupied < RingFiFo::SLOT_NUM &&
+                           (shared_state
+                                .producers_allocated[static_cast<std::size_t>(shared_state.next_producer_slot)] &
+                            laneMask) == 0;
+                });
+                tileIndex = shared_state.next_producer_slot;
+                shared_state.producers_allocated[static_cast<std::size_t>(tileIndex % RingFiFo::SLOT_NUM)] |= laneMask;
+                subTileIndex = static_cast<int>(laneId);
+                return;
+            } else {
+                shared_state.cv.wait(lock, [&shared_state]() { return shared_state.occupied < RingFiFo::SLOT_NUM; });
+            }
             tileIndex = shared_state.next_producer_slot;
             subTileIndex = static_cast<int>(get_subblockid());
         }
 
-        template <TileSplitAxis Split = TileSplitAxis::TILE_UP_DOWN>
+        template <typename TileProd, TileSplitAxis Split = TileSplitAxis::TILE_UP_DOWN>
         PTO_INTERNAL void record()
         {
             (void)Split;
             auto &shared_state = TPipe::GetSharedState();
             {
                 std::lock_guard<std::mutex> lock(shared_state.mutex);
-                if constexpr (TPipe::is_c2v && Split != TileSplitAxis::TILE_NO_SPLIT) {
-                    shared_state.remaining_consumers[static_cast<std::size_t>(tileIndex % RingFiFo::SLOT_NUM)] =
-                        cpu_pipe::GetSplitCount<Split>();
+                const auto slotIdx = static_cast<std::size_t>(tileIndex % RingFiFo::SLOT_NUM);
+                shared_state.transfer_dirs[slotIdx] = cpu_pipe::GetProducerTransferDir<TPipe, TileProd>();
+                if constexpr (TPipe::is_c2v && cpu_pipe::IsC2VProducerTile<TileProd>() &&
+                              Split != TileSplitAxis::TILE_NO_SPLIT) {
+                    shared_state.remaining_consumers[slotIdx] = cpu_pipe::GetSplitCount<Split>();
                 } else {
-                    shared_state.remaining_consumers[static_cast<std::size_t>(tileIndex % RingFiFo::SLOT_NUM)] = 1;
+                    shared_state.remaining_consumers[slotIdx] = 1;
+                }
+                if constexpr (TPipe::is_v2c && cpu_pipe::IsV2CProducerTile<TileProd>() &&
+                              Split != TileSplitAxis::TILE_NO_SPLIT) {
+                    const uint32_t laneMask = cpu_pipe::GetSplitLaneMask<Split>(static_cast<uint32_t>(subTileIndex));
+                    shared_state.producers_done[slotIdx] |= laneMask;
+                    if (shared_state.producers_done[slotIdx] != cpu_pipe::GetActiveSplitLaneMask<Split>()) {
+                        return;
+                    }
+                    shared_state.producers_allocated[slotIdx] = 0;
+                    shared_state.producers_done[slotIdx] = 0;
                 }
                 shared_state.next_producer_slot = (tileIndex + 1) % RingFiFo::SLOT_NUM;
                 ++shared_state.occupied;
@@ -312,13 +523,34 @@ struct TPipe {
             entryOffset = offset;
         }
 
-        template <TileSplitAxis Split = TileSplitAxis::TILE_UP_DOWN>
+        template <typename TileCons, TileSplitAxis Split = TileSplitAxis::TILE_UP_DOWN>
         PTO_INTERNAL void wait()
         {
             (void)Split;
             auto &shared_state = TPipe::GetSharedState();
             std::unique_lock<std::mutex> lock(shared_state.mutex);
-            shared_state.cv.wait(lock, [&shared_state]() { return shared_state.occupied > 0; });
+            constexpr auto expectedDir = cpu_pipe::GetConsumerTransferDir<TPipe, TileCons>();
+            if constexpr (TPipe::is_c2v && cpu_pipe::IsC2VConsumerTile<TileCons>() &&
+                          Split != TileSplitAxis::TILE_NO_SPLIT) {
+                const uint32_t laneId = cpu_pipe::GetSplitLaneId<Split>();
+                const uint32_t laneMask = cpu_pipe::GetSplitLaneMask<Split>(laneId);
+                shared_state.cv.wait(lock, [&shared_state, laneMask, expectedDir]() {
+                    return shared_state.occupied > 0 &&
+                           shared_state.transfer_dirs[static_cast<std::size_t>(shared_state.next_consumer_slot)] ==
+                               expectedDir &&
+                           (shared_state.consumers_claimed[static_cast<std::size_t>(shared_state.next_consumer_slot)] &
+                            laneMask) == 0;
+                });
+                tileIndex = shared_state.next_consumer_slot;
+                shared_state.consumers_claimed[static_cast<std::size_t>(tileIndex % RingFiFo::SLOT_NUM)] |= laneMask;
+                subTileIndex = static_cast<int>(laneId);
+                return;
+            }
+            shared_state.cv.wait(lock, [&shared_state, expectedDir]() {
+                return shared_state.occupied > 0 &&
+                       shared_state.transfer_dirs[static_cast<std::size_t>(shared_state.next_consumer_slot)] ==
+                           expectedDir;
+            });
             tileIndex = shared_state.next_consumer_slot;
             subTileIndex = static_cast<int>(get_subblockid());
         }
@@ -336,11 +568,113 @@ struct TPipe {
                     --remaining;
                 } else {
                     remaining = 0;
+                    shared_state.consumers_claimed[slotIndex] = 0;
+                    shared_state.transfer_dirs[slotIndex] = cpu_pipe::TransferDir::None;
                     shared_state.next_consumer_slot = (tileIndex + 1) % RingFiFo::SLOT_NUM;
                     --shared_state.occupied;
                 }
             }
             shared_state.cv.notify_all();
+        }
+
+        template <typename TileCons, TileSplitAxis Split>
+        PTO_INTERNAL void popTileFromVecFiFo(RingFiFo &fifo, TileCons &tile)
+        {
+            const std::size_t slotIndex = static_cast<std::size_t>(tileIndex % RingFiFo::SLOT_NUM);
+            const std::size_t entryBase = slotIndex * RingFiFo::SLOT_SIZE + static_cast<std::size_t>(entryOffset);
+            uint64_t localTileBase = fifo.C2V_CONSUMER_BUF + entryBase;
+            TASSIGN_IMPL(tile, localTileBase);
+        }
+
+        template <typename TileCons, TileSplitAxis Split>
+        PTO_INTERNAL void popTileFromVecFiFoSplit(RingFiFo &fifo, TileCons &tile)
+        {
+            using T = typename TileCons::DType;
+            constexpr uint32_t splitCount = cpu_pipe::GetSplitCount<Split>();
+            const uint32_t splitIndex = (get_subblockid() < splitCount) ? get_subblockid() : (splitCount - 1);
+            const std::size_t slotIndex = static_cast<std::size_t>(tileIndex % RingFiFo::SLOT_NUM);
+            const auto &slotStorage = TPipe::GetSharedState().local_slot_storage[slotIndex];
+            const auto *slotPtr =
+                reinterpret_cast<const T *>(slotStorage.data() + splitIndex * RingFiFo::SLOT_SIZE + entryOffset);
+            cpu_pipe::EnsureTileStorage(tile);
+            cpu_pipe::CopyLinearToTile(tile, slotPtr, static_cast<uint32_t>(tile.GetValidCol()));
+        }
+
+        template <typename TileCons, TileSplitAxis Split>
+        PTO_INTERNAL void popTileFromMatFiFo(RingFiFo &fifo, TileCons &tile)
+        {
+            using T = typename TileCons::DType;
+            constexpr int rows = TileCons::Rows;
+            constexpr int cols = TileCons::Cols;
+            using SlotTile = Tile<TileType::Mat, T, rows, cols, BLayout::RowMajor, rows, cols>;
+            const std::size_t slotIndex = static_cast<std::size_t>(tileIndex % RingFiFo::SLOT_NUM);
+            const std::size_t entryBase = slotIndex * RingFiFo::SLOT_SIZE + static_cast<std::size_t>(entryOffset);
+            const auto &slotStorage = TPipe::GetSharedState().local_slot_storage[slotIndex];
+            const auto *slotPtr = reinterpret_cast<const T *>(slotStorage.data() + entryOffset);
+
+            SlotTile slotTile;
+            TASSIGN_IMPL(slotTile, fifo.V2C_CONSUMER_BUF + entryBase);
+            cpu_pipe::CopyLinearToTile(slotTile, slotPtr, static_cast<uint32_t>(slotTile.GetValidCol()));
+            cpu_pipe::EnsureTileStorage(tile);
+            TMOV_IMPL(tile, slotTile);
+        }
+
+        template <typename TileCons, TileSplitAxis Split>
+        PTO_INTERNAL void popTileFromGMFiFo(RingFiFo &fifo, TileCons &tile)
+        {
+            using T = typename TileCons::DType;
+            const std::size_t slotIndex = static_cast<std::size_t>(tileIndex % RingFiFo::SLOT_NUM);
+            const std::size_t entryBase = slotIndex * RingFiFo::SLOT_SIZE + static_cast<std::size_t>(entryOffset);
+            cpu_pipe::EnsureTileStorage(tile);
+            if constexpr (TPipe::is_c2v && TileCons::Loc == TileType::Vec) {
+                constexpr int splitNum = 2;
+                constexpr int consRows = TileCons::Rows;
+                constexpr int consCols = TileCons::Cols;
+                constexpr int prodCols = (Split == TileSplitAxis::TILE_LEFT_RIGHT) ? consCols * splitNum : consCols;
+                constexpr int gmValidR = consRows;
+                constexpr int gmValidC = consCols;
+                constexpr int gmStrideR = prodCols;
+                std::size_t subOffset = 0;
+                if constexpr (Split == TileSplitAxis::TILE_UP_DOWN) {
+                    subOffset = static_cast<std::size_t>(get_subblockid()) * consRows * prodCols * sizeof(T);
+                } else if constexpr (Split == TileSplitAxis::TILE_LEFT_RIGHT) {
+                    subOffset = static_cast<std::size_t>(get_subblockid()) * consCols * sizeof(T);
+                }
+                using GlobalData = GlobalTensor<T, Shape<1, 1, 1, gmValidR, gmValidC>, Stride<1, 1, 1, gmStrideR, 1>>;
+                auto *addr = reinterpret_cast<__gm__ T *>(reinterpret_cast<std::uintptr_t>(fifo.GM_SLOT_BUFFER) +
+                                                          entryBase + subOffset);
+                GlobalData globalData(addr);
+                TLOAD_IMPL(tile, globalData);
+                return;
+            }
+
+            constexpr int rows = TileCons::Rows;
+            constexpr int cols = TileCons::Cols;
+            using GlobalData = GlobalTensor<T, Shape<1, 1, 1, rows, cols>, Stride<1, 1, 1, cols, 1>>;
+            auto *addr =
+                reinterpret_cast<__gm__ T *>(reinterpret_cast<std::uintptr_t>(fifo.GM_SLOT_BUFFER) + entryBase);
+            GlobalData globalData(addr);
+            TLOAD_IMPL(tile, globalData);
+        }
+
+        template <typename TileCons, TileSplitAxis Split>
+        PTO_INTERNAL bool pop(RingFiFo &fifo, TileCons &tile)
+        {
+            if (fifo.GM_SLOT_BUFFER != nullptr) {
+                popTileFromGMFiFo<TileCons, Split>(fifo, tile);
+                return true;
+            } else if constexpr (TPipe::is_c2v) {
+                if constexpr (Split == TileSplitAxis::TILE_NO_SPLIT) {
+                    popTileFromVecFiFo<TileCons, Split>(fifo, tile);
+                } else {
+                    popTileFromVecFiFoSplit<TileCons, Split>(fifo, tile);
+                }
+                return false;
+            } else if constexpr (TPipe::is_v2c) {
+                popTileFromMatFiFo<TileCons, Split>(fifo, tile);
+                return false;
+            }
+            return false;
         }
     };
 
@@ -389,18 +723,22 @@ PTO_INTERNAL void TPush_v2c(Pipe &pipe, TileProd &tile, size_t entryBase)
     constexpr int consCols =
         (Split == TileSplitAxis::TILE_LEFT_RIGHT) ? (TileProd::Cols * 2) : static_cast<int>(TileProd::Cols);
     using SlotTile = Tile<TileType::Mat, T, consRows, consCols, BLayout::RowMajor, consRows, consCols>;
-    SlotTile slotTile;
-    TASSIGN(slotTile, static_cast<uint64_t>(pipe.fifo.V2C_CONSUMER_BUF + entryBase));
-    cpu_pipe::FillTile(slotTile, static_cast<T>(0));
-    cpu_pipe::InsertTileWindow(slotTile, tile, cpu_pipe::GetSplitRowOffset<Split, SlotTile>(),
-                               cpu_pipe::GetSplitColOffset<Split, SlotTile>());
+    (void)entryBase;
+    const std::size_t slotIndex = static_cast<std::size_t>(pipe.prod.getTileId() % Pipe::RingFiFo::SLOT_NUM);
+    auto &slotStorage = Pipe::GetSharedState().local_slot_storage[slotIndex];
+    auto *slotPtr = reinterpret_cast<T *>(slotStorage.data() + pipe.prod.entryOffset);
+    const uint32_t rowOff = cpu_pipe::GetSplitRowOffset<Split, SlotTile>();
+    const uint32_t colOff = cpu_pipe::GetSplitColOffset<Split, SlotTile>();
+    cpu_pipe::FillLinearRegion(slotPtr, static_cast<uint32_t>(consCols), static_cast<T>(0), rowOff,
+                               static_cast<uint32_t>(TileProd::Rows), colOff, static_cast<uint32_t>(TileProd::Cols));
+    cpu_pipe::InsertTileWindowToLinear(slotPtr, static_cast<uint32_t>(consCols), tile, rowOff, colOff);
 }
 
 template <typename Pipe, typename TileProd, TileSplitAxis Split>
 PTO_INTERNAL void TPUSH_IMPL(Pipe &pipe, TileProd &tile)
 {
     if (pipe.prod.getAllocateStatus()) {
-        pipe.prod.template allocate<Split>();
+        pipe.prod.template allocate<TileProd, Split>();
     }
     const std::size_t slotIndex = static_cast<std::size_t>(pipe.prod.getTileId() % Pipe::RingFiFo::SLOT_NUM);
     const std::size_t entryBase =
@@ -409,22 +747,33 @@ PTO_INTERNAL void TPUSH_IMPL(Pipe &pipe, TileProd &tile)
         using T = typename TileProd::DType;
         constexpr int rows = TileProd::Rows;
         constexpr int cols = TileProd::Cols;
-        std::size_t subOffset = 0;
-        if constexpr (Split != TileSplitAxis::TILE_NO_SPLIT) {
-            subOffset = static_cast<std::size_t>(get_subblockid()) * rows * cols * sizeof(T);
+        if constexpr (Pipe::is_v2c && TileProd::Loc == TileType::Vec) {
+            constexpr int gmStrideR = (Split == TileSplitAxis::TILE_LEFT_RIGHT) ? (cols * 2) : cols;
+            std::size_t subOffset = 0;
+            if constexpr (Split == TileSplitAxis::TILE_UP_DOWN) {
+                subOffset = static_cast<std::size_t>(get_subblockid()) * rows * cols * sizeof(T);
+            } else if constexpr (Split == TileSplitAxis::TILE_LEFT_RIGHT) {
+                subOffset = static_cast<std::size_t>(get_subblockid()) * cols * sizeof(T);
+            }
+            using GlobalData = GlobalTensor<T, Shape<1, 1, 1, rows, cols>, Stride<1, 1, 1, gmStrideR, 1>>;
+            auto *addr = reinterpret_cast<__gm__ T *>(reinterpret_cast<std::uintptr_t>(pipe.fifo.GM_SLOT_BUFFER) +
+                                                      entryBase + subOffset);
+            GlobalData globalData(addr);
+            TSTORE_IMPL(globalData, tile);
+        } else {
+            using GlobalData = GlobalTensor<T, Shape<1, 1, 1, rows, cols>, Stride<1, 1, 1, cols, 1>>;
+            auto *addr =
+                reinterpret_cast<__gm__ T *>(reinterpret_cast<std::uintptr_t>(pipe.fifo.GM_SLOT_BUFFER) + entryBase);
+            GlobalData globalData(addr);
+            TSTORE_IMPL(globalData, tile);
         }
-        using GlobalData = GlobalTensor<T, Shape<1, 1, 1, rows, cols>, Stride<1, 1, 1, cols, 1>>;
-        auto *addr = reinterpret_cast<__gm__ T *>(reinterpret_cast<std::uintptr_t>(pipe.fifo.GM_SLOT_BUFFER) +
-                                                  entryBase + subOffset);
-        GlobalData globalData(addr);
-        TSTORE_IMPL(globalData, tile);
     } else if constexpr (Pipe::is_c2v) {
         TPush_c2v<Pipe, TileProd, Split>(pipe, tile, entryBase, slotIndex);
     } else if constexpr (Pipe::is_v2c) {
         TPush_v2c<Pipe, TileProd, Split>(pipe, tile, entryBase);
     }
     if (pipe.prod.getRecordStatus()) {
-        pipe.prod.template record<Split>();
+        pipe.prod.template record<TileProd, Split>();
     }
 }
 

--- a/tests/cpu/st/testcase/CMakeLists.txt
+++ b/tests/cpu/st/testcase/CMakeLists.txt
@@ -46,6 +46,7 @@ tadd
 taddc
 tadds
 taddsc
+tassign_alias
 tand
 tands
 tbroadcast

--- a/tests/cpu/st/testcase/tassign_alias/CMakeLists.txt
+++ b/tests/cpu/st/testcase/tassign_alias/CMakeLists.txt
@@ -1,0 +1,1 @@
+pto_cpu_sim_st(tassign_alias)

--- a/tests/cpu/st/testcase/tassign_alias/main.cpp
+++ b/tests/cpu/st/testcase/tassign_alias/main.cpp
@@ -1,0 +1,69 @@
+/**
+Copyright (c) 2025 Huawei Technologies Co., Ltd.
+This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+CANN Open Software License Agreement Version 2.0 (the "License").
+Please refer to the License for details. You may not use this file except in compliance with the License.
+THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+See LICENSE in the root of the software repository for the full text of the License.
+*/
+
+#include <cstdint>
+
+#include <gtest/gtest.h>
+#include <pto/pto-inst.hpp>
+
+using namespace pto;
+
+class TAssignAliasTest : public testing::Test {
+protected:
+    void SetUp() override
+    {
+        NPU_MEMORY_INIT(NPUArch::A2A3);
+        NPU_MEMORY_CLEAR();
+    }
+};
+
+TEST_F(TAssignAliasTest, exact_alias_reuses_same_backing_buffer)
+{
+    using BaseTile = Tile<TileType::Vec, float, 8, 64, BLayout::RowMajor, 8, 64>;
+    using AliasTile = Tile<TileType::Vec, float, 8, 64, BLayout::RowMajor, 8, 64>;
+
+    BaseTile base;
+    AliasTile alias;
+
+    TASSIGN(base, 0);
+    TASSIGN(alias, reinterpret_cast<std::uintptr_t>(base.data()));
+
+    ASSERT_EQ(base.data(), alias.data());
+
+    base.SetValue(5, 3.5f);
+    EXPECT_FLOAT_EQ(alias.GetValue(5), 3.5f);
+
+    alias.SetValue(17, -2.25f);
+    EXPECT_FLOAT_EQ(base.GetValue(17), -2.25f);
+}
+
+TEST_F(TAssignAliasTest, interior_alias_treats_pointer_as_pointer_not_offset)
+{
+    using BaseTile = Tile<TileType::Vec, float, 8, 64, BLayout::RowMajor, 8, 64>;
+    using TailTile = Tile<TileType::Vec, float, 4, 64, BLayout::RowMajor, 4, 64>;
+
+    constexpr std::size_t kRowOffset = 4;
+    constexpr std::size_t kColCount = 64;
+    constexpr std::size_t kElementOffset = kRowOffset * kColCount;
+
+    BaseTile base;
+    TailTile tail;
+
+    TASSIGN(base, 0);
+    TASSIGN(tail, reinterpret_cast<std::uintptr_t>(base.data() + kElementOffset));
+
+    ASSERT_EQ(tail.data(), base.data() + kElementOffset);
+
+    tail.SetValue(3, 9.0f);
+    EXPECT_FLOAT_EQ(base.GetValue(kElementOffset + 3), 9.0f);
+
+    base.SetValue(kElementOffset + 10, -7.0f);
+    EXPECT_FLOAT_EQ(tail.GetValue(10), -7.0f);
+}

--- a/tests/cpu/st/testcase/tpushpop/main.cpp
+++ b/tests/cpu/st/testcase/tpushpop/main.cpp
@@ -9,6 +9,7 @@ See LICENSE in the root of the software repository for the full text of the Lice
 */
 
 #include <pto/pto-inst.hpp>
+#include <atomic>
 #include <chrono>
 #include <gtest/gtest.h>
 #include <pto/common/fifo.hpp>
@@ -19,6 +20,166 @@ See LICENSE in the root of the software repository for the full text of the Lice
 using namespace std;
 using namespace pto;
 using namespace PtoTestCommon;
+
+namespace {
+using HookTestPipe = TPipe<6, Direction::DIR_C2V, sizeof(float) * 16 * 16, 1>;
+using HookedV2CPipe = TPipe<9, Direction::DIR_V2C, sizeof(float) * 16 * 16, 2>;
+
+std::atomic<uint32_t> g_injected_subblock_id{0};
+std::atomic<uint32_t> g_pipe_hook_call_count{0};
+void *g_pipe_hook_storage = nullptr;
+size_t g_pipe_hook_size = 0;
+uint64_t g_pipe_hook_last_key = 0;
+
+uint32_t MockSubblockIdHook()
+{
+    return g_injected_subblock_id.load(std::memory_order_relaxed);
+}
+
+void *MockPipeSharedStateHook(uint64_t pipeKey, size_t size)
+{
+    g_pipe_hook_last_key = pipeKey;
+    g_pipe_hook_size = size;
+    g_pipe_hook_call_count.fetch_add(1, std::memory_order_relaxed);
+    return g_pipe_hook_storage;
+}
+
+struct ScopedCpuStubHooks {
+    ScopedCpuStubHooks(void *subblockHook, void *pipeSharedStateHook)
+    {
+        pto::cpu_sim::register_hooks(subblockHook, pipeSharedStateHook);
+    }
+
+    ~ScopedCpuStubHooks()
+    {
+        pto::cpu_sim::register_hooks(nullptr, nullptr);
+        cpu_sim::reset_execution_context();
+    }
+};
+
+template <TileSplitAxis SplitAxis>
+using DirBothVecTile =
+    Tile<TileType::Vec, float, (SplitAxis == TileSplitAxis::TILE_UP_DOWN) ? 8 : 16,
+         (SplitAxis == TileSplitAxis::TILE_LEFT_RIGHT) ? 8 : 16, BLayout::RowMajor,
+         (SplitAxis == TileSplitAxis::TILE_UP_DOWN) ? 8 : 16, (SplitAxis == TileSplitAxis::TILE_LEFT_RIGHT) ? 8 : 16>;
+
+template <typename TileData>
+void fillTileSequence(TileData &tile, float start)
+{
+    for (int i = 0; i < tile.Numel; ++i) {
+        tile.data()[i] = start + static_cast<float>(i);
+    }
+}
+
+template <TileSplitAxis SplitAxis>
+void expectVecMatchesAccSplit(const auto &vec, const auto &acc, uint32_t laneId)
+{
+    for (int r = 0; r < vec.GetValidRow(); ++r) {
+        for (int c = 0; c < vec.GetValidCol(); ++c) {
+            uint32_t srcRow = r;
+            uint32_t srcCol = c;
+            if constexpr (SplitAxis == TileSplitAxis::TILE_UP_DOWN) {
+                srcRow += laneId * vec.GetValidRow();
+            } else {
+                srcCol += laneId * vec.GetValidCol();
+            }
+            EXPECT_FLOAT_EQ(vec.data()[GetTileElementOffset<std::remove_cvref_t<decltype(vec)>>(r, c)],
+                            acc.data()[GetTileElementOffset<std::remove_cvref_t<decltype(acc)>>(
+                                static_cast<int>(srcRow), static_cast<int>(srcCol))]);
+        }
+    }
+}
+
+template <TileSplitAxis SplitAxis, uint8_t FlagId>
+void testDirBothConsumerWaitsForMatchingDirection()
+{
+    using VecTile = DirBothVecTile<SplitAxis>;
+    using MatTile = Tile<TileType::Mat, float, 16, 16, BLayout::RowMajor, 16, 16>;
+    using AccTile = TileAcc<float, 16, 16>;
+    using Pipe = TPipe<FlagId, Direction::DIR_BOTH, sizeof(float) * MatTile::Numel, 2>;
+
+    Pipe::reset_for_cpu_sim();
+    Pipe vecProducer0((__gm__ void *)nullptr, 0x0, 0x10000);
+    Pipe vecProducer1((__gm__ void *)nullptr, 0x0, 0x10000);
+    Pipe cubePipe((__gm__ void *)nullptr, 0x0, 0x10000);
+    Pipe vecConsumer0((__gm__ void *)nullptr, 0x0, 0x10000);
+    Pipe vecConsumer1((__gm__ void *)nullptr, 0x0, 0x10000);
+
+    VecTile src0;
+    VecTile src1;
+    MatTile poppedMat;
+    AccTile accSrc;
+    VecTile dst0;
+    VecTile dst1;
+
+    TASSIGN(src0, 0x0);
+    TASSIGN(src1, VecTile::Numel * sizeof(float));
+    TASSIGN(poppedMat, 2 * VecTile::Numel * sizeof(float));
+    TASSIGN(accSrc, 2 * VecTile::Numel * sizeof(float) + MatTile::Numel * sizeof(float));
+    TASSIGN(dst0, 2 * VecTile::Numel * sizeof(float) + MatTile::Numel * sizeof(float) + AccTile::Numel * sizeof(float));
+    TASSIGN(dst1, 2 * VecTile::Numel * sizeof(float) + MatTile::Numel * sizeof(float) + AccTile::Numel * sizeof(float) +
+                      VecTile::Numel * sizeof(float));
+
+    fillTileSequence(src0, 1.0f);
+    fillTileSequence(src1, 1001.0f);
+    fillTileSequence(accSrc, 2001.0f);
+    std::fill(poppedMat.data(), poppedMat.data() + poppedMat.Numel, 0.0f);
+    std::fill(dst0.data(), dst0.data() + dst0.Numel, 0.0f);
+    std::fill(dst1.data(), dst1.data() + dst1.Numel, 0.0f);
+
+    {
+        cpu_sim::ScopedExecutionContext ctx(0, 0, 2);
+        TPUSH<Pipe, VecTile, SplitAxis>(vecProducer0, src0);
+    }
+    {
+        cpu_sim::ScopedExecutionContext ctx(0, 1, 2);
+        TPUSH<Pipe, VecTile, SplitAxis>(vecProducer1, src1);
+    }
+
+    std::atomic<bool> vec0Done{false};
+    std::atomic<bool> vec1Done{false};
+    std::thread consumerThread0([&]() {
+        cpu_sim::ScopedExecutionContext ctx(0, 0, 2);
+        TPOP<Pipe, VecTile, SplitAxis>(vecConsumer0, dst0);
+        vec0Done.store(true, std::memory_order_release);
+    });
+    std::thread consumerThread1([&]() {
+        cpu_sim::ScopedExecutionContext ctx(0, 1, 2);
+        TPOP<Pipe, VecTile, SplitAxis>(vecConsumer1, dst1);
+        vec1Done.store(true, std::memory_order_release);
+    });
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(30));
+    EXPECT_FALSE(vec0Done.load(std::memory_order_acquire));
+    EXPECT_FALSE(vec1Done.load(std::memory_order_acquire));
+
+    {
+        cpu_sim::ScopedExecutionContext ctx(0, 0, 1);
+        TPOP<Pipe, MatTile, SplitAxis>(cubePipe, poppedMat);
+        TFREE<Pipe, SplitAxis>(cubePipe);
+    }
+
+    {
+        cpu_sim::ScopedExecutionContext ctx(0, 0, 1);
+        TPUSH<Pipe, AccTile, SplitAxis>(cubePipe, accSrc);
+    }
+
+    consumerThread0.join();
+    consumerThread1.join();
+
+    expectVecMatchesAccSplit<SplitAxis>(dst0, accSrc, 0);
+    expectVecMatchesAccSplit<SplitAxis>(dst1, accSrc, 1);
+
+    {
+        cpu_sim::ScopedExecutionContext ctx(0, 0, 2);
+        TFREE<Pipe, SplitAxis>(vecConsumer0);
+    }
+    {
+        cpu_sim::ScopedExecutionContext ctx(0, 1, 2);
+        TFREE<Pipe, SplitAxis>(vecConsumer1);
+    }
+}
+} // namespace
 
 template <typename T, int rows, int cols, TileType srcLoc>
 void fillTile(auto &tile, int iter)
@@ -263,4 +424,75 @@ TEST_F(TPushPopTest, a5_style_v2c_local_split_push_pop)
             EXPECT_EQ(dst.data()[GetTileElementOffset<MatTile>(r, c)], 0.0f);
         }
     }
+}
+
+TEST_F(TPushPopTest, cpu_stub_prefers_injected_hooks_for_subblock_and_pipe_state)
+{
+    HookTestPipe::SharedStateStorage storage{};
+    g_injected_subblock_id.store(7, std::memory_order_relaxed);
+    g_pipe_hook_call_count.store(0, std::memory_order_relaxed);
+    g_pipe_hook_storage = &storage;
+    g_pipe_hook_size = 0;
+    g_pipe_hook_last_key = 0;
+
+    ScopedCpuStubHooks hooks(reinterpret_cast<void *>(MockSubblockIdHook),
+                             reinterpret_cast<void *>(MockPipeSharedStateHook));
+    cpu_sim::set_execution_context(0, 1, 2);
+
+    EXPECT_EQ(get_subblockid(), 7u);
+
+    auto &state = HookTestPipe::GetSharedState();
+    state.next_producer_slot = 3;
+    auto &stateAgain = HookTestPipe::GetSharedState();
+
+    EXPECT_EQ(&state, &stateAgain);
+    EXPECT_EQ(stateAgain.next_producer_slot, 3);
+    EXPECT_GT(g_pipe_hook_call_count.load(std::memory_order_relaxed), 0u);
+    EXPECT_EQ(g_pipe_hook_size, sizeof(HookTestPipe::SharedStateStorage));
+    EXPECT_NE(g_pipe_hook_last_key, 0u);
+}
+
+TEST_F(TPushPopTest, v2c_split_single_subblock_with_injected_pipe_hook_tracks_one_active_lane)
+{
+    using VecTile = Tile<TileType::Vec, float, 8, 16, BLayout::RowMajor, 8, 16>;
+
+    HookedV2CPipe::SharedStateStorage storage{};
+    g_pipe_hook_call_count.store(0, std::memory_order_relaxed);
+    g_pipe_hook_storage = &storage;
+    g_pipe_hook_size = 0;
+    g_pipe_hook_last_key = 0;
+
+    ScopedCpuStubHooks hooks(nullptr, reinterpret_cast<void *>(MockPipeSharedStateHook));
+    HookedV2CPipe::reset_for_cpu_sim();
+
+    HookedV2CPipe pipe((__gm__ void *)nullptr, 0x0, 0x10000);
+    VecTile src;
+    TASSIGN(src, 0);
+    fillTile<float, 8, 16, TileType::Vec>(src, 0);
+
+    {
+        cpu_sim::ScopedExecutionContext ctx(0, 0, 1);
+        EXPECT_EQ(cpu_pipe::GetActiveSplitCount<TileSplitAxis::TILE_UP_DOWN>(), 1u);
+        EXPECT_EQ(cpu_pipe::GetActiveSplitLaneMask<TileSplitAxis::TILE_UP_DOWN>(), 0x1u);
+        TPUSH<HookedV2CPipe, VecTile, TileSplitAxis::TILE_UP_DOWN>(pipe, src);
+    }
+
+    auto &state = HookedV2CPipe::GetSharedState();
+    EXPECT_EQ(state.occupied, 1);
+    EXPECT_EQ(state.next_producer_slot, 1);
+    EXPECT_EQ(state.producers_done[0], 0u);
+    EXPECT_EQ(state.producers_allocated[0], 0u);
+    EXPECT_GT(g_pipe_hook_call_count.load(std::memory_order_relaxed), 0u);
+    EXPECT_EQ(g_pipe_hook_size, sizeof(HookedV2CPipe::SharedStateStorage));
+    EXPECT_NE(g_pipe_hook_last_key, 0u);
+}
+
+TEST_F(TPushPopTest, a5_style_dir_both_updown_waits_for_matching_direction)
+{
+    testDirBothConsumerWaitsForMatchingDirection<TileSplitAxis::TILE_UP_DOWN, 7>();
+}
+
+TEST_F(TPushPopTest, a5_style_dir_both_leftright_waits_for_matching_direction)
+{
+    testDirBothConsumerWaitsForMatchingDirection<TileSplitAxis::TILE_LEFT_RIGHT, 8>();
 }


### PR DESCRIPTION
## Summary
- Add injectable CPU-sim hooks for subblock IDs and pipe shared state,
  enabling test-controlled split pipe execution contexts
- Add transfer-direction tracking for CPU-sim pipes so DIR_BOTH queues
  route C2V and V2C traffic through matching producer and consumer lanes
- Add split-lane producer allocation, completion, and active-lane masks
  for V2C split pushes using the runtime subblock dimension
- Refactor CPU-sim TPOP data movement into direction-specific consumer
  helpers for GM, Vec FIFO, split Vec FIFO, and Mat FIFO paths
- Add CPU-sim tile storage helpers and linear slot insertion for split
  V2C pushes with correct row and column placement
- Add NPUMemoryModel address containment checks so TASSIGN can bind alias
  tiles to existing simulated on-chip memory pointers
- Add CPU ST coverage for TASSIGN aliasing, injectable pipe hooks,
  DIR_BOTH split routing, and hook-backed single-subblock V2C split pushes

## Testing
- [x] All 18 targeted CPU ST tests pass
- [x] Pre-commit hooks pass

Closes #66