### PR TITLE
fix: Skip inactive Vec lanes in TPush/TPop/TFree for TILE_NO_SPLIT mode

### DIFF
--- a/include/pto/cpu/TPop.hpp
+++ b/include/pto/cpu/TPop.hpp
@@ -18,6 +18,11 @@ namespace pto {
 template <typename Pipe, typename TileCons, TileSplitAxis Split>
 PTO_INTERNAL void TPOP_IMPL(Pipe &pipe, TileCons &tile)
 {
+    if (cpu_pipe::IsInactiveNoSplitVecLane<TileCons, Split>()) {
+        cpu_pipe::EnsureTileStorage(tile);
+        cpu_pipe::FillTile(tile, typename TileCons::DType{});
+        return;
+    }
     // 1. Wait for data
     if (pipe.cons.getWaitStatus()) {
         pipe.cons.template wait<TileCons, Split>();
@@ -36,6 +41,9 @@ PTO_INTERNAL void TPOP_IMPL(TileCons &tile, Pipe &pipe)
 template <typename Pipe, TileSplitAxis Split>
 PTO_INTERNAL void TFREE_IMPL(Pipe &pipe)
 {
+    if (cpu_pipe::IsInactiveNoSplitVecConsumerLane<Pipe, Split>()) {
+        return;
+    }
     if (pipe.cons.getFreeStatus()) {
         pipe.cons.template free<Split>();
     }

--- a/include/pto/cpu/TPush.hpp
+++ b/include/pto/cpu/TPush.hpp
@@ -150,6 +150,32 @@ PTO_INTERNAL constexpr uint32_t GetActiveSplitLaneMask()
     return (1u << GetActiveSplitCount<TileData, Split>()) - 1u;
 }
 
+template <typename TileData, TileSplitAxis Split>
+PTO_INTERNAL bool IsInactiveNoSplitVecLane()
+{
+    static_assert(is_tile_data_v<TileData> || is_conv_tile_v<TileData>,
+                  "IsInactiveNoSplitVecLane requires a Tile or ConvTile type.");
+    if constexpr (Split != TileSplitAxis::TILE_NO_SPLIT) {
+        return false;
+    }
+    if constexpr (TileData::Loc != TileType::Vec) {
+        return false;
+    }
+    return get_subblockid() != 0;
+}
+
+template <typename Pipe, TileSplitAxis Split>
+PTO_INTERNAL bool IsInactiveNoSplitVecConsumerLane()
+{
+    if constexpr (Split != TileSplitAxis::TILE_NO_SPLIT) {
+        return false;
+    }
+    if constexpr (!Pipe::is_c2v) {
+        return false;
+    }
+    return get_subblockid() != 0;
+}
+
 template <typename TileData>
 PTO_INTERNAL void FillTile(TileData &tile, typename TileData::DType value)
 {
@@ -741,6 +767,9 @@ PTO_INTERNAL void TPush_v2c(Pipe &pipe, TileProd &tile, size_t entryBase)
 template <typename Pipe, typename TileProd, TileSplitAxis Split>
 PTO_INTERNAL void TPUSH_IMPL(Pipe &pipe, TileProd &tile)
 {
+    if (cpu_pipe::IsInactiveNoSplitVecLane<TileProd, Split>()) {
+        return;
+    }
     if (pipe.prod.getAllocateStatus()) {
         pipe.prod.template allocate<TileProd, Split>();
     }

--- a/tests/cpu/st/testcase/tpushpop_cv_nosplit/main.cpp
+++ b/tests/cpu/st/testcase/tpushpop_cv_nosplit/main.cpp
@@ -10,6 +10,7 @@ See LICENSE in the root of the software repository for the full text of the Lice
 
 #include <algorithm>
 #include <gtest/gtest.h>
+#include <mutex>
 #include <pto/pto-inst.hpp>
 #include <vector>
 #include "test_common.h"
@@ -112,6 +113,59 @@ void runCubeToVectorNoSplitWraparound()
         EXPECT_TRUE(ResultCmp(expected, actual[iter], 0));
     }
 }
+
+template <typename T, int rows, int cols>
+void runCubeToVectorNoSplitInactiveLaneNoOp()
+{
+    constexpr int kFifoDepth = 2;
+    using CubeTile = Tile<TileType::Mat, T, rows, cols>;
+    using VecTile = Tile<TileType::Vec, T, rows, cols>;
+    using Pipe = TPipe<kPipeFlagId + 2, Direction::DIR_C2V, sizeof(T) * VecTile::Numel, kFifoDepth>;
+
+    NPU_MEMORY_CLEAR();
+    Pipe::reset_for_cpu_sim();
+    Pipe pipe((__gm__ void *)nullptr, kVecConsumerBase, 0x0);
+
+    {
+        cpu_sim::ScopedExecutionContext producerCtx(0, 0, 1);
+        CubeTile cubeTile;
+        TASSIGN(cubeTile, 0x0);
+        fillCubeTile<T, rows, cols>(cubeTile, 0);
+        TPUSH<Pipe, CubeTile, TileSplitAxis::TILE_NO_SPLIT>(pipe, cubeTile);
+    }
+
+    {
+        cpu_sim::ScopedExecutionContext inactiveVecCtx(0, 1, 2);
+        VecTile vecTile;
+        TASSIGN(vecTile, 0x4000);
+        TPOP<Pipe, VecTile, TileSplitAxis::TILE_NO_SPLIT>(pipe, vecTile);
+        TFREE<Pipe, TileSplitAxis::TILE_NO_SPLIT>(pipe);
+    }
+
+    {
+        auto &sharedState = Pipe::GetSharedState();
+        std::lock_guard<std::mutex> lock(sharedState.mutex);
+        EXPECT_EQ(sharedState.occupied, 1);
+        EXPECT_EQ(sharedState.next_consumer_slot, 0);
+    }
+
+    VecTile vecTile;
+    TASSIGN(vecTile, 0x4000);
+    {
+        cpu_sim::ScopedExecutionContext activeVecCtx(0, 0, 2);
+        TPOP<Pipe, VecTile, TileSplitAxis::TILE_NO_SPLIT>(pipe, vecTile);
+        TFREE<Pipe, TileSplitAxis::TILE_NO_SPLIT>(pipe);
+    }
+
+    const auto expected = makeExpected<T, rows, cols>(0);
+    EXPECT_TRUE(ResultCmp(expected, vecTile.data(), 0));
+
+    {
+        auto &sharedState = Pipe::GetSharedState();
+        std::lock_guard<std::mutex> lock(sharedState.mutex);
+        EXPECT_EQ(sharedState.occupied, 0);
+    }
+}
 } // namespace
 
 class TPushPopCVNoSplitTest : public testing::Test {
@@ -137,4 +191,9 @@ TEST_F(TPushPopCVNoSplitTest, cube_to_vector_single_tile_float_16x32)
 TEST_F(TPushPopCVNoSplitTest, cube_to_vector_fifo_wraparound_float_16x32)
 {
     runCubeToVectorNoSplitWraparound<float, 16, 32>();
+}
+
+TEST_F(TPushPopCVNoSplitTest, cube_to_vector_inactive_aiv1_is_noop_in_no_split_mode)
+{
+    runCubeToVectorNoSplitInactiveLaneNoOp<float, 16, 32>();
 }

--- a/tests/cpu/st/testcase/tpushpop_vc_nosplit/main.cpp
+++ b/tests/cpu/st/testcase/tpushpop_vc_nosplit/main.cpp
@@ -10,6 +10,7 @@ See LICENSE in the root of the software repository for the full text of the Lice
 
 #include <algorithm>
 #include <gtest/gtest.h>
+#include <mutex>
 #include <pto/pto-inst.hpp>
 #include <vector>
 #include "test_common.h"
@@ -112,6 +113,60 @@ void runVectorToCubeNoSplitWraparound()
         EXPECT_TRUE(ResultCmp(expected, actual[iter], 0));
     }
 }
+
+template <typename T, int rows, int cols>
+void runVectorToCubeNoSplitInactiveLaneNoOp()
+{
+    constexpr int kFifoDepth = 2;
+    using VecTile = Tile<TileType::Vec, T, rows, cols>;
+    using MatTile = Tile<TileType::Mat, T, rows, cols>;
+    using Pipe = TPipe<kPipeFlagId + 2, Direction::DIR_V2C, sizeof(T) * MatTile::Numel, kFifoDepth>;
+
+    NPU_MEMORY_CLEAR();
+    Pipe::reset_for_cpu_sim();
+    Pipe pipe((__gm__ void *)nullptr, 0x0, kMatConsumerBase);
+
+    {
+        cpu_sim::ScopedExecutionContext inactiveVecCtx(0, 1, 2);
+        VecTile inactiveVecTile;
+        TASSIGN(inactiveVecTile, 0x0);
+        fillVectorTile<T, rows, cols>(inactiveVecTile, 7);
+        TPUSH<Pipe, VecTile, TileSplitAxis::TILE_NO_SPLIT>(pipe, inactiveVecTile);
+    }
+
+    {
+        auto &sharedState = Pipe::GetSharedState();
+        std::lock_guard<std::mutex> lock(sharedState.mutex);
+        EXPECT_EQ(sharedState.occupied, 0);
+        EXPECT_EQ(sharedState.next_producer_slot, 0);
+    }
+
+    VecTile vecTile;
+    MatTile matTile;
+    TASSIGN(vecTile, 0x0);
+    TASSIGN(matTile, 0x4000);
+
+    {
+        cpu_sim::ScopedExecutionContext activeVecCtx(0, 0, 2);
+        fillVectorTile<T, rows, cols>(vecTile, 0);
+        TPUSH<Pipe, VecTile, TileSplitAxis::TILE_NO_SPLIT>(pipe, vecTile);
+    }
+
+    {
+        cpu_sim::ScopedExecutionContext cubeCtx(0, 0, 1);
+        TPOP<Pipe, MatTile, TileSplitAxis::TILE_NO_SPLIT>(pipe, matTile);
+        TFREE<Pipe, TileSplitAxis::TILE_NO_SPLIT>(pipe);
+    }
+
+    const auto expected = makeExpected<T, rows, cols>(0);
+    EXPECT_TRUE(ResultCmp(expected, matTile.data(), 0));
+
+    {
+        auto &sharedState = Pipe::GetSharedState();
+        std::lock_guard<std::mutex> lock(sharedState.mutex);
+        EXPECT_EQ(sharedState.occupied, 0);
+    }
+}
 } // namespace
 
 class TPushPopVCNoSplitTest : public testing::Test {
@@ -137,4 +192,9 @@ TEST_F(TPushPopVCNoSplitTest, vector_to_cube_single_tile_float_16x32)
 TEST_F(TPushPopVCNoSplitTest, vector_to_cube_fifo_wraparound_float_16x32)
 {
     runVectorToCubeNoSplitWraparound<float, 16, 32>();
+}
+
+TEST_F(TPushPopVCNoSplitTest, vector_to_cube_inactive_aiv1_is_noop_in_no_split_mode)
+{
+    runVectorToCubeNoSplitInactiveLaneNoOp<float, 16, 32>();
 }


### PR DESCRIPTION
## Summary
- Add `IsInactiveNoSplitVecLane` and `IsInactiveNoSplitVecConsumerLane` guards in TPush.hpp to detect non-zero subblock lanes that should not participate in no-split Vec pipe operations
- Insert early-return paths in `TPUSH_IMPL`, `TPOP_IMPL`, and `TFREE_IMPL` so inactive AIV1 lanes become no-ops; `TPOP_IMPL` also zero-fills the consumer tile to ensure deterministic output
- Add system tests for both C2V and V2C directions verifying that inactive AIV1 lanes do not corrupt FIFO state or data in no-split mode

## Testing
- [x] All tests pass
- [x] Code review completed
- [x] Pre-commit hooks pass