### PR TITLE
feat: `TPUSH`/`TPOP` fine-grained sync

### DIFF
--- a/demos/torch_jit/flash_atten/fa_compile_and_run.py
+++ b/demos/torch_jit/flash_atten/fa_compile_and_run.py
@@ -14,17 +14,54 @@
 
 import random
 import math
+from pathlib import Path
+
+import matplotlib.pyplot as plt
 import torch
 import torch_npu
 from jit_util_flash import jit_compile_flash
+from util.device import get_test_device
+from util.bench import do_bench
 
-NUM_ITERATIONS = 50
+_DEVICE = get_test_device()
+torch.npu.set_device(_DEVICE)
+
+NUM_ITERATIONS = 15
 WARMUP = 10
 SEED = 1
 
 random.seed(SEED)
 torch.manual_seed(SEED)
 torch.npu.manual_seed(SEED)
+
+
+def attn_flops_matmul_softmax_scale(
+    batch_size: int,
+    s_q: int,
+    s_k: int,
+    h: int,
+    include_scale: bool = True,
+    count_exp_as_flop: bool = True,
+    count_max_as_flop: bool = True,
+):
+    flops_matmul = 4 * batch_size * s_q * s_k * h
+    flops_scale = (batch_size * s_q * s_k) if include_scale else 0
+
+    rows = batch_size * s_q
+    softmax_ops = 0
+    if count_max_as_flop:
+        softmax_ops += rows * (s_k - 1)
+    softmax_ops += rows * s_k
+    if count_exp_as_flop:
+        softmax_ops += rows * s_k
+    softmax_ops += rows * (s_k - 1)
+    softmax_ops += rows * s_k
+
+    return flops_matmul + flops_scale + softmax_ops
+
+
+def tflops(flops: int, ms: float) -> float:
+    return flops / (ms * 1e-3) / 1e12
 
 
 # ---------------------------
@@ -57,72 +94,108 @@ def fused_attention(q, k, v, is_causal=False):
     return out.squeeze(0)
 
 
-def time_op_npu(fn):
-    """
-    Accurate device timing:
-    - warmup to stabilize
-    - synchronize around measurement
-    - measure average per-iter ms
-    """
-    for _ in range(WARMUP):
-        _ = fn()
-    torch.npu.synchronize()
-
-    start = torch.npu.Event(enable_timing=True)
-    end = torch.npu.Event(enable_timing=True)
-
-    start.record()
-    for _ in range(NUM_ITERATIONS):
-        _ = fn()
-    end.record()
-    torch.npu.synchronize()
-
-    total_ms = start.elapsed_time(end)
-    return total_ms / NUM_ITERATIONS
-
-
 def test_flash():
-    s0, s1, head = 128, 2048, 128
-
-    device = "npu:0"
-    torch.npu.set_device(device)
+    s0, head = 128 * 24, 128
+    s1_values = [1024, 2048, 4096, 8192, 16384, 32768, 64*1024, 128*1024]
 
     dtype = torch.float16
-
-    # ==========================
-    # Inputs
-    # ==========================
     q2d = torch.randn((s0, head), dtype=dtype).npu()
-    k2d = torch.randn((s1, head), dtype=dtype).npu()
-    v2d = torch.randn((s1, head), dtype=dtype).npu()
 
     # ==========================
     # Compile flash ONCE
     # ==========================
     flash = jit_compile_flash(verbose=False)
 
-    # ==========================
-    # Benchmark reference ops
-    # ==========================
-    ref_ms = time_op_npu(lambda: fa_reference(q2d, k2d, v2d))
-    npu_ms = time_op_npu(lambda: fused_attention(q2d, k2d, v2d))
-    flash_ms = time_op_npu(lambda: flash(q2d, k2d, v2d))
+    flash_ms_values = []
+    npu_ms_values = []
+    ref_ms_values = []
+    flash_tflops_values = []
+    npu_tflops_values = []
+    ref_tflops_values = []
 
-    # ==========================
-    # Correctness check
-    # ==========================
-    o_out = flash(q2d, k2d, v2d)
-    o_ref = fa_reference(q2d, k2d, v2d).to(torch.float32)
-    o_npu = fused_attention(q2d, k2d, v2d).to(torch.float32)
+    for s1 in s1_values:
+        flops_total = attn_flops_matmul_softmax_scale(1, s0, s1, head)
 
-    print(f"JIT flash kernel           : {flash_ms:.3f} ms/iter")
-    print(f"npu_fused_infer_attention  : {npu_ms:.3f} ms/iter")
-    print(f"torch reference            : {ref_ms:.3f} ms/iter")
-    torch.testing.assert_close(o_out, o_ref, rtol=1e-3, atol=1e-3)
-    print("vs torch reference: PASSED")
-    torch.testing.assert_close(o_out, o_npu, rtol=1e-3, atol=1e-3)
-    print("vs npu_fused_attention: PASSED")
+        # ==========================
+        # Inputs
+        # ==========================
+        k2d = torch.randn((s1, head), dtype=dtype).npu()
+        v2d = torch.randn((s1, head), dtype=dtype).npu()
+
+        # ==========================
+        # Benchmark reference ops
+        # ==========================
+        ref_ms = do_bench(
+            lambda: fa_reference(q2d, k2d, v2d),
+            warmup_iters=WARMUP,
+            benchmark_iters=NUM_ITERATIONS,
+            unit="ms",
+        )
+        npu_ms = do_bench(
+            lambda: fused_attention(q2d, k2d, v2d),
+            warmup_iters=WARMUP,
+            benchmark_iters=NUM_ITERATIONS,
+            unit="ms",
+        )
+        flash_ms = do_bench(
+            lambda: flash(q2d, k2d, v2d),
+            warmup_iters=WARMUP,
+            benchmark_iters=NUM_ITERATIONS,
+            unit="ms",
+        )
+
+        flash_ms_values.append(flash_ms)
+        npu_ms_values.append(npu_ms)
+        ref_ms_values.append(ref_ms)
+        flash_tflops_values.append(tflops(flops_total, flash_ms))
+        npu_tflops_values.append(tflops(flops_total, npu_ms))
+        ref_tflops_values.append(tflops(flops_total, ref_ms))
+
+        # ==========================
+        # Correctness check
+        # ==========================
+        o_out = flash(q2d, k2d, v2d)
+        o_ref = fa_reference(q2d, k2d, v2d).to(torch.float32)
+        o_npu = fused_attention(q2d, k2d, v2d).to(torch.float32)
+
+        print(f"S1                         : {s1}")
+        print(f"FLOPs total                : {flops_total}")
+        print(
+            f"JIT flash kernel           : {flash_ms:.3f} ms/iter  "
+            f"({tflops(flops_total, flash_ms):.3f} TFLOP/s)"
+        )
+        print(
+            f"npu_fused_infer_attention  : {npu_ms:.3f} ms/iter  "
+            f"({tflops(flops_total, npu_ms):.3f} TFLOP/s)"
+        )
+        print(
+            f"torch reference            : {ref_ms:.3f} ms/iter  "
+            f"({tflops(flops_total, ref_ms):.3f} TFLOP/s)"
+        )
+        torch.testing.assert_close(o_out, o_ref, rtol=1e-3, atol=1e-3)
+        print("vs torch reference: PASSED")
+        torch.testing.assert_close(o_out, o_npu, rtol=1e-3, atol=1e-3)
+        print("vs npu_fused_attention: PASSED")
+        print("")
+
+    plot_path = Path(__file__).with_name("fa_compile_and_run_s1_plot.png")
+    plt.figure(figsize=(8, 5))
+    plt.plot(s1_values, flash_tflops_values, marker="o", label="flash")
+    plt.plot(s1_values, ref_tflops_values, marker="o", label="ref")
+    plt.plot(s1_values, npu_tflops_values, marker="o", label="torch_npu")
+    plt.xscale("log", base=2)
+    plt.xticks(s1_values, [str(v) for v in s1_values])
+    plt.xlabel("S1")
+    plt.ylabel("TFLOP/s")
+    plt.title(f"Flash Attention TFLOP/s vs S1 (S0={s0}, head={head})")
+    plt.grid(True, which="both", axis="both", linestyle="--", linewidth=0.5)
+    plt.legend()
+    plt.tight_layout()
+    plt.savefig(plot_path, dpi=160)
+    plt.close()
+    print(f"Saved plot to {plot_path}")
 
 
 if __name__ == "__main__":
     test_flash()
