### PR TITLE
feat(codegen): Add column-major DN layout support for TLoad with flattened rows

### DIFF
--- a/include/pto/cpu/TLoad.hpp
+++ b/include/pto/cpu/TLoad.hpp
@@ -69,21 +69,89 @@ __tf__ PTO_INLINE void LoadPlainMatrix(typename GlobalData::DType __out__ *dst, 
 }
 
 template <typename GlobalData, typename TileData>
-__tf__ PTO_INLINE void LoadPlain(typename GlobalData::DType __out__ *dst, typename TileData::TileDType __in__ src,
-                                 int gShape0, int gShape1, int gShape2, int gShape3, int gShape4, int gStride0,
-                                 int gStride1, int gStride2, int gStride3, int gStride4, int validRow, int validCol)
+__tf__ PTO_INLINE void LoadPlainDnClassic(typename GlobalData::DType __out__ *dst,
+                                          typename TileData::TileDType __in__ src, int gShape0, int gShape1,
+                                          int gShape2, int gShape3, int gShape4, int gStride0, int gStride1,
+                                          int gStride2, int gStride3, int gStride4, int validRow, int validCol)
 {
     int64_t dstStride1 = gShape2;
     int64_t dstStride0 = gShape1 * dstStride1;
 
-    for (uint32_t i = 0; i < gShape0; i++) {
-        int64_t dstAddr0 = i * dstStride0;
-        int64_t srcAddr0 = i * gStride0;
-        for (uint32_t j = 0; j < gShape1; j++) {
-            int64_t dstAddr1 = j * dstStride1;
-            int64_t srcAddr1 = j * gStride1;
-            for (uint32_t k = 0; k < gShape2; k++) {
-                size_t offsetSrcBase = srcAddr0 + srcAddr1 + k * gStride2;
+    for (uint32_t i = 0; i < static_cast<uint32_t>(gShape0); i++) {
+        int64_t dstAddr0 = static_cast<int64_t>(i) * dstStride0;
+        int64_t srcAddr0 = static_cast<int64_t>(i) * gStride0;
+        for (uint32_t j = 0; j < static_cast<uint32_t>(gShape1); j++) {
+            int64_t dstAddr1 = static_cast<int64_t>(j) * dstStride1;
+            int64_t srcAddr1 = static_cast<int64_t>(j) * gStride1;
+            for (uint32_t k = 0; k < static_cast<uint32_t>(gShape2); k++) {
+                size_t offsetSrcBase = srcAddr0 + srcAddr1 + static_cast<int64_t>(k) * gStride2;
+                LoadPlainMatrix<GlobalData, TileData>(dst, src + offsetSrcBase, gShape3, gShape4, gStride3, gStride4,
+                                                      validRow, validCol, dstAddr0 + dstAddr1 + k);
+            }
+        }
+    }
+}
+
+template <typename GlobalData, typename TileData>
+__tf__ PTO_INLINE void LoadPlainDnFlattenRows(typename GlobalData::DType __out__ *dst,
+                                              typename TileData::TileDType __in__ src, int gShape0, int gShape1,
+                                              int gShape2, int gShape3, int gShape4, int gStride0, int gStride1,
+                                              int gStride2, int gStride3, int gStride4, int validRow, int validCol)
+{
+    (void)validRow;
+    (void)validCol;
+    for (uint32_t i = 0; i < static_cast<uint32_t>(gShape0); i++) {
+        const std::size_t srcAddr0 = static_cast<std::size_t>(i) * static_cast<std::size_t>(gStride0);
+        const std::size_t dstAddr0 =
+            static_cast<std::size_t>(i) * static_cast<std::size_t>(gShape1) * gShape2 * gShape3;
+        for (uint32_t j = 0; j < static_cast<uint32_t>(gShape1); j++) {
+            const std::size_t srcAddr1 = static_cast<std::size_t>(j) * static_cast<std::size_t>(gStride1);
+            const std::size_t dstAddr1 = static_cast<std::size_t>(j) * static_cast<std::size_t>(gShape2) * gShape3;
+            for (uint32_t k = 0; k < static_cast<uint32_t>(gShape2); k++) {
+                const std::size_t srcAddr2 = static_cast<std::size_t>(k) * static_cast<std::size_t>(gStride2);
+                const std::size_t dstRowBase = dstAddr0 + dstAddr1 + static_cast<std::size_t>(k) * gShape3;
+                for (std::size_t c = 0; c < static_cast<std::size_t>(gShape4); c++) {
+                    const std::size_t dstBase = c * static_cast<std::size_t>(TileData::Rows) + dstRowBase;
+                    const std::size_t srcBase = srcAddr0 + srcAddr1 + srcAddr2 + c * static_cast<std::size_t>(gStride4);
+                    PTO_CPU_VECTORIZE_LOOP
+                    for (std::size_t r = 0; r < static_cast<std::size_t>(gShape3); r++) {
+                        dst[dstBase + r] = src[srcBase + r * static_cast<std::size_t>(gStride3)];
+                    }
+                }
+            }
+        }
+    }
+}
+
+template <typename GlobalData, typename TileData>
+__tf__ PTO_INLINE void LoadPlain(typename GlobalData::DType __out__ *dst, typename TileData::TileDType __in__ src,
+                                 int gShape0, int gShape1, int gShape2, int gShape3, int gShape4, int gStride0,
+                                 int gStride1, int gStride2, int gStride3, int gStride4, int validRow, int validCol)
+{
+    if constexpr (!TileData::isRowMajor) {
+        const int64_t flattenedRows = static_cast<int64_t>(gShape0) * gShape1 * gShape2 * static_cast<int64_t>(gShape3);
+        if (flattenedRows == validRow && gShape4 == validCol) {
+            LoadPlainDnFlattenRows<GlobalData, TileData>(dst, src, gShape0, gShape1, gShape2, gShape3, gShape4,
+                                                         gStride0, gStride1, gStride2, gStride3, gStride4, validRow,
+                                                         validCol);
+            return;
+        }
+        LoadPlainDnClassic<GlobalData, TileData>(dst, src, gShape0, gShape1, gShape2, gShape3, gShape4, gStride0,
+                                                 gStride1, gStride2, gStride3, gStride4, validRow, validCol);
+        return;
+    }
+
+    int64_t dstStride1 = gShape2;
+    int64_t dstStride0 = gShape1 * dstStride1;
+
+    for (uint32_t i = 0; i < static_cast<uint32_t>(gShape0); i++) {
+        int64_t dstAddr0 = static_cast<int64_t>(i) * dstStride0;
+        int64_t srcAddr0 = static_cast<int64_t>(i) * gStride0;
+        for (uint32_t j = 0; j < static_cast<uint32_t>(gShape1); j++) {
+            int64_t dstAddr1 = static_cast<int64_t>(j) * dstStride1;
+            int64_t srcAddr1 = static_cast<int64_t>(j) * gStride1;
+            for (uint32_t k = 0; k < static_cast<uint32_t>(gShape2); k++) {
+                size_t offsetSrcBase = srcAddr0 + srcAddr1 + static_cast<int64_t>(k) * gStride2;
                 LoadPlainMatrix<GlobalData, TileData>(dst, src + offsetSrcBase, gShape3, gShape4, gStride3, gStride4,
                                                       validRow, validCol, dstAddr0 + dstAddr1 + k);
             }
@@ -124,8 +192,15 @@ __tf__ AICORE void TLoad(typename TileData::TileDType __out__ dst, typename Glob
                          int gShape1, int gShape2, int gShape3, int gShape4, int gStride0, int gStride1, int gStride2,
                          int gStride3, int gStride4, int validRow, int validCol)
 {
-    assert((gShape0 * gShape1 * gShape2 * gShape3 == validRow && gShape4 == validCol && TileData::isRowMajor) ||
-           (gShape0 * gShape1 * gShape2 * gShape4 == validCol && gShape3 == validRow && !TileData::isRowMajor));
+    const bool isFlattenRowsColMajor =
+        !TileData::isRowMajor &&
+        static_cast<int64_t>(gShape0) * gShape1 * gShape2 * static_cast<int64_t>(gShape3) == validRow &&
+        gShape4 == validCol;
+    assert((static_cast<int64_t>(gShape0) * gShape1 * gShape2 * gShape3 == validRow && gShape4 == validCol &&
+            TileData::isRowMajor) ||
+           (static_cast<int64_t>(gShape0) * gShape1 * gShape2 * gShape4 == validCol && gShape3 == validRow &&
+            !TileData::isRowMajor) ||
+           isFlattenRowsColMajor);
 
     // Filling padding
     std::fill(dst, dst + (TileData::Cols * TileData::Rows), getPadValue<TileData>());

--- a/tests/cpu/st/testcase/tload/main.cpp
+++ b/tests/cpu/st/testcase/tload/main.cpp
@@ -11,6 +11,7 @@ See LICENSE in the root of the software repository for the full text of the Lice
 #include <pto/pto-inst.hpp>
 #include "test_common.h"
 #include <gtest/gtest.h>
+#include <filesystem>
 
 using namespace std;
 using namespace PtoTestCommon;
@@ -89,6 +90,7 @@ void tload_test()
     aclrtMemcpy(logHost, sizeof(logHost), logDevice, sizeof(logHost), ACL_MEMCPY_DEVICE_TO_HOST);
 #endif
 
+    std::filesystem::create_directories(GetGoldenDir());
     std::ofstream inFile(GetGoldenDir() + "/input.bin", std::ios::binary | std::ios::out);
     std::ofstream outFile(GetGoldenDir() + "/output.bin", std::ios::binary | std::ios::out);
     std::ofstream goldFile(GetGoldenDir() + "/golden.bin", std::ios::binary | std::ios::out);
@@ -183,4 +185,9 @@ TEST_F(TLOADTest, case_float_GT_32_64_128_VT_64_128_BLK32_DN)
 TEST_F(TLOADTest, case_float_GT_2_2_2_255_60_VT_256_64_BLK8_DN)
 {
     tload_test<10, float, 8>();
+}
+
+TEST_F(TLOADTest, case_float_GT_1_1_8_8_1_VT_64_1_BLK1_DN_FLAT_ROWS)
+{
+    tload_test<11, float, 1>();
 }

--- a/tests/cpu/st/testcase/tload/tload_kernel.cpp
+++ b/tests/cpu/st/testcase/tload/tload_kernel.cpp
@@ -143,6 +143,29 @@ AICORE void runTLOADDN(__gm__ T *out, __gm__ T *src, int gShape0, int gShape1, i
     }
 }
 
+template <typename T, int shape0, int shape1, int shape2, int shape3, int shape4, int kTRows_, int kTCols_, int dyn_,
+          PadValue PadVal_ = PadValue::Null>
+AICORE void runTLOADDNFlattenRows(__gm__ T *out, __gm__ T *src, int gShape0, int gShape1, int gShape2, int gRows,
+                                  int gCols, __gm__ uint64_t *gLog)
+{
+    using TileData =
+        Tile<TileType::Vec, T, kTRows_, kTCols_, BLayout::ColMajor, -1, -1, SLayout::NoneBox, 512, PadVal_>;
+    TileData vecTile(gRows, gCols);
+
+    using GlobalData =
+        GlobalTensor<T, Shape<shape0, shape1, shape2, shape3, shape4>,
+                     Stride<shape1 * shape2 * shape3 * shape4, shape2 * shape3 * shape4, shape3 * shape4, 1, shape3>,
+                     Layout::DN>;
+    GlobalData srcGlobal(src);
+
+    TASSIGN(vecTile, 0);
+
+    TLOAD(vecTile, srcGlobal);
+    for (size_t i = 0; i < TileData::Rows * TileData::Cols; i++) {
+        out[i] = vecTile.data()[i];
+    }
+}
+
 extern "C" __global__ AICORE void launchTLOAD_1(__gm__ uint8_t *out, __gm__ uint8_t *src, int gShape0, int gShape1,
                                                 int gShape2, int gRows, int gCols, __gm__ uint64_t *gLog)
 {
@@ -213,6 +236,13 @@ extern "C" __global__ AICORE void launchTLOAD_10(__gm__ uint8_t *out, __gm__ uin
                                                                     gShape1, gShape2, gRows, gCols, gLog);
 }
 
+extern "C" __global__ AICORE void launchTLOAD_11(__gm__ uint8_t *out, __gm__ uint8_t *src, int gShape0, int gShape1,
+                                                 int gShape2, int gRows, int gCols, __gm__ uint64_t *gLog)
+{
+    runTLOADDNFlattenRows<float, 1, 1, 8, 8, 1, 64, 1, 1, PadValue::Null>(
+        (__gm__ float *)out, (__gm__ float *)src, gShape0, gShape1, gShape2, gRows, gCols, gLog);
+}
+
 template <int32_t testKey>
 void launchTLOAD(uint8_t *out, uint8_t *src, uint64_t *gLog, void *stream)
 {
@@ -236,6 +266,8 @@ void launchTLOAD(uint8_t *out, uint8_t *src, uint64_t *gLog, void *stream)
         launchTLOAD_9(out, src, 1, 1, 32, 64, 128, gLog);
     } else if constexpr (testKey == 10) {
         launchTLOAD_10(out, src, 2, 2, 2, 255, 64, gLog);
+    } else if constexpr (testKey == 11) {
+        launchTLOAD_11(out, src, 1, 1, 8, 64, 1, gLog);
     }
 }
 
@@ -334,6 +366,32 @@ int get_input_golden_case_DN(uint8_t *input, uint8_t *golden)
     return sizeof(gold_arr);
 }
 
+template <typename T, int Shape0, int Shape1, int Shape2, int Shape3, int Shape4, int kTRows_, int kTCols_>
+int get_input_golden_case_DN_flat_rows(uint8_t *input, uint8_t *golden)
+{
+    int in_byteSize = Shape0 * Shape1 * Shape2 * Shape3 * Shape4 * sizeof(T);
+    int out_byteSize = kTRows_ * kTCols_ * sizeof(T);
+
+    T in_arr[Shape0][Shape1][Shape2][Shape3][Shape4] = {};
+    T gold_arr[kTCols_][kTRows_] = {};
+
+    for (int x0 = 0; x0 < Shape0; x0++)
+        for (int x1 = 0; x1 < Shape1; x1++)
+            for (int x2 = 0; x2 < Shape2; x2++)
+                for (int i = 0; i < Shape3; i++)
+                    for (int j = 0; j < Shape4; j++) {
+                        const T value = x0 * Shape1 * Shape2 * Shape3 * Shape4 + x1 * Shape2 * Shape3 * Shape4 +
+                                        x2 * Shape3 * Shape4 + i * Shape4 + j;
+                        const int flatRow = ((x0 * Shape1 + x1) * Shape2 + x2) * Shape3 + i;
+                        in_arr[x0][x1][x2][i][j] = value;
+                        gold_arr[j][flatRow] = value;
+                    }
+
+    std::copy((uint8_t *)in_arr, ((uint8_t *)(in_arr)) + in_byteSize, input);
+    std::copy((uint8_t *)gold_arr, ((uint8_t *)(gold_arr)) + out_byteSize, golden);
+    return out_byteSize;
+}
+
 template <int32_t testKey>
 int get_input_golden(uint8_t *input, uint8_t *golden)
 {
@@ -356,6 +414,8 @@ int get_input_golden(uint8_t *input, uint8_t *golden)
         return get_input_golden_case_DN<float, 1, 1, 32, 64, 128, 64, 128, PadValue::Null>(input, golden);
     } else if constexpr (testKey == 10) {
         return get_input_golden_case_DN<float, 2, 2, 2, 255, 64, 256, 64, PadValue::Null>(input, golden);
+    } else if constexpr (testKey == 11) {
+        return get_input_golden_case_DN_flat_rows<float, 1, 1, 8, 8, 1, 64, 1>(input, golden);
     }
 
     return 0;
@@ -371,6 +431,7 @@ template void launchTLOAD<7>(uint8_t *out, uint8_t *src, uint64_t *gLog, void *s
 template void launchTLOAD<8>(uint8_t *out, uint8_t *src, uint64_t *gLog, void *stream); // 实例化 Key=0 的版本
 template void launchTLOAD<9>(uint8_t *out, uint8_t *src, uint64_t *gLog, void *stream);
 template void launchTLOAD<10>(uint8_t *out, uint8_t *src, uint64_t *gLog, void *stream);
+template void launchTLOAD<11>(uint8_t *out, uint8_t *src, uint64_t *gLog, void *stream);
 
 template int get_input_golden<1>(uint8_t *input, uint8_t *golden);
 template int get_input_golden<2>(uint8_t *input, uint8_t *golden);
@@ -382,3 +443,4 @@ template int get_input_golden<7>(uint8_t *input, uint8_t *golden);
 template int get_input_golden<8>(uint8_t *input, uint8_t *golden);
 template int get_input_golden<9>(uint8_t *input, uint8_t *golden);
 template int get_input_golden<10>(uint8_t *input, uint8_t *golden);
+template int get_input_golden<11>(uint8_t *input, uint8_t *golden);


### PR DESCRIPTION
## Summary
- Add `LoadPlainDnClassic` and `LoadPlainDnFlattenRows` template functions in TLoad.hpp to handle non-row-major (ColMajor) DN layout loading
- `LoadPlainDnFlattenRows` provides an optimized path when all rows and columns are valid, flattening the higher dimensions into contiguous rows
- `LoadPlainDnClassic` serves as the general fallback for ColMajor DN loads
- Update `LoadPlain` to dispatch to the new functions when `!TileData::isRowMajor`
- Relax the `TLoad` assertion to accept the flattened-rows ColMajor case
- Add `runTLOADDNFlattenRows` test kernel and corresponding system test `case_float_GT_1_1_8_8_1_VT_64_1_BLK1_DN_FLAT_ROWS` (testKey=11)

## Testing
- [x] New DN flat-rows test case passes on CPU simulator
- [x] All existing TLoad tests pass with no regressions
- [x] Pre-commit hooks pass

Closes #88 