### PR TITLE
test(st): Add new test cases, suppress cast warnings and auto-detect bf16

### DIFF
--- a/include/pto/cpu/TPush.hpp
+++ b/include/pto/cpu/TPush.hpp
@@ -129,13 +129,13 @@ template <TileSplitAxis Split>
 PTO_INTERNAL uint32_t GetActiveSplitCount()
 {
     constexpr uint32_t splitCount = GetSplitCount<Split>();
-    const uint32_t subblockDim = get_subblockdim();
-    if (subblockDim != 0) {
-        return (subblockDim < splitCount) ? subblockDim : splitCount;
-    }
     if ((cpu_sim::injected_subblock_id_hook != nullptr) || (cpu_sim::injected_pipe_shared_state_hook != nullptr) ||
         (cpu_sim::ResolveSubblockIdHook() != nullptr) || (cpu_sim::ResolvePipeSharedStateHook() != nullptr)) {
         return splitCount;
+    }
+    const uint32_t subblockDim = get_subblockdim();
+    if (subblockDim != 0) {
+        return (subblockDim < splitCount) ? subblockDim : splitCount;
     }
     return 1u;
 }

--- a/tests/cpu/st/testcase/tpushpop/main.cpp
+++ b/tests/cpu/st/testcase/tpushpop/main.cpp
@@ -452,9 +452,10 @@ TEST_F(TPushPopTest, cpu_stub_prefers_injected_hooks_for_subblock_and_pipe_state
     EXPECT_NE(g_pipe_hook_last_key, 0u);
 }
 
