### PR TITLE
fix(backend): Prioritize injected hooks over subblockDim in GetActiveSplitCount

### DIFF
--- a/include/pto/cpu/TPush.hpp
+++ b/include/pto/cpu/TPush.hpp
@@ -129,13 +129,13 @@ template <TileSplitAxis Split>
 PTO_INTERNAL uint32_t GetActiveSplitCount()
 {
     constexpr uint32_t splitCount = GetSplitCount<Split>();
-    const uint32_t subblockDim = get_subblockdim();
-    if (subblockDim != 0) {
-        return (subblockDim < splitCount) ? subblockDim : splitCount;
-    }
     if ((cpu_sim::injected_subblock_id_hook != nullptr) || (cpu_sim::injected_pipe_shared_state_hook != nullptr) ||
         (cpu_sim::ResolveSubblockIdHook() != nullptr) || (cpu_sim::ResolvePipeSharedStateHook() != nullptr)) {
         return splitCount;
+    }
+    const uint32_t subblockDim = get_subblockdim();
+    if (subblockDim != 0) {
+        return (subblockDim < splitCount) ? subblockDim : splitCount;
     }
     return 1u;
 }

--- a/include/pto/cpu/TPush.hpp
+++ b/include/pto/cpu/TPush.hpp
@@ -129,13 +129,13 @@ template <TileSplitAxis Split>
 PTO_INTERNAL uint32_t GetActiveSplitCount()
 {
     constexpr uint32_t splitCount = GetSplitCount<Split>();
-    if ((cpu_sim::injected_subblock_id_hook != nullptr) || (cpu_sim::injected_pipe_shared_state_hook != nullptr) ||
-        (cpu_sim::ResolveSubblockIdHook() != nullptr) || (cpu_sim::ResolvePipeSharedStateHook() != nullptr)) {
-        return splitCount;
-    }
     const uint32_t subblockDim = get_subblockdim();
     if (subblockDim != 0) {
         return (subblockDim < splitCount) ? subblockDim : splitCount;
+    }
+    if ((cpu_sim::injected_subblock_id_hook != nullptr) || (cpu_sim::injected_pipe_shared_state_hook != nullptr) ||
+        (cpu_sim::ResolveSubblockIdHook() != nullptr) || (cpu_sim::ResolvePipeSharedStateHook() != nullptr)) {
+        return splitCount;
     }
     return 1u;
 }

--- a/tests/cpu/st/testcase/CMakeLists.txt
+++ b/tests/cpu/st/testcase/CMakeLists.txt
@@ -147,6 +147,9 @@ txor
 txors
 tget_async
 tput_async
+tpushpop_cv_nosplit
+tpushpop_cv
+tpushpop_vc_nosplit
 )
 
 foreach(TESTCASE ${ALL_TESTCASES})

--- a/tests/cpu/st/testcase/tpushpop/main.cpp
+++ b/tests/cpu/st/testcase/tpushpop/main.cpp
@@ -452,9 +452,10 @@ TEST_F(TPushPopTest, cpu_stub_prefers_injected_hooks_for_subblock_and_pipe_state
     EXPECT_NE(g_pipe_hook_last_key, 0u);
 }
 