+

--- a/demos/torch_jit/flash_atten/fa_kernel.cpp
+++ b/demos/torch_jit/flash_atten/fa_kernel.cpp
@@ -149,6 +149,22 @@ constexpr AICORE std::size_t tile_buffer_total_bytes()
     return tile_storage_bytes<TileType>() * NumBuffers;
 }
 
+AICORE inline pto::PipeChunk make_pipe_chunk(int chunk_index, int chunk_count)
+{
+    const bool is_first = (chunk_index == 0);
+    const bool is_last = (chunk_index + 1 == chunk_count);
+    if (is_first && is_last) {
+        return pto::PipeChunk::Single;
+    }
+    if (is_first) {
+        return pto::PipeChunk::First;
+    }
+    if (is_last) {
+        return pto::PipeChunk::Last;
+    }
+    return pto::PipeChunk::Middle;
+}
+
 template <typename TileType, std::size_t NumBuffers>
 AICORE inline uint32_t assign_tile_buffers(TileType (&tiles)[NumBuffers], uint32_t base_offset)
 {
@@ -208,14 +224,13 @@ AICORE inline void allocate_cube_tile_buffers(TileQType (&qTiles)[NumQ], TileKTy
     (void)l1_offset;
 }
 
-template <typename TileDataF_T, typename ReduceTileF_T, typename TileDataH_T, typename TileOutT, std::size_t SrcBuffers,
-          std::size_t XexpBuffers, std::size_t pvVecBuffers, std::size_t ExpMaxBuffers>
+template <typename TileDataF_T, typename ReduceTileF_T, typename TileDataH_T, typename TileOutT,
+          std::size_t SrcBuffers, std::size_t XexpBuffers, std::size_t pvVecBuffers, std::size_t ExpMaxBuffers>
 AICORE inline void allocate_vec_tile_buffers(TileDataF_T (&srcTiles)[SrcBuffers], ReduceTileF_T &m1_local_max,
                                              TileDataF_T &input_reduce_tmp, ReduceTileF_T &l1_local_sum,
                                              ReduceTileF_T &m2_global_max, ReduceTileF_T &l2_global_sum,
-                                             ReduceTileF_T (&l1_exp_max)[ExpMaxBuffers],
-                                             TileDataH_T (&x_expT)[XexpBuffers], TileOutT (&pvTile)[pvVecBuffers],
-                                             TileOutT &runningOTile, TileDataF_T &triu)
+                                             ReduceTileF_T (&l1_exp_max)[ExpMaxBuffers], TileDataH_T (&x_expT)[XexpBuffers],
+                                             TileOutT (&pvTile)[pvVecBuffers], TileOutT &runningOTile, TileDataF_T &triu)
 {
     constexpr std::size_t float_tile_bytes = tile_storage_bytes<TileDataF_T>();
     constexpr std::size_t reduce_tile_bytes = tile_storage_bytes<ReduceTileF_T>();
@@ -366,26 +381,22 @@ AICORE inline void compute_qk(int tile_id, int sub_tile_id, __gm__ half *q, __gm
 
 template <int HEAD_SIZE, int CUBE_S0, int CUBE_S1, int TILE_S1, int QKP_CV_FIFO, int PV_CV_FIFO,
           int CV_FIFO_CONS_SYNC_PERIOD, bool INTERMEDIATE_CHECK, typename TileMatPData, typename TileMatVData,
-          typename TilePVData, typename TSyncSM2PV, typename TSyncPV2GU>
-AICORE inline void compute_pv(int tile_id, int sub_tile_id, __gm__ half *p_tile_fifo, __gm__ half *v,
-                              __gm__ float *pv_tile_fifo, TileMatPData &pMatTile, TileMatVData &vMatTile,
-                              TilePVData &pvAccTile, uint64_t svMatTileEventId, int accTileEvtID, TSyncSM2PV &sm2pvSync,
-                              TSyncPV2GU &pv2guSync)
+          typename TilePVData, typename PPipe, typename TSyncPV2GU>
+AICORE inline void compute_pv(int tile_id, int sub_tile_id, __gm__ half *v, __gm__ float *pv_tile_fifo,
+                              TileMatPData &pMatTile, TileMatVData &vMatTile, TilePVData &pvAccTile,
+                              uint64_t svMatTileEventId, int accTileEvtID, PPipe &pPipe, TSyncPV2GU &pv2guSync)
 {
     constexpr uint32_t Cube_S0 = CUBE_S0;
     constexpr uint32_t Cube_S1 = CUBE_S1;
     constexpr uint32_t Tile_S1 = TILE_S1;
     constexpr uint32_t kTileFactor = Tile_S1 / Cube_S1;
     constexpr uint32_t Cube_HEAD = HEAD_SIZE;
-    constexpr uint32_t TileElems = Cube_S0 * Tile_S1;
     static_assert(QKP_CV_FIFO >= 1, "QKP_CV_FIFO must be >= 1");
     static_assert(Tile_S1 % Cube_S1 == 0, "TILE_S1 must be divisible by CUBE_S1");
 
     const int s1_index = tile_id * static_cast<int>(Tile_S1) + sub_tile_id * static_cast<int>(Cube_S1);
-    const int sync_iter = tile_id;
-    const bool should_wait_consume = should_wait_consumption<QKP_CV_FIFO, CV_FIFO_CONS_SYNC_PERIOD>(sync_iter);
-    const bool should_notify_consume = should_notify_consumption<QKP_CV_FIFO, CV_FIFO_CONS_SYNC_PERIOD>(sync_iter);
-    const bool is_last_subtile = (sub_tile_id + 1 == static_cast<int>(kTileFactor));
+    const pto::PipeChunk pChunk = make_pipe_chunk(sub_tile_id, static_cast<int>(kTileFactor));
+    const int pTileEntryOffset = sub_tile_id * static_cast<int>(Cube_S1 * sizeof(half));
 
     if constexpr (DAV_CUBE) {
         using GlobalVT =
@@ -396,26 +407,7 @@ AICORE inline void compute_pv(int tile_id, int sub_tile_id, __gm__ half *p_tile_
         GlobalVT vLoad((__gm__ half *)(v + s1_index * HEAD_SIZE));
         TLOAD(vMatTile, vLoad);
 
-        if (sub_tile_id == 0)
-            sm2pvSync.wait(); // wait for softmax produce data
-
-// For TILE_S1 > CUBE_S1, need to stride by Tile_S1 for each Cube_S1 chunk
-#ifndef P_FIFO_USE_NZ
-        using GlobalXexpTileT =
-            GlobalTensor<half, pto::Shape<1, 1, 1, Cube_S0, Cube_S1>, pto::Stride<1, 1, 1, Cube_S1, 1>>;
-#else
-        using GlobalXexpTileT = GlobalTensor<half, pto::Shape<1, Cube_S1 / 16, Cube_S0 / 16, 16, 16>,
-                                             pto::Stride<Cube_S0 * Cube_S1, Cube_S0 * 16, 16 * 16, 16, 1>, Layout::NZ>;
-#endif
-
-        const uint32_t buf_idx = static_cast<uint32_t>(tile_id % QKP_CV_FIFO);
-        const size_t base_elems =
-            static_cast<size_t>(buf_idx) * static_cast<size_t>(Cube_S0) * static_cast<size_t>(Tile_S1) +
-            static_cast<size_t>(sub_tile_id) * static_cast<size_t>(Cube_S0) * static_cast<size_t>(Cube_S1);
-        GlobalXexpTileT xexpLoad(p_tile_fifo + base_elems);
-        TLOAD(pMatTile, xexpLoad);
-        if (sub_tile_id == static_cast<int>(kTileFactor) - 1 && should_notify_consume)
-            sm2pvSync.free(); // notify SV consume data
+        TPOP<PPipe, TileMatPData, TileSplitAxis::TILE_LEFT_RIGHT>(pPipe, pMatTile, pChunk, pTileEntryOffset);
 
         set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);
         wait_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);
@@ -427,6 +419,7 @@ AICORE inline void compute_pv(int tile_id, int sub_tile_id, __gm__ half *p_tile_
 #endif
 
 #if UF_ENABLE
+        const bool is_last_subtile = (sub_tile_id + 1 == static_cast<int>(kTileFactor));
         const AccMode accMode = (sub_tile_id == 0) ?
                                     (is_last_subtile ? AccMode::InitFinalSum : AccMode::InitPartialSum) :
                                     (is_last_subtile ? AccMode::AccFinalSum : AccMode::AccPartialSum);
@@ -444,7 +437,7 @@ AICORE inline void compute_pv(int tile_id, int sub_tile_id, __gm__ half *p_tile_
             wait_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
 #endif
 
-            if (should_wait_consume)
+            if (should_wait_consumption<QKP_CV_FIFO, CV_FIFO_CONS_SYNC_PERIOD>(tile_id))
                 pv2guSync.allocate(); // wait for update consume data
 
             using GlobalDataPV =
@@ -467,14 +460,14 @@ AICORE inline void compute_pv(int tile_id, int sub_tile_id, __gm__ half *p_tile_
 }
 
 template <int HEAD_SIZE, int CUBE_S0, int CUBE_S1, int TILE_S1, int QKP_CV_FIFO, int CV_FIFO_CONS_SYNC_PERIOD,
-          bool INTERMEDIATE_CHECK, bool CAUSAL_MASK, typename TileDataF_T, typename TileDataH_T, typename ReduceTileF_T,
-          typename TSyncQK2SM, typename TSyncSM2PV>
-AICORE inline void compute_p(int tile_id, int row_slice, __gm__ float *qk_tile_fifo, __gm__ half *p_tile_fifo,
-                             __gm__ float *exp_max_ififo, __gm__ float *global_sum_out, __gm__ float *exp_max_out,
-                             TileDataF_T &qkVecTile, TileDataH_T &x_expT, TileDataF_T &input_reduce_tmp,
-                             ReduceTileF_T &m1_local_max, ReduceTileF_T &l1_local_sum, ReduceTileF_T &m2_global_max,
-                             ReduceTileF_T &l2_global_sum, ReduceTileF_T &l1_exp_max_ififo, TileDataF_T triu,
-                             uint64_t pTileEventId, TSyncQK2SM &qk2smSync, TSyncSM2PV sm2pvSync, int blk_idx)
+          bool INTERMEDIATE_CHECK, bool CAUSAL_MASK, typename TileDataF_T, typename TileDataH_T,
+          typename ReduceTileF_T, typename TSyncQK2SM, typename PPipe>
+AICORE inline void compute_p(int tile_id, int row_slice, __gm__ float *qk_tile_fifo, __gm__ float *exp_max_ififo,
+                             __gm__ float *global_sum_out, __gm__ float *exp_max_out, TileDataF_T &qkVecTile,
+                             TileDataH_T &x_expT, TileDataF_T &input_reduce_tmp, ReduceTileF_T &m1_local_max,
+                             ReduceTileF_T &l1_local_sum, ReduceTileF_T &m2_global_max, ReduceTileF_T &l2_global_sum,
+                             ReduceTileF_T &l1_exp_max_ififo, TileDataF_T triu, uint64_t pTileEventId,
+                             TSyncQK2SM &qk2smSync, PPipe &pPipe, int blk_idx)
 {
     constexpr uint32_t Cube_S0 = CUBE_S0;
     constexpr uint32_t Cube_S1 = CUBE_S1;
@@ -492,7 +485,6 @@ AICORE inline void compute_p(int tile_id, int row_slice, __gm__ float *qk_tile_f
         const int s0_index = blk_idx * Cube_S0 + row_offset;
         const int s1_index = tile_id * static_cast<int>(Tile_S1);
         const int sync_iter = tile_id;
-        const bool should_wait_consume = should_wait_consumption<QKP_CV_FIFO, CV_FIFO_CONS_SYNC_PERIOD>(sync_iter);
         const bool should_notify_consume = should_notify_consumption<QKP_CV_FIFO, CV_FIFO_CONS_SYNC_PERIOD>(sync_iter);
 
         wait_flag(PIPE_V, PIPE_MTE2, pTileEventId);
@@ -560,25 +552,15 @@ AICORE inline void compute_p(int tile_id, int row_slice, __gm__ float *qk_tile_f
         set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
         wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
 
-        const bool should_wait_sv_consumed = should_wait_consumption<QKP_CV_FIFO, CV_FIFO_CONS_SYNC_PERIOD>(sync_iter);
-        if (row_slice == 0 && should_wait_sv_consumed)
-            sm2pvSync.allocate(); // wait for SV consume data
+        const pto::PipeChunk pChunk = make_pipe_chunk(row_slice, static_cast<int>(kTileFactor));
+        // TPUSH(TILE_UP_DOWN) already offsets each vec subblock by one Vec_S0 row block.
+        // The entry offset only needs the remaining band shift to place rows in logical S0 order.
+        const int pTileEntryOffset =
+            (static_cast<int>(get_subblockid()) * (static_cast<int>(kTileFactor) - 1) + row_slice) *
+            static_cast<int>(Vec_S0 * Tile_S1 * sizeof(half));
+        TPUSH<PPipe, TileDataH_T, TileSplitAxis::TILE_UP_DOWN>(pPipe, x_expT, pChunk, pTileEntryOffset);
 
-        using GlobalPTileHalfSub =
-            GlobalTensor<half, pto::Shape<1, 1, 1, Vec_S0, Cube_S1>, pto::Stride<1, 1, 1, Cube_S1, 1>>;
-        using TileDataH_Sub = Tile<TileType::Vec, half, Vec_S0, Tile_S1, BLayout::RowMajor, Vec_S0, Cube_S1>;
-        __gm__ half *p_ptr = p_tile_fifo + base_elems + row_offset * static_cast<size_t>(Cube_S1);
-        for (int sub_col = 0; sub_col < static_cast<int>(kTileFactor); ++sub_col) {
-            __gm__ half *p_ptr_sub =
-                p_ptr + static_cast<size_t>(sub_col) * static_cast<size_t>(Cube_S1) * static_cast<size_t>(Cube_S0);
-            GlobalPTileHalfSub pTileHalfSub((__gm__ half *)(p_ptr_sub));
-
-            TileDataH_Sub xExpSub;
-            const uint64_t col_byte_offset = static_cast<uint64_t>(sub_col * Cube_S1 * sizeof(half));
-            TASSIGN(xExpSub, (uint64_t)x_expT.data() + col_byte_offset);
-            TSTORE(pTileHalfSub, xExpSub);
-        }
-
+        set_flag(PIPE_MTE3, PIPE_V, pTileEventId);
         if constexpr (INTERMEDIATE_CHECK) {
             // On the final row_slice, emit the exp_max for this subblock only (Cube_S0 / VEC_CORES rows)
             if (row_slice == static_cast<int>(kTileFactor) - 1) {
@@ -587,7 +569,7 @@ AICORE inline void compute_p(int tile_id, int row_slice, __gm__ float *qk_tile_f
                     GlobalTensor<float, pto::Shape<1, 1, 1, 1, SubblockRows>, pto::Stride<1, 1, 1, Cube_S0, 1>>;
                 using ExpMaxSub = Tile<TileType::Vec, float, 1, SubblockRows, BLayout::RowMajor, 1, SubblockRows>;
                 const size_t base_elems_pmax =
-                    static_cast<size_t>(buf_idx) * static_cast<size_t>(Cube_S0) + subblock_base_rows;
+                    static_cast<size_t>(tile_id % QKP_CV_FIFO) * static_cast<size_t>(Cube_S0) + subblock_base_rows;
                 __gm__ float *p_ptr_fp32 = exp_max_ififo + base_elems_pmax;
                 GlobalPMaxFloatSub pMaxGlobal(p_ptr_fp32);
                 ExpMaxSub l1_exp_max_rowmajor;
@@ -595,11 +577,6 @@ AICORE inline void compute_p(int tile_id, int row_slice, __gm__ float *qk_tile_f
                 TSTORE(pMaxGlobal, l1_exp_max_rowmajor);
             }
         }
-
-        if (row_slice == static_cast<int>(kTileFactor) - 1)
-            sm2pvSync.record(); // notify softmax produce data
-
-        set_flag(PIPE_MTE3, PIPE_V, pTileEventId);
     }
 }
 
@@ -672,6 +649,10 @@ __global__ AICORE void runTFA(__gm__ uint64_t *ffts_addr, __gm__ half *q, __gm__
                               __gm__ float *qk_tile_fifo, __gm__ float *pv_tile_fifo, __gm__ uint8_t *cv_comm_buf,
                               __gm__ uint8_t *profile_buf, int s0, int s1)
 {
+    if constexpr (DAV_VEC) {
+        set_mask_norm();
+        set_vector_mask(-1, -1);
+    }
     uint64_t tStart = get_sys_cnt();
 
     set_ffts_base_addr((uint64_t)ffts_addr);
@@ -752,8 +733,8 @@ __global__ AICORE void runTFA(__gm__ uint64_t *ffts_addr, __gm__ half *q, __gm__
     // Define per-tile vector tiles sized to Cube_S1
     using TileDataF_T = Tile<TileType::Vec, float, Vec_S0, Tile_S1, BLayout::RowMajor, Vec_S0, Tile_S1>;
     using TileDataH_T = Tile<TileType::Vec, half, Vec_S0, Tile_S1, BLayout::RowMajor, Vec_S0, Tile_S1>;
-    constexpr uint32_t SubblockRows = Cube_S0 / VEC_CORES;
     // Reduce tiles cover one vector core's rows (Cube_S0 / VEC_CORES); slices are extracted per row_slice
+    constexpr uint32_t SubblockRows = Cube_S0 / VEC_CORES;
     using ReduceTileF_T = Tile<TileType::Vec, float, SubblockRows, 1, BLayout::ColMajor, SubblockRows, 1>;
 
     TileDataF_T qkVecTile[srcVecTNBuffers];
@@ -814,8 +795,12 @@ __global__ AICORE void runTFA(__gm__ uint64_t *ffts_addr, __gm__ half *q, __gm__
     __gm__ float *pv_tile_fifo_block = pv_tile_fifo + static_cast<size_t>(comm_slot) * pv_fifo_block_stride;
 
     constexpr TSync_Custom<SyncOpType::TSTORE_C2GM, SyncOpType::TLOAD> qk2smSync = {BUF0_QK_READY};
-    constexpr TSync_Custom<SyncOpType::TSTORE_V2GM, SyncOpType::TLOAD> sm2pvSync = {BUF1_SM_READY};
     constexpr TSync_Custom<SyncOpType::TSTORE_C2GM, SyncOpType::TLOAD> pv2guSync = {UPDATE_READY};
+
+    constexpr uint32_t p_tile_fifo_slots = qkp_tile_fifo_size;
+    using PPipe =
+        TPipe<BUF1_SM_READY, Direction::DIR_V2C, Cube_S0 * Tile_S1 * sizeof(half), p_tile_fifo_slots, pMatTNBuffers>;
+    PPipe pPipe((__gm__ void *)p_tile_fifo_block, 0u, (uint32_t)(uint64_t)pMatTile[0].data());
 
     int num_tiles_s1 = s1 / Tile_S1;
     if constexpr (DAV_CUBE) {
@@ -856,14 +841,13 @@ __global__ AICORE void runTFA(__gm__ uint64_t *ffts_addr, __gm__ half *q, __gm__
         }
         if constexpr (DAV_VEC) {
             for (int row_slice = 0; row_slice < static_cast<int>(kTileFactor); ++row_slice) {
-                // Init only on the very first S1 tile; row_slice partitions rows within that tile
                 compute_p<HEAD_SIZE, CUBE_S0, CUBE_S1, Tile_S1, qkp_tile_fifo_size, CV_FIFO_CONS_SYNC_PERIOD,
                           INTERMEDIATE_CHECK, CAUSAL_MASK>(
-                    preload_tile, row_slice, qk_tile_fifo_block, p_tile_fifo_block, exp_max_ififo_block,
-                    global_sum_block, exp_max_block, qkVecTile[p_gu_src_pingpong_id % srcVecTNBuffers],
-                    x_expT[p_gu_src_pingpong_id % xexpVecTNBuffers], input_reduce_tmp, m1_local_max, l1_local_sum,
-                    m2_global_max, l2_global_sum, l1_exp_max_ififo[preload_tile % qkp_tile_fifo_size], triu,
-                    p_gu_src_pingpong_id % xexpVecTNBuffers, qk2smSync, sm2pvSync, block_idx);
+                    preload_tile, row_slice, qk_tile_fifo_block, exp_max_ififo_block, global_sum_block, exp_max_block,
+                    qkVecTile[p_gu_src_pingpong_id % srcVecTNBuffers], x_expT[p_gu_src_pingpong_id % xexpVecTNBuffers],
+                    input_reduce_tmp, m1_local_max, l1_local_sum, m2_global_max, l2_global_sum,
+                    l1_exp_max_ififo[preload_tile % qkp_tile_fifo_size], triu, p_gu_src_pingpong_id % xexpVecTNBuffers,
+                    qk2smSync, pPipe, block_idx);
                 p_gu_src_pingpong_id++;
             }
         }
@@ -894,11 +878,12 @@ __global__ AICORE void runTFA(__gm__ uint64_t *ffts_addr, __gm__ half *q, __gm__
                 if (next_qk_tile != -1) {
                     compute_p<HEAD_SIZE, CUBE_S0, CUBE_S1, Tile_S1, qkp_tile_fifo_size, CV_FIFO_CONS_SYNC_PERIOD,
                               INTERMEDIATE_CHECK, CAUSAL_MASK>(
-                        next_qk_tile, sub_tile, qk_tile_fifo_block, p_tile_fifo_block, exp_max_ififo_block,
-                        global_sum_block, exp_max_block, qkVecTile[p_gu_src_pingpong_id % srcVecTNBuffers],
+                        next_qk_tile, sub_tile, qk_tile_fifo_block, exp_max_ififo_block, global_sum_block,
+                        exp_max_block, qkVecTile[p_gu_src_pingpong_id % srcVecTNBuffers],
                         x_expT[p_gu_src_pingpong_id % xexpVecTNBuffers], input_reduce_tmp, m1_local_max, l1_local_sum,
-                        m2_global_max, l2_global_sum, l1_exp_max_ififo[next_qk_tile % qkp_tile_fifo_size], triu,
-                        p_gu_src_pingpong_id % xexpVecTNBuffers, qk2smSync, sm2pvSync, block_idx);
+                        m2_global_max, l2_global_sum,
+                        l1_exp_max_ififo[next_qk_tile % qkp_tile_fifo_size], triu,
+                        p_gu_src_pingpong_id % xexpVecTNBuffers, qk2smSync, pPipe, block_idx);
                     p_gu_src_pingpong_id++;
                 }
             }
@@ -906,9 +891,9 @@ __global__ AICORE void runTFA(__gm__ uint64_t *ffts_addr, __gm__ half *q, __gm__
             if constexpr (DAV_CUBE) {
                 compute_pv<HEAD_SIZE, CUBE_S0, CUBE_S1, Tile_S1, qkp_tile_fifo_size, pv_tile_fifo_size,
                            CV_FIFO_CONS_SYNC_PERIOD, INTERMEDIATE_CHECK>(
-                    tile_id, sub_tile, p_tile_fifo_block, v, pv_tile_fifo_block,
-                    pMatTile[pv_src_pingpong_id % pMatTNBuffers], vMatTile[pv_src_pingpong_id % vMatTNBuffers],
-                    pvAccTile, pv_src_pingpong_id % vMatTNBuffers + PV_EVENT_ID0, pvAccTileEvtID, sm2pvSync, pv2guSync);
+                    tile_id, sub_tile, v, pv_tile_fifo_block, pMatTile[pv_src_pingpong_id % pMatTNBuffers],
+                    vMatTile[pv_src_pingpong_id % vMatTNBuffers], pvAccTile,
+                    pv_src_pingpong_id % vMatTNBuffers + PV_EVENT_ID0, pvAccTileEvtID, pPipe, pv2guSync);
                 pv_src_pingpong_id++;
             }
         }
@@ -924,7 +909,6 @@ __global__ AICORE void runTFA(__gm__ uint64_t *ffts_addr, __gm__ half *q, __gm__
 
     const int pending_qk_sm_consumed =
         pending_consumption_events(num_tiles_s1, static_cast<int>(qkp_tile_fifo_size), CV_FIFO_CONS_SYNC_PERIOD);
-    const int pending_sv_consumed = pending_qk_sm_consumed; // same schedule and FIFO settings
     const int pending_update_consumed =
         pending_consumption_events(num_tiles_s1, static_cast<int>(qkp_tile_fifo_size), CV_FIFO_CONS_SYNC_PERIOD);
 
@@ -951,8 +935,6 @@ __global__ AICORE void runTFA(__gm__ uint64_t *ffts_addr, __gm__ half *q, __gm__
         wait_flag(PIPE_V, PIPE_MTE2, EVENT_ID1);
         wait_flag(PIPE_MTE3, PIPE_V, EVENT_ID0);
         wait_flag(PIPE_MTE3, PIPE_V, EVENT_ID1);
-        for (int i = 0; i < pending_sv_consumed; ++i)
-            sm2pvSync.allocate();
 #ifdef __DAV_C220_VEC__
         ffts_cross_core_sync(PIPE_MTE2, _getFFTSMsg(CV_CORE_SYNC, CV_BLOCK_END)); // cube can exit CV comm now
 #endif
@@ -1090,3 +1072,4 @@ extern "C" void call_kernel(void *stream,
 
 #undef LAUNCH_TFA
 }
+

--- a/demos/torch_jit/tpush_chunk_bench/tpush_chunk_bench.cpp
+++ b/demos/torch_jit/tpush_chunk_bench/tpush_chunk_bench.cpp
@@ -1,3 +1,13 @@
+/**
+Copyright (c) 2026 Huawei Technologies Co., Ltd.
+This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+CANN Open Software License Agreement Version 2.0 (the "License").
+Please refer to the License for details. You may not use this file except in compliance with the License.
+THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+See LICENSE in the root of the software repository for the full text of the License.
+*/
+
 #include <pto/pto-inst.hpp>
 
 #include "pto_macro_matmul.hpp"

--- a/demos/torch_jit/tpush_chunk_bench/tpush_chunk_bench.cpp
+++ b/demos/torch_jit/tpush_chunk_bench/tpush_chunk_bench.cpp
@@ -1,0 +1,88 @@
+#include <pto/pto-inst.hpp>
+
+#include "pto_macro_matmul.hpp"
+#include "pto_macro_fa_softmax.hpp"
+#include "pto_macro_fa_gu.hpp"
+
+using namespace pto;
+
+constexpr int CHUNKS = 4;
+constexpr int ROWS = 32;
+constexpr int VROWS = 16;
+constexpr int COLS = 256;
+constexpr int SLOTS = 4;
+constexpr int CHUNK_BYTES = ROWS * COLS * sizeof(half);
+constexpr int SLOT_BYTES = CHUNKS * CHUNK_BYTES;
+
+using VTile = Tile<TileType::Vec, half, VROWS, COLS, BLayout::RowMajor, VROWS, COLS>;
+using MTile = Tile<TileType::Mat, half, ROWS, COLS, BLayout::RowMajor, ROWS, COLS>;
+using VGlobal = GlobalTensor<half, Shape<1, 1, 1, VROWS, COLS>, Stride<1, 1, 1, COLS, 1>>;
+using MGlobal = GlobalTensor<half, Shape<1, 1, 1, ROWS, COLS>, Stride<1, 1, 1, COLS, 1>>;
+
+AICORE inline PipeChunk chunk(int i)
+{
+    return i == 0 ? PipeChunk::First : (i + 1 == CHUNKS ? PipeChunk::Last : PipeChunk::Middle);
+}
+
+template <bool Chunked>
+AICORE void run_vec(__gm__ half *input, __gm__ half *fifo, int iters)
+{
+#ifdef __DAV_VEC__
+    set_mask_norm();
+    set_vector_mask(-1, -1);
+    VTile tile;
+    TASSIGN(tile, 0u);
+    VGlobal global(input + get_subblockid() * VROWS * COLS);
+    TLOAD(tile, global);
+    using Pipe = TPipe<0, Direction::DIR_V2C, SLOT_BYTES, SLOTS, 2, true>;
+    Pipe pipe((__gm__ void *)fifo, 0u, 0u);
+    for (int i = 0; i < iters; ++i) {
+        for (int j = 0; j < CHUNKS; ++j) {
+            if constexpr (Chunked) {
+                TPUSH<Pipe, VTile, TileSplitAxis::TILE_UP_DOWN>(pipe, tile, chunk(j), j * CHUNK_BYTES);
+            } else {
+                TPUSH<Pipe, VTile, TileSplitAxis::TILE_UP_DOWN>(pipe, tile, PipeChunk::Single, 0);
+            }
+        }
+    }
+#endif
+}
+
+template <bool Chunked>
+AICORE void run_cube(__gm__ half *output, __gm__ half *fifo, int iters)
+{
+#ifdef __DAV_CUBE__
+    MTile tile[2];
+    TASSIGN(tile[0], 0u);
+    TASSIGN(tile[1], CHUNK_BYTES);
+    using Pipe = TPipe<0, Direction::DIR_V2C, SLOT_BYTES, SLOTS, 2, true>;
+    Pipe pipe((__gm__ void *)fifo, 0u, (uint32_t)(uint64_t)tile[0].data());
+    for (int i = 0; i < iters; ++i) {
+        for (int j = 0; j < CHUNKS; ++j) {
+            if constexpr (Chunked) {
+                TPOP<Pipe, MTile, TileSplitAxis::TILE_UP_DOWN>(pipe, tile[j & 1], chunk(j), j * CHUNK_BYTES);
+            } else {
+                TPOP<Pipe, MTile, TileSplitAxis::TILE_UP_DOWN>(pipe, tile[j & 1], PipeChunk::Single, 0);
+            }
+        }
+    }
+    MGlobal global(output);
+    TSTORE(global, tile[(CHUNKS - 1) & 1]);
+#endif
+}
+
+template <bool Chunked>
+__global__ AICORE void kernel(__gm__ half *input, __gm__ half *output, __gm__ half *fifo, int iters)
+{
+    run_vec<Chunked>(input, fifo, iters);
+    run_cube<Chunked>(output, fifo, iters);
+}
+
+extern "C" void call_kernel(void *stream, half *input, half *output, half *fifo, int mode, int iters)
+{
+    if (mode) {
+        kernel<true><<<1, nullptr, stream>>>(input, output, fifo, iters);
+    } else {
+        kernel<false><<<1, nullptr, stream>>>(input, output, fifo, iters);
+    }
+}

--- a/demos/torch_jit/tpush_chunk_bench/tpush_chunk_bench.py
+++ b/demos/torch_jit/tpush_chunk_bench/tpush_chunk_bench.py
@@ -1,3 +1,17 @@
+#!/usr/bin/python3
+# coding=utf-8
+# --------------------------------------------------------------------------------
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the
+# terms and conditions of CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance
+# with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY,
+# OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# --------------------------------------------------------------------------------
+
 import ctypes
 import os
 import subprocess

--- a/demos/torch_jit/tpush_chunk_bench/tpush_chunk_bench.py
+++ b/demos/torch_jit/tpush_chunk_bench/tpush_chunk_bench.py
@@ -1,0 +1,83 @@
+import ctypes
+import os
+import subprocess
+from pathlib import Path
+import torch
+from util.bench import do_bench
+from util.device import get_test_device
+
+ASCEND_TOOLKIT_HOME = os.environ["ASCEND_TOOLKIT_HOME"]
+PTO_LIB_PATH = os.environ["PTO_LIB_PATH"]
+DEVICE = get_test_device()
+torch.npu.set_device(DEVICE)
+
+ROWS = 32
+COLS = 256
+FULL_ROWS = 128
+SLOTS = 4
+SINGLE = 0
+CHUNKED = 1
+WARMUP = 10
+BENCH = 30
+ITERS = 4096
+
+
+HERE = Path(__file__).resolve().parent
+SO = HERE / "tpush_chunk_bench.so"
+subprocess.run(
+    [
+        "bisheng",
+        "-fPIC",
+        "-shared",
+        "-xcce",
+        f"--npu-arch={os.environ.get('NPU_ARCH', 'dav-2201').strip()}",
+        "-O2",
+        "-std=c++17",
+        "-Wno-ignored-attributes",
+        f"-I{PTO_LIB_PATH}/include",
+        f"-I{PTO_LIB_PATH}/kernels/manual/a2a3/flash_atten",
+        f"-I{ASCEND_TOOLKIT_HOME}/include",
+        str(HERE / "tpush_chunk_bench.cpp"),
+        "-o",
+        str(SO),
+    ],
+    check=True,
+)
+
+run = ctypes.CDLL(os.path.abspath(SO)).call_kernel
+run.argtypes = [ctypes.c_void_p, ctypes.c_void_p, ctypes.c_void_p, ctypes.c_void_p, ctypes.c_int, ctypes.c_int]
+stream = torch.npu.current_stream()._as_parameter_
+ptr = ctypes.c_void_p
+
+
+def call(x: torch.Tensor, y: torch.Tensor, fifo: torch.Tensor, mode: int):
+    run(stream, ptr(x.data_ptr()), ptr(y.data_ptr()), ptr(fifo.data_ptr()), mode, ITERS)
+
+
+def make():
+    x = torch.randn((ROWS, COLS), device=DEVICE, dtype=torch.float16)
+    return x, torch.empty_like(x), torch.empty((SLOTS, FULL_ROWS, COLS), device=DEVICE, dtype=torch.float16)
+
+
+x0, y0, f0 = make()
+x1, y1, f1 = make()
+x1.copy_(x0)
+
+call(x0, y0, f0, SINGLE)
+call(x1, y1, f1, CHUNKED)
+torch.npu.synchronize()
+
+torch.testing.assert_close(y0, x0)
+torch.testing.assert_close(y1, x1)
+torch.testing.assert_close(y0, y1)
+
+t0 = do_bench(lambda: call(x0, y0, f0, SINGLE), warmup_iters=WARMUP, benchmark_iters=BENCH, unit="ms")
+t1 = do_bench(lambda: call(x1, y1, f1, CHUNKED), warmup_iters=WARMUP, benchmark_iters=BENCH, unit="ms")
+
+print(f"kernel_iters : {ITERS}")
+print(f"single mode  : {t0:.3f} ms")
+print(f"chunked mode : {t1:.3f} ms")
+print(f"speedup      : {t0 / t1:.3f}x")
+print(f"time saved   : {100.0 * (t0 - t1) / t0:.1f}%")
+
+SO.unlink(missing_ok=True)

--- a/demos/torch_jit/util/bench.py
+++ b/demos/torch_jit/util/bench.py
@@ -1,0 +1,59 @@
+#!/usr/bin/python3
+# coding=utf-8
+# --------------------------------------------------------------------------------
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the
+# terms and conditions of CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance
+# with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY,
+# OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# --------------------------------------------------------------------------------
+
+from typing import Callable, List, Literal, Union
+
+
+def do_bench(
+    fn: Callable,
+    warmup_iters: int = 5,
+    benchmark_iters: int = 15,
+    aggregation: Literal["mean", "none"] = "mean",
+    unit: Literal["s", "ms", "us", "ns"] = "us",
+) -> Union[float, List[float]]:
+    """
+    Benchmark a given function with warmup.
+
+    Args:
+        fn: Function to benchmark.
+        warmup_iters: Number of warmup runs.
+        benchmark_iters: Number of benchmark runs.
+        aggregation: Aggregation mode for benchmark times.
+        unit: Time unit of the benchmarks.
+    Returns:
+        Runtime, or list of runtimes, in specified units.
+    """
+    import torch
+    import torch_npu
+
+    start_events = [torch.npu.Event(enable_timing=True) for _ in range(benchmark_iters)]
+    end_events = [torch.npu.Event(enable_timing=True) for _ in range(benchmark_iters)]
+
+    for _ in range(warmup_iters):
+        fn()
+    torch_npu.npu.synchronize()
+
+    for i in range(benchmark_iters):
+        start_events[i].record()
+        fn()
+        end_events[i].record()
+
+    torch_npu.npu.synchronize()
+    factor = {"s": 1e-3, "ms": 1e0, "us": 1e3, "ns": 1e6}[unit]
+    times = [
+        factor * start.elapsed_time(end) for start, end in zip(start_events, end_events)
+    ]
+    if aggregation == "mean":
+        return sum(times) / len(times)
+    return times

--- a/demos/torch_jit/util/device.py
+++ b/demos/torch_jit/util/device.py
@@ -1,0 +1,32 @@
+#!/usr/bin/python3
+# coding=utf-8
+# --------------------------------------------------------------------------------
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the
+# terms and conditions of CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance
+# with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY,
+# OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# --------------------------------------------------------------------------------
+
+import os
+
+DEVICE_ENV_VAR = "PTO_TEST_DEVICE_ID"
+DEFAULT_DEVICE_ID = "0"
+DEVICE_PREFIX = "npu:"
+
+
+def get_test_device() -> str:
+    device_id = os.getenv(DEVICE_ENV_VAR)
+    if not device_id:
+        print(
+            f"Warning: {DEVICE_ENV_VAR} is not set; defaulting to {DEFAULT_DEVICE_ID}."
+        )
+        device_id = DEFAULT_DEVICE_ID
+
+    if device_id.startswith(DEVICE_PREFIX):
+        return device_id
+    return f"{DEVICE_PREFIX}{device_id}"

--- a/include/pto/common/fifo.hpp
+++ b/include/pto/common/fifo.hpp
@@ -37,6 +37,14 @@ enum Direction : uint8_t
 #endif
 };
 
+enum class PipeChunk : uint8_t
+{
+    Single = 0, // Full slot in one call: entry sync + exit sync + advance slot
+    First = 1,  // First partial chunk: entry sync, keep current slot open
+    Middle = 2, // Middle partial chunk: no sync, keep current slot open
+    Last = 3,   // Final partial chunk: exit sync + advance slot
+};
+
 template <int SlotSize, int SlotNum, int LocalSlotNum>
 struct RingFIFO {
     __gm__ void *GM_SLOT_BUFFER = nullptr; // Global memory

--- a/include/pto/common/pto_instr.hpp
+++ b/include/pto/common/pto_instr.hpp
@@ -1840,6 +1840,14 @@ PTO_INST RecordEvent TPUSH(Pipe &pipe, TileProd &tile, WaitEvents &... events)
     return {};
 }
 
+template <typename Pipe, typename TileProd, TileSplitAxis Split, typename... WaitEvents>
+PTO_INST RecordEvent TPUSH(Pipe &pipe, TileProd &tile, PipeChunk chunk, int entryOffset, WaitEvents &... events)
+{
+    TSYNC(events...);
+    TPUSH_IMPL<Pipe, TileProd, Split>(pipe, tile, chunk, entryOffset);
+    return {};
+}
+
 template <typename TileData, typename Pipe, typename... WaitEvents>
 PTO_INST RecordEvent TPUSH(TileData &tile, Pipe &pipe, WaitEvents &... events)
 {
@@ -1853,6 +1861,14 @@ PTO_INST RecordEvent TPOP(Pipe &pipe, TileCons &tile, WaitEvents &... events)
 {
     TSYNC(events...);
     TPOP_IMPL<Pipe, TileCons, Split>(pipe, tile);
+    return {};
+}
+
+template <typename Pipe, typename TileCons, TileSplitAxis Split, typename... WaitEvents>
+PTO_INST RecordEvent TPOP(Pipe &pipe, TileCons &tile, PipeChunk chunk, int entryOffset, WaitEvents &... events)
+{
+    TSYNC(events...);
+    TPOP_IMPL<Pipe, TileCons, Split>(pipe, tile, chunk, entryOffset);
     return {};
 }
 

--- a/include/pto/npu/a2a3/TPop.hpp
+++ b/include/pto/npu/a2a3/TPop.hpp
@@ -43,6 +43,30 @@ PTO_INTERNAL void TPOP_IMPL(Pipe &pipe, TileCons &tile)
     }
 }
 
+template <typename Pipe, typename TileCons, TileSplitAxis Split>
+PTO_INTERNAL void TPOP_IMPL(Pipe &pipe, TileCons &tile, PipeChunk chunk, int entryOffset)
+{
+    const bool doWait = (chunk == PipeChunk::Single || chunk == PipeChunk::First);
+    const bool doFree = (chunk == PipeChunk::Single || chunk == PipeChunk::Last);
+    const bool advanceSlot = (chunk == PipeChunk::Single || chunk == PipeChunk::Last);
+
+    if (doWait) {
+        pipe.cons.wait();
+    }
+
+    auto consumer = pipe.cons;
+    consumer.entryOffset = entryOffset;
+    consumer.template pop<TileCons, Split>(pipe.fifo, tile);
+
+    if (advanceSlot) {
+        pipe.cons.tileIndex++;
+    }
+
+    if (doFree) {
+        consumer.free();
+    }
+}
+
 template <typename Pipe, TileSplitAxis Split>
 PTO_INTERNAL void TFREE_IMPL(Pipe &pipe)
 {

--- a/include/pto/npu/a2a3/TPush.hpp
+++ b/include/pto/npu/a2a3/TPush.hpp
@@ -370,9 +370,11 @@ struct TPipe {
             using T = typename TileCons::DType;
             constexpr int ConsM = TileCons::Rows;
             constexpr int ConsN = TileCons::Cols;
+            constexpr int splitNum = 2;
+            constexpr int ProdN = (Split == TileSplitAxis::TILE_LEFT_RIGHT) ? ConsN * splitNum : ConsN;
             size_t entryBase = (static_cast<size_t>(tileIndex) % RingFiFo::SLOT_NUM) *
                                RingFiFo::SLOT_SIZE; // ConsM * ConsN * sizeof(T);
-            using GlobalData = GlobalTensor<T, pto::Shape<1, 1, 1, ConsM, ConsN>, pto::Stride<1, 1, 1, ConsN, 1>>;
+            using GlobalData = GlobalTensor<T, pto::Shape<1, 1, 1, ConsM, ConsN>, pto::Stride<1, 1, 1, ProdN, 1>>;
             GlobalData globalTensor((__gm__ T *)((uint64_t)fifo.GM_SLOT_BUFFER + entryBase + entryOffset));
 
             uint64_t localTileBase =
@@ -446,6 +448,30 @@ PTO_INTERNAL void TPUSH_IMPL(Pipe &pipe, TileProd &tile)
     bool isRecord = pipe.prod.getRecordStatus();
     if (isRecord) {
         pipe.prod.record();
+    }
+}
+
+template <typename Pipe, typename TileProd, TileSplitAxis Split>
+PTO_INTERNAL void TPUSH_IMPL(Pipe &pipe, TileProd &tile, PipeChunk chunk, int entryOffset)
+{
+    const bool doAllocate = (chunk == PipeChunk::Single || chunk == PipeChunk::First);
+    const bool doRecord = (chunk == PipeChunk::Single || chunk == PipeChunk::Last);
+    const bool advanceSlot = (chunk == PipeChunk::Single || chunk == PipeChunk::Last);
+
+    if (doAllocate) {
+        pipe.prod.allocate();
+    }
+
+    auto producer = pipe.prod;
+    producer.entryOffset = entryOffset;
+    producer.template push<TileProd, Split>(pipe.fifo, tile);
+
+    if (advanceSlot) {
+        pipe.prod.tileIndex++;
+    }
+
+    if (doRecord) {
+        producer.record();
     }
 }
 

--- a/include/pto/pto-inst.hpp
+++ b/include/pto/pto-inst.hpp
@@ -12,6 +12,7 @@ See LICENSE in the root of the software repository for the full text of the Lice
 #define PTO_INST_HPP
 
 #include <pto/common/type.hpp>
+#include <pto/common/fifo.hpp>
 #if defined(__CPU_SIM)
 #include "pto/common/cpu_stub.hpp"
 #elif defined(__COSTMODEL)


### PR DESCRIPTION

## Summary
Currently, Flash-attention uses `TMPipe` objects and manipulate the `allocate()`/`record()`/`wait()`/`free()`/... calls using the `cons`/`prod` pipe attributes to avoid paying the full cross-core synchonization costs for every `TPUSH`. This allows it to do cross-core communication in a chunked fashion, _without paying the sync overhead for each chunk_.

I propose we add a parameter to `TPUSH` that specifies if chunk is the first, middle, or the final chunk being sent, giving us control over when syncs are done **without** ever having to touch the pipe attributes.

Using this approach Flash-attention can be simplified (remove all pipe attribute manipulation and just have a clean `TPUSH` call), while keeping the performance.

### API addition


`TPUSH` is now overloaded and supports the additional `PipeChunk` and `entryOffset` parameter

```cpp
TPUSH(Pipe&, TileProd&, PipeChunk chunk, int entryOffset, ...)
TPOP(Pipe&, TileCons&, PipeChunk chunk, int entryOffset, ...)
```
where
```cpp
enum class PipeChunk : uint8_t
{
    Single = 0, // Full slot in one call: entry sync + exit sync + advance slot
    First = 1,  // First partial chunk: entry sync, keep current slot open
    Middle = 2, // Middle partial chunk: no sync, keep current slot open
    Last = 3,   // Final partial chunk: exit sync + advance slot
};
```


### TODO

- [ ] If accepted implement for `cpu` and `a5` (simple)



## Benchmark and verify

### Flash-attention
I modified the flash attention implementation which makes it both simpler and keeps the performance as it was.

<img width="1280" height="800" alt="image" src="https://github.com/user-attachments/assets/7d1c2f56-c818-447a-9d2e-2caaecc0451e" />

### Minimal reproduction
Here is a benchmark to compare normal mode(sync every `TPUSH`) vs chunked mode. W so pushing a tile in 4 chunks with normal mode vs in chunked mode.
The single mode does 4x syncs while the chunked mode does in total 1 full sync. So here we gain 2.5x performance by not performing these 3 extra syncs. Assuming the memory transfer is 0 cost, we could theoretically have a 4x gain, for 4 chunks.
```markdown
> python tpush_chunk_bench.py 
kernel_iters : 4096
single mode  : 13.021 ms
chunked mode : 5.096 ms
speedup      : 2.555x
time saved   : 60.9%
```


## Problem/limitation of the  `TPUSH` api

Let's say a core wants to send a `128x128` tile to another core in 4 stages/chunks, so it sends `32x128` per time. Hence 4 chunks need to be sent to fill the `128x128` GM FIFO slot.

When relying purely on the `TPUSH` api we have to do 4 `TPUSH` which each time will `ffts_cross_core_sync()` and `wait_flag_dev()` both in consumer and producer side. But using the `TPipe` object manually it is possible to specify when you want to do the syncs/waits, so in that case it just checks if the FIFO slot is ready for the 1st piece, then it can send the other pieces without any syncs, and for the 4th piece it can do a `.free()` call which is the final sync.
The conclusion is it sent the `128x128` tile in 4 separate transactions but it only paid the waiting for a single `TPUSH`

This doesn't seem possible with the current `TPUSH` api without modifying the `TPipe` object directly.