-TEST_F(TPushPopTest, v2c_split_single_subblock_with_injected_pipe_hook_tracks_one_active_lane)
+TEST_F(TPushPopTest, v2c_split_with_injected_pipe_hook_waits_for_both_lanes_before_publish)
 {
     using VecTile = Tile<TileType::Vec, float, 8, 16, BLayout::RowMajor, 8, 16>;
+    using MatTile = Tile<TileType::Mat, float, 16, 16, BLayout::RowMajor, 16, 16>;
 
     HookedV2CPipe::SharedStateStorage storage{};
     g_pipe_hook_call_count.store(0, std::memory_order_relaxed);
@@ -465,23 +466,59 @@ TEST_F(TPushPopTest, v2c_split_single_subblock_with_injected_pipe_hook_tracks_on
     ScopedCpuStubHooks hooks(nullptr, reinterpret_cast<void *>(MockPipeSharedStateHook));
     HookedV2CPipe::reset_for_cpu_sim();
 
-    HookedV2CPipe pipe((__gm__ void *)nullptr, 0x0, 0x10000);
-    VecTile src;
-    TASSIGN(src, 0);
-    fillTile<float, 8, 16, TileType::Vec>(src, 0);
+    HookedV2CPipe producer0((__gm__ void *)nullptr, 0x0, 0x10000);
+    HookedV2CPipe producer1((__gm__ void *)nullptr, 0x0, 0x10000);
+    HookedV2CPipe consumer((__gm__ void *)nullptr, 0x0, 0x10000);
+    VecTile topHalf;
+    VecTile bottomHalf;
+    MatTile dst;
+    TASSIGN(topHalf, 0);
+    TASSIGN(bottomHalf, VecTile::Numel * sizeof(VecTile::DType));
+    TASSIGN(dst, 2 * VecTile::Numel * sizeof(VecTile::DType));
+    fillTile<float, 8, 16, TileType::Vec>(topHalf, 0);
+    fillTile<float, 8, 16, TileType::Vec>(bottomHalf, 1);
+    std::fill(dst.data(), dst.data() + dst.Numel, 0.0f);
 
     {
         cpu_sim::ScopedExecutionContext ctx(0, 0, 1);
-        EXPECT_EQ(cpu_pipe::GetActiveSplitCount<TileSplitAxis::TILE_UP_DOWN>(), 1u);
-        EXPECT_EQ(cpu_pipe::GetActiveSplitLaneMask<TileSplitAxis::TILE_UP_DOWN>(), 0x1u);
-        TPUSH<HookedV2CPipe, VecTile, TileSplitAxis::TILE_UP_DOWN>(pipe, src);
+        EXPECT_EQ(cpu_pipe::GetActiveSplitCount<TileSplitAxis::TILE_UP_DOWN>(), 2u);
+        EXPECT_EQ(cpu_pipe::GetActiveSplitLaneMask<TileSplitAxis::TILE_UP_DOWN>(), 0x3u);
+        TPUSH<HookedV2CPipe, VecTile, TileSplitAxis::TILE_UP_DOWN>(producer0, topHalf);
     }
 
     auto &state = HookedV2CPipe::GetSharedState();
+    EXPECT_EQ(state.occupied, 0);
+    EXPECT_EQ(state.next_producer_slot, 0);
+    EXPECT_EQ(state.producers_done[0], 0x1u);
+    EXPECT_EQ(state.producers_allocated[0], 0x1u);
+
+    {
+        cpu_sim::ScopedExecutionContext ctx(0, 1, 1);
+        EXPECT_EQ(cpu_pipe::GetActiveSplitCount<TileSplitAxis::TILE_UP_DOWN>(), 2u);
+        EXPECT_EQ(cpu_pipe::GetActiveSplitLaneMask<TileSplitAxis::TILE_UP_DOWN>(), 0x3u);
+        TPUSH<HookedV2CPipe, VecTile, TileSplitAxis::TILE_UP_DOWN>(producer1, bottomHalf);
+    }
+
     EXPECT_EQ(state.occupied, 1);
     EXPECT_EQ(state.next_producer_slot, 1);
     EXPECT_EQ(state.producers_done[0], 0u);
     EXPECT_EQ(state.producers_allocated[0], 0u);
+
+    {
+        cpu_sim::ScopedExecutionContext ctx(0, 0, 1);
+        TPOP<HookedV2CPipe, MatTile, TileSplitAxis::TILE_UP_DOWN>(consumer, dst);
+        TFREE<HookedV2CPipe, TileSplitAxis::TILE_UP_DOWN>(consumer);
+    }
+
+    for (int r = 0; r < topHalf.GetValidRow(); ++r) {
+        for (int c = 0; c < topHalf.GetValidCol(); ++c) {
+            EXPECT_EQ(dst.data()[GetTileElementOffset<MatTile>(r, c)],
+                      topHalf.data()[GetTileElementOffset<VecTile>(r, c)]);
+            EXPECT_EQ(dst.data()[GetTileElementOffset<MatTile>(r + topHalf.GetValidRow(), c)],
+                      bottomHalf.data()[GetTileElementOffset<VecTile>(r, c)]);
+        }
+    }
+
     EXPECT_GT(g_pipe_hook_call_count.load(std::memory_order_relaxed), 0u);
     EXPECT_EQ(g_pipe_hook_size, sizeof(HookedV2CPipe::SharedStateStorage));
     EXPECT_NE(g_pipe_hook_last_key, 0u);


### PR DESCRIPTION
## Summary
- Add `tisa_coverage` and `tpushpop_cv` test cases to CMakeLists build list
- Remove `IdxTile` / `gatherIdx` from TQUANT coverage test to match updated MXFP8 NZ API (no longer requires gather index parameter)
- Remove duplicate BF16 textract test entries already covered by `NumExt.bf16` cases
- Add `cast_without_overflow_warning` helper in `utils.py`, `cpu_bfloat16.py`, and `tcvt/gen_data.py` to suppress NumPy overflow and invalid-value cast warnings during intentional type narrowing
- Add `should_generate_bf16_data()` in `all_cpu_tests.py` to auto-detect compiler bfloat16 support when `--enable-bf16` is not explicitly set
- Clean up PYTHONPATH construction in `generate_test_data` to avoid trailing path separator

## Testing
- [x] All CPU ST tests pass
- [x] Pre-commit hooks pass