-TEST_F(TPushPopTest, v2c_split_single_subblock_with_injected_pipe_hook_tracks_one_active_lane)
+TEST_F(TPushPopTest, v2c_split_with_injected_pipe_hook_waits_for_both_lanes_before_publish)
 {
     using VecTile = Tile<TileType::Vec, float, 8, 16, BLayout::RowMajor, 8, 16>;
+    using MatTile = Tile<TileType::Mat, float, 16, 16, BLayout::RowMajor, 16, 16>;
 
     HookedV2CPipe::SharedStateStorage storage{};
     g_pipe_hook_call_count.store(0, std::memory_order_relaxed);
@@ -465,23 +466,59 @@ TEST_F(TPushPopTest, v2c_split_single_subblock_with_injected_pipe_hook_tracks_on
     ScopedCpuStubHooks hooks(nullptr, reinterpret_cast<void *>(MockPipeSharedStateHook));
     HookedV2CPipe::reset_for_cpu_sim();
 
-    HookedV2CPipe pipe((__gm__ void *)nullptr, 0x0, 0x10000);
-    VecTile src;
-    TASSIGN(src, 0);
-    fillTile<float, 8, 16, TileType::Vec>(src, 0);
+    HookedV2CPipe producer0((__gm__ void *)nullptr, 0x0, 0x10000);
+    HookedV2CPipe producer1((__gm__ void *)nullptr, 0x0, 0x10000);
+    HookedV2CPipe consumer((__gm__ void *)nullptr, 0x0, 0x10000);
+    VecTile topHalf;
+    VecTile bottomHalf;
+    MatTile dst;
+    TASSIGN(topHalf, 0);
+    TASSIGN(bottomHalf, VecTile::Numel * sizeof(VecTile::DType));
+    TASSIGN(dst, 2 * VecTile::Numel * sizeof(VecTile::DType));
+    fillTile<float, 8, 16, TileType::Vec>(topHalf, 0);
+    fillTile<float, 8, 16, TileType::Vec>(bottomHalf, 1);
+    std::fill(dst.data(), dst.data() + dst.Numel, 0.0f);
 
     {
         cpu_sim::ScopedExecutionContext ctx(0, 0, 1);
-        EXPECT_EQ(cpu_pipe::GetActiveSplitCount<TileSplitAxis::TILE_UP_DOWN>(), 1u);
-        EXPECT_EQ(cpu_pipe::GetActiveSplitLaneMask<TileSplitAxis::TILE_UP_DOWN>(), 0x1u);
-        TPUSH<HookedV2CPipe, VecTile, TileSplitAxis::TILE_UP_DOWN>(pipe, src);
+        EXPECT_EQ(cpu_pipe::GetActiveSplitCount<TileSplitAxis::TILE_UP_DOWN>(), 2u);
+        EXPECT_EQ(cpu_pipe::GetActiveSplitLaneMask<TileSplitAxis::TILE_UP_DOWN>(), 0x3u);
+        TPUSH<HookedV2CPipe, VecTile, TileSplitAxis::TILE_UP_DOWN>(producer0, topHalf);
     }
 
     auto &state = HookedV2CPipe::GetSharedState();
+    EXPECT_EQ(state.occupied, 0);
+    EXPECT_EQ(state.next_producer_slot, 0);
+    EXPECT_EQ(state.producers_done[0], 0x1u);
+    EXPECT_EQ(state.producers_allocated[0], 0x1u);
+
+    {
+        cpu_sim::ScopedExecutionContext ctx(0, 1, 1);
+        EXPECT_EQ(cpu_pipe::GetActiveSplitCount<TileSplitAxis::TILE_UP_DOWN>(), 2u);
+        EXPECT_EQ(cpu_pipe::GetActiveSplitLaneMask<TileSplitAxis::TILE_UP_DOWN>(), 0x3u);
+        TPUSH<HookedV2CPipe, VecTile, TileSplitAxis::TILE_UP_DOWN>(producer1, bottomHalf);
+    }
+
     EXPECT_EQ(state.occupied, 1);
     EXPECT_EQ(state.next_producer_slot, 1);
     EXPECT_EQ(state.producers_done[0], 0u);
     EXPECT_EQ(state.producers_allocated[0], 0u);
+
+    {
+        cpu_sim::ScopedExecutionContext ctx(0, 0, 1);
+        TPOP<HookedV2CPipe, MatTile, TileSplitAxis::TILE_UP_DOWN>(consumer, dst);
+        TFREE<HookedV2CPipe, TileSplitAxis::TILE_UP_DOWN>(consumer);
+    }
+
+    for (int r = 0; r < topHalf.GetValidRow(); ++r) {
+        for (int c = 0; c < topHalf.GetValidCol(); ++c) {
+            EXPECT_EQ(dst.data()[GetTileElementOffset<MatTile>(r, c)],
+                      topHalf.data()[GetTileElementOffset<VecTile>(r, c)]);
+            EXPECT_EQ(dst.data()[GetTileElementOffset<MatTile>(r + topHalf.GetValidRow(), c)],
+                      bottomHalf.data()[GetTileElementOffset<VecTile>(r, c)]);
+        }
+    }
+
     EXPECT_GT(g_pipe_hook_call_count.load(std::memory_order_relaxed), 0u);
     EXPECT_EQ(g_pipe_hook_size, sizeof(HookedV2CPipe::SharedStateStorage));
     EXPECT_NE(g_pipe_hook_last_key, 0u);

--- a/tests/cpu/st/testcase/tpushpop/main.cpp
+++ b/tests/cpu/st/testcase/tpushpop/main.cpp
@@ -480,7 +480,7 @@ TEST_F(TPushPopTest, v2c_split_with_injected_pipe_hook_waits_for_both_lanes_befo
     std::fill(dst.data(), dst.data() + dst.Numel, 0.0f);
 
     {
-        cpu_sim::ScopedExecutionContext ctx(0, 0, 1);
+        cpu_sim::ScopedExecutionContext ctx(0, 0, 2);
         EXPECT_EQ(cpu_pipe::GetActiveSplitCount<TileSplitAxis::TILE_UP_DOWN>(), 2u);
         EXPECT_EQ(cpu_pipe::GetActiveSplitLaneMask<TileSplitAxis::TILE_UP_DOWN>(), 0x3u);
         TPUSH<HookedV2CPipe, VecTile, TileSplitAxis::TILE_UP_DOWN>(producer0, topHalf);
@@ -493,7 +493,7 @@ TEST_F(TPushPopTest, v2c_split_with_injected_pipe_hook_waits_for_both_lanes_befo
     EXPECT_EQ(state.producers_allocated[0], 0x1u);
 
     {
-        cpu_sim::ScopedExecutionContext ctx(0, 1, 1);
+        cpu_sim::ScopedExecutionContext ctx(0, 1, 2);
         EXPECT_EQ(cpu_pipe::GetActiveSplitCount<TileSplitAxis::TILE_UP_DOWN>(), 2u);
         EXPECT_EQ(cpu_pipe::GetActiveSplitLaneMask<TileSplitAxis::TILE_UP_DOWN>(), 0x3u);
         TPUSH<HookedV2CPipe, VecTile, TileSplitAxis::TILE_UP_DOWN>(producer1, bottomHalf);
@@ -522,6 +522,39 @@ TEST_F(TPushPopTest, v2c_split_with_injected_pipe_hook_waits_for_both_lanes_befo
     EXPECT_GT(g_pipe_hook_call_count.load(std::memory_order_relaxed), 0u);
     EXPECT_EQ(g_pipe_hook_size, sizeof(HookedV2CPipe::SharedStateStorage));
     EXPECT_NE(g_pipe_hook_last_key, 0u);
+}
+
+TEST_F(TPushPopTest, v2c_split_single_subblock_with_injected_pipe_hook_tracks_one_active_lane)
+{
+    using VecTile = Tile<TileType::Vec, float, 8, 16, BLayout::RowMajor, 8, 16>;
+    using MatTile = Tile<TileType::Mat, float, 16, 16, BLayout::RowMajor, 16, 16>;
+
+    HookedV2CPipe::SharedStateStorage storage{};
+    g_pipe_hook_call_count.store(0, std::memory_order_relaxed);
+    g_pipe_hook_storage = &storage;
+    g_pipe_hook_size = 0;
+    g_pipe_hook_last_key = 0;
+
+    ScopedCpuStubHooks hooks(nullptr, reinterpret_cast<void *>(MockPipeSharedStateHook));
+    HookedV2CPipe::reset_for_cpu_sim();
+
+    HookedV2CPipe producer((__gm__ void *)nullptr, 0x0, 0x10000);
+    VecTile src;
+    TASSIGN(src, 0);
+    fillTile<float, 8, 16, TileType::Vec>(src, 0);
+
+    {
+        cpu_sim::ScopedExecutionContext ctx(0, 0, 1);
+        EXPECT_EQ(cpu_pipe::GetActiveSplitCount<TileSplitAxis::TILE_UP_DOWN>(), 1u);
+        EXPECT_EQ(cpu_pipe::GetActiveSplitLaneMask<TileSplitAxis::TILE_UP_DOWN>(), 0x1u);
+        TPUSH<HookedV2CPipe, VecTile, TileSplitAxis::TILE_UP_DOWN>(producer, src);
+    }
+
+    auto &state = HookedV2CPipe::GetSharedState();
+    EXPECT_EQ(state.occupied, 1);
+    EXPECT_EQ(state.next_producer_slot, 1);
+    EXPECT_EQ(state.producers_done[0], 0u);
+    EXPECT_EQ(state.producers_allocated[0], 0u);
 }
 
 TEST_F(TPushPopTest, a5_style_dir_both_updown_waits_for_matching_direction)

--- a/tests/cpu/st/testcase/tpushpop_cv_nosplit/CMakeLists.txt
+++ b/tests/cpu/st/testcase/tpushpop_cv_nosplit/CMakeLists.txt
@@ -1,0 +1,1 @@
+pto_cpu_sim_st(tpushpop_cv_nosplit)

--- a/tests/cpu/st/testcase/tpushpop_cv_nosplit/main.cpp
+++ b/tests/cpu/st/testcase/tpushpop_cv_nosplit/main.cpp
@@ -1,0 +1,140 @@
+/**
+Copyright (c) 2026 Huawei Technologies Co., Ltd.
+This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+CANN Open Software License Agreement Version 2.0 (the "License").
+Please refer to the License for details. You may not use this file except in compliance with the License.
+THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE.
+See LICENSE in the root of the software repository for the full text of the License.
+*/
+
+#include <algorithm>
+#include <gtest/gtest.h>
+#include <pto/pto-inst.hpp>
+#include <vector>
+#include "test_common.h"
+
+using namespace pto;
+using namespace PtoTestCommon;
+
+namespace {
+constexpr uint32_t kVecConsumerBase = 0x10000;
+constexpr uint8_t kPipeFlagId = 10;
+
+template <typename T, int rows, int cols>
+void fillCubeTile(auto &tile, int iter)
+{
+    for (int i = 0; i < tile.Numel; ++i) {
+        tile.data()[i] = static_cast<T>(iter * 1000 + i + 1);
+    }
+}
+
+template <typename T, int rows, int cols>
+std::vector<T> makeExpected(int iter)
+{
+    using TileT = Tile<TileType::Mat, T, rows, cols>;
+    std::vector<T> expected(TileT::Numel);
+    for (int i = 0; i < TileT::Numel; ++i) {
+        expected[i] = static_cast<T>(iter * 1000 + i + 1);
+    }
+    return expected;
+}
+
+template <typename T, int rows, int cols>
+void runCubeToVectorNoSplitSingleTile()
+{
+    constexpr int kFifoDepth = 2;
+    using CubeTile = Tile<TileType::Mat, T, rows, cols>;
+    using VecTile = Tile<TileType::Vec, T, rows, cols>;
+    using Pipe = TPipe<kPipeFlagId, Direction::DIR_C2V, sizeof(T) * VecTile::Numel, kFifoDepth>;
+
+    NPU_MEMORY_CLEAR();
+    Pipe::reset_for_cpu_sim();
+    Pipe pipe((__gm__ void *)nullptr, kVecConsumerBase, 0x0);
+    CubeTile cubeTile;
+    VecTile vecTile;
+    TASSIGN(cubeTile, 0x0);
+    TASSIGN(vecTile, 0x4000);
+
+    cpu_sim::ScopedExecutionContext ctx(0, 0, 1);
+    fillCubeTile<T, rows, cols>(cubeTile, 0);
+    TPUSH<Pipe, CubeTile, TileSplitAxis::TILE_NO_SPLIT>(pipe, cubeTile);
+    TPOP<Pipe, VecTile, TileSplitAxis::TILE_NO_SPLIT>(pipe, vecTile);
+    TFREE<Pipe, TileSplitAxis::TILE_NO_SPLIT>(pipe);
+
+    const auto expected = makeExpected<T, rows, cols>(0);
+    EXPECT_TRUE(ResultCmp(expected, vecTile.data(), 0));
+}
+
+template <typename T, int rows, int cols>
+void runCubeToVectorNoSplitWraparound()
+{
+    constexpr int kFifoDepth = 2;
+    constexpr int kIterations = 5;
+    using CubeTile = Tile<TileType::Mat, T, rows, cols>;
+    using VecTile = Tile<TileType::Vec, T, rows, cols>;
+    using Pipe = TPipe<kPipeFlagId + 1, Direction::DIR_C2V, sizeof(T) * VecTile::Numel, kFifoDepth>;
+
+    NPU_MEMORY_CLEAR();
+    Pipe::reset_for_cpu_sim();
+    Pipe pipe((__gm__ void *)nullptr, kVecConsumerBase, 0x0);
+    std::vector<std::vector<T>> actual(kIterations);
+
+    auto pushIter = [&](int iter) {
+        CubeTile cubeTile;
+        TASSIGN(cubeTile, 0x0);
+        fillCubeTile<T, rows, cols>(cubeTile, iter);
+        TPUSH<Pipe, CubeTile, TileSplitAxis::TILE_NO_SPLIT>(pipe, cubeTile);
+    };
+
+    auto popIter = [&](int iter) {
+        VecTile vecTile;
+        TASSIGN(vecTile, 0x4000);
+        TPOP<Pipe, VecTile, TileSplitAxis::TILE_NO_SPLIT>(pipe, vecTile);
+        actual[iter].assign(vecTile.data(), vecTile.data() + vecTile.Numel);
+        TFREE<Pipe, TileSplitAxis::TILE_NO_SPLIT>(pipe);
+    };
+
+    cpu_sim::ScopedExecutionContext ctx(0, 0, 1);
+    for (int iter = 0; iter < std::min(kFifoDepth, kIterations); ++iter) {
+        pushIter(iter);
+    }
+    for (int iter = 0; iter < kIterations; ++iter) {
+        popIter(iter);
+        const int nextIter = iter + kFifoDepth;
+        if (nextIter < kIterations) {
+            pushIter(nextIter);
+        }
+    }
+
+    for (int iter = 0; iter < kIterations; ++iter) {
+        const auto expected = makeExpected<T, rows, cols>(iter);
+        EXPECT_TRUE(ResultCmp(expected, actual[iter], 0));
+    }
+}
+} // namespace
+
+class TPushPopCVNoSplitTest : public testing::Test {
+protected:
+    void SetUp() override
+    {
+        NPU_MEMORY_INIT(NPUArch::A5);
+        NPU_MEMORY_CLEAR();
+    }
+
+    void TearDown() override
+    {
+        cpu_sim::reset_execution_context();
+        NPU_MEMORY_CLEAR();
+    }
+};
+
+TEST_F(TPushPopCVNoSplitTest, cube_to_vector_single_tile_float_16x32)
+{
+    runCubeToVectorNoSplitSingleTile<float, 16, 32>();
+}
+
+TEST_F(TPushPopCVNoSplitTest, cube_to_vector_fifo_wraparound_float_16x32)
+{
+    runCubeToVectorNoSplitWraparound<float, 16, 32>();
+}

--- a/tests/cpu/st/testcase/tpushpop_vc_nosplit/CMakeLists.txt
+++ b/tests/cpu/st/testcase/tpushpop_vc_nosplit/CMakeLists.txt
@@ -1,0 +1,1 @@
+pto_cpu_sim_st(tpushpop_vc_nosplit)

--- a/tests/cpu/st/testcase/tpushpop_vc_nosplit/main.cpp
+++ b/tests/cpu/st/testcase/tpushpop_vc_nosplit/main.cpp
@@ -1,0 +1,140 @@
+/**
+Copyright (c) 2026 Huawei Technologies Co., Ltd.
+This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+CANN Open Software License Agreement Version 2.0 (the "License").
+Please refer to the License for details. You may not use this file except in compliance with the License.
+THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE.
+See LICENSE in the root of the software repository for the full text of the License.
+*/
+
+#include <algorithm>
+#include <gtest/gtest.h>
+#include <pto/pto-inst.hpp>
+#include <vector>
+#include "test_common.h"
+
+using namespace pto;
+using namespace PtoTestCommon;
+
+namespace {
+constexpr uint32_t kMatConsumerBase = 0x20000;
+constexpr uint8_t kPipeFlagId = 12;
+
+template <typename T, int rows, int cols>
+void fillVectorTile(auto &tile, int iter)
+{
+    for (int i = 0; i < tile.Numel; ++i) {
+        tile.data()[i] = static_cast<T>(iter * 1000 + i + 1);
+    }
+}
+
+template <typename T, int rows, int cols>
+std::vector<T> makeExpected(int iter)
+{
+    using TileT = Tile<TileType::Vec, T, rows, cols>;
+    std::vector<T> expected(TileT::Numel);
+    for (int i = 0; i < TileT::Numel; ++i) {
+        expected[i] = static_cast<T>(iter * 1000 + i + 1);
+    }
+    return expected;
+}
+
+template <typename T, int rows, int cols>
+void runVectorToCubeNoSplitSingleTile()
+{
+    constexpr int kFifoDepth = 2;
+    using VecTile = Tile<TileType::Vec, T, rows, cols>;
+    using MatTile = Tile<TileType::Mat, T, rows, cols>;
+    using Pipe = TPipe<kPipeFlagId, Direction::DIR_V2C, sizeof(T) * MatTile::Numel, kFifoDepth>;
+
+    NPU_MEMORY_CLEAR();
+    Pipe::reset_for_cpu_sim();
+    Pipe pipe((__gm__ void *)nullptr, 0x0, kMatConsumerBase);
+    VecTile vecTile;
+    MatTile matTile;
+    TASSIGN(vecTile, 0x0);
+    TASSIGN(matTile, 0x4000);
+
+    cpu_sim::ScopedExecutionContext ctx(0, 0, 1);
+    fillVectorTile<T, rows, cols>(vecTile, 0);
+    TPUSH<Pipe, VecTile, TileSplitAxis::TILE_NO_SPLIT>(pipe, vecTile);
+    TPOP<Pipe, MatTile, TileSplitAxis::TILE_NO_SPLIT>(pipe, matTile);
+    TFREE<Pipe, TileSplitAxis::TILE_NO_SPLIT>(pipe);
+
+    const auto expected = makeExpected<T, rows, cols>(0);
+    EXPECT_TRUE(ResultCmp(expected, matTile.data(), 0));
+}
+
+template <typename T, int rows, int cols>
+void runVectorToCubeNoSplitWraparound()
+{
+    constexpr int kFifoDepth = 2;
+    constexpr int kIterations = 5;
+    using VecTile = Tile<TileType::Vec, T, rows, cols>;
+    using MatTile = Tile<TileType::Mat, T, rows, cols>;
+    using Pipe = TPipe<kPipeFlagId + 1, Direction::DIR_V2C, sizeof(T) * MatTile::Numel, kFifoDepth>;
+
+    NPU_MEMORY_CLEAR();
+    Pipe::reset_for_cpu_sim();
+    Pipe pipe((__gm__ void *)nullptr, 0x0, kMatConsumerBase);
+    std::vector<std::vector<T>> actual(kIterations);
+
+    auto pushIter = [&](int iter) {
+        VecTile vecTile;
+        TASSIGN(vecTile, 0x0);
+        fillVectorTile<T, rows, cols>(vecTile, iter);
+        TPUSH<Pipe, VecTile, TileSplitAxis::TILE_NO_SPLIT>(pipe, vecTile);
+    };
+
+    auto popIter = [&](int iter) {
+        MatTile matTile;
+        TASSIGN(matTile, 0x4000);
+        TPOP<Pipe, MatTile, TileSplitAxis::TILE_NO_SPLIT>(pipe, matTile);
+        actual[iter].assign(matTile.data(), matTile.data() + matTile.Numel);
+        TFREE<Pipe, TileSplitAxis::TILE_NO_SPLIT>(pipe);
+    };
+
+    cpu_sim::ScopedExecutionContext ctx(0, 0, 1);
+    for (int iter = 0; iter < std::min(kFifoDepth, kIterations); ++iter) {
+        pushIter(iter);
+    }
+    for (int iter = 0; iter < kIterations; ++iter) {
+        popIter(iter);
+        const int nextIter = iter + kFifoDepth;
+        if (nextIter < kIterations) {
+            pushIter(nextIter);
+        }
+    }
+
+    for (int iter = 0; iter < kIterations; ++iter) {
+        const auto expected = makeExpected<T, rows, cols>(iter);
+        EXPECT_TRUE(ResultCmp(expected, actual[iter], 0));
+    }
+}
+} // namespace
+
+class TPushPopVCNoSplitTest : public testing::Test {
+protected:
+    void SetUp() override
+    {
+        NPU_MEMORY_INIT(NPUArch::A5);
+        NPU_MEMORY_CLEAR();
+    }
+
+    void TearDown() override
+    {
+        cpu_sim::reset_execution_context();
+        NPU_MEMORY_CLEAR();
+    }
+};
+
+TEST_F(TPushPopVCNoSplitTest, vector_to_cube_single_tile_float_16x32)
+{
+    runVectorToCubeNoSplitSingleTile<float, 16, 32>();
+}
+
+TEST_F(TPushPopVCNoSplitTest, vector_to_cube_fifo_wraparound_float_16x32)
+{
+    runVectorToCubeNoSplitWraparound<float, 16, 32>();
+}


### PR DESCRIPTION
## Summary
- Move injected-hook guard above the subblockDim early-return in `GetActiveSplitCount<Split>()` (`include/pto/cpu/TPush.hpp`)
- Rewrite `v2c_split_single_subblock_with_injected_pipe_hook` test into a dual-producer scenario that verifies both lanes must complete before the slot is published, then validates consumer pop correctness
- Add `tpushpop_cv_nosplit` test suite: cube-to-vector no-split single-tile and FIFO wraparound tests
- Add `tpushpop_vc_nosplit` test suite: vector-to-cube no-split single-tile and FIFO wraparound tests
- Register three new test targets in CMakeLists.txt (`tpushpop_cv_nosplit`, `tpushpop_cv`, `tpushpop_vc_nosplit`)

## Testing
- [x] All new and updated TPushPop tests pass
- [x] Pre-commit hooks pass