### PR TITLE
refactor(codegen): Support heterogeneous tile types in CPU PTO instruction impls

### DIFF
--- a/include/pto/cpu/TAdd.hpp
+++ b/include/pto/cpu/TAdd.hpp
@@ -16,55 +16,64 @@ See LICENSE in the root of the software repository for the full text of the Lice
 #include "pto/cpu/parallel.hpp"
 
 namespace pto {
-template <typename tile_shape>
-void TAdd_Impl(typename tile_shape::TileDType dst, typename tile_shape::TileDType src0,
-               typename tile_shape::TileDType src1, unsigned validRow, unsigned validCol)
+template <typename TileDataDst, typename TileDataSrc0, typename TileDataSrc1>
+void TAdd_Impl(typename TileDataDst::TileDType dst, typename TileDataSrc0::TileDType src0,
+               typename TileDataSrc1::TileDType src1, unsigned validRow, unsigned validCol)
 {
-    if constexpr (tile_shape::SFractal == SLayout::NoneBox) {
-        if constexpr (tile_shape::isRowMajor) {
+    static_assert(std::is_same_v<typename TileDataDst::DType, typename TileDataSrc0::DType> &&
+                      std::is_same_v<typename TileDataDst::DType, typename TileDataSrc1::DType>,
+                  "Fix: TADD the data type of dst must be consistent with src0 and src1.");
+    if constexpr (TileDataDst::SFractal == SLayout::NoneBox) {
+        if constexpr (TileDataDst::isRowMajor) {
             cpu::parallel_for_rows(validRow, validCol, [&](std::size_t r) {
-                const std::size_t base = r * tile_shape::Cols;
+                const std::size_t dstBase = r * TileDataDst::Cols;
+                const std::size_t src0Base = r * TileDataSrc0::Cols;
+                const std::size_t src1Base = r * TileDataSrc1::Cols;
                 PTO_CPU_VECTORIZE_LOOP
                 for (std::size_t c = 0; c < validCol; ++c) {
-                    const std::size_t idx = base + c;
-                    dst[idx] = src0[idx] + src1[idx];
+                    dst[dstBase + c] = src0[src0Base + c] + src1[src1Base + c];
                 }
             });
         } else {
             cpu::parallel_for_rows(validCol, validRow, [&](std::size_t c) {
-                const std::size_t base = c * tile_shape::Rows;
+                const std::size_t dstBase = c * TileDataDst::Rows;
+                const std::size_t src0Base = c * TileDataSrc0::Rows;
+                const std::size_t src1Base = c * TileDataSrc1::Rows;
                 PTO_CPU_VECTORIZE_LOOP
                 for (std::size_t r = 0; r < validRow; ++r) {
-                    const std::size_t idx = base + r;
-                    dst[idx] = src0[idx] + src1[idx];
+                    dst[dstBase + r] = src0[src0Base + r] + src1[src1Base + r];
                 }
             });
         }
     } else {
-        if constexpr (tile_shape::isRowMajor) {
+        if constexpr (TileDataDst::isRowMajor) {
             cpu::parallel_for_rows(validRow, validCol, [&](std::size_t r) {
                 for (std::size_t c = 0; c < validCol; ++c) {
-                    const std::size_t idx = GetTileElementOffset<tile_shape>(r, c);
-                    dst[idx] = src0[idx] + src1[idx];
+                    dst[GetTileElementOffset<TileDataDst>(r, c)] =
+                        src0[GetTileElementOffset<TileDataSrc0>(r, c)] + src1[GetTileElementOffset<TileDataSrc1>(r, c)];
                 }
             });
         } else {
             cpu::parallel_for_rows(validCol, validRow, [&](std::size_t c) {
                 for (std::size_t r = 0; r < validRow; ++r) {
-                    const std::size_t idx = GetTileElementOffset<tile_shape>(r, c);
-                    dst[idx] = src0[idx] + src1[idx];
+                    dst[GetTileElementOffset<TileDataDst>(r, c)] =
+                        src0[GetTileElementOffset<TileDataSrc0>(r, c)] + src1[GetTileElementOffset<TileDataSrc1>(r, c)];
                 }
             });
         }
     }
 }
 
-template <typename tile_shape>
-PTO_INTERNAL void TADD_IMPL(tile_shape &dst, tile_shape &src0, tile_shape &src1)
+template <typename TileDataDst, typename TileDataSrc0, typename TileDataSrc1>
+PTO_INTERNAL void TADD_IMPL(TileDataDst &dst, TileDataSrc0 &src0, TileDataSrc1 &src1)
 {
     unsigned row = dst.GetValidRow();
     unsigned col = dst.GetValidCol();
-    TAdd_Impl<tile_shape>(dst.data(), src0.data(), src1.data(), row, col);
+    PTO_ASSERT(src0.GetValidRow() == row && src0.GetValidCol() == col,
+               "Fix: TADD input tile src0 valid shape mismatch with output tile dst shape.");
+    PTO_ASSERT(src1.GetValidRow() == row && src1.GetValidCol() == col,
+               "Fix: TADD input tile src1 valid shape mismatch with output tile dst shape.");
+    TAdd_Impl<TileDataDst, TileDataSrc0, TileDataSrc1>(dst.data(), src0.data(), src1.data(), row, col);
 }
 } // namespace pto
 #endif

--- a/include/pto/cpu/TCmps.hpp
+++ b/include/pto/cpu/TCmps.hpp
@@ -90,9 +90,11 @@ AICORE void TCmps(typename TileDataDst::TileDType __out__ dst, typename TileData
     }
 }
 
-template <typename TileDataDst, typename TileDataSrc, typename T>
-PTO_INTERNAL void TCMPS_IMPL(TileDataDst &dst, TileDataSrc &src0, T src1, CmpMode cmpMode)
+template <typename TileDataDst, typename TileDataSrc>
+PTO_INTERNAL void TCMPS_IMPL(TileDataDst &dst, TileDataSrc &src0, typename TileDataSrc::DType src1, CmpMode cmpMode)
 {
+    using T = typename TileDataSrc::DType;
+
     unsigned dstValidRow = dst.GetValidRow();
     unsigned dstValidCol = dst.GetValidCol();
 
@@ -104,6 +106,58 @@ PTO_INTERNAL void TCMPS_IMPL(TileDataDst &dst, TileDataSrc &src0, T src1, CmpMod
 
     TCmps<TileDataDst, TileDataSrc, T>(dst.data(), src0.data(), src1, cmpMode, srcValidRow, srcValidCol, dstValidRow,
                                        dstValidCol, dstStride, srcStride);
+}
+
+template <typename TileDataDst, typename TileDataSrc0, typename TileDataSrc1,
+          typename = std::void_t<typename TileDataSrc1::DType>>
+PTO_INTERNAL void TCMPS_IMPL(TileDataDst &dst, TileDataSrc0 &src0, TileDataSrc1 &src1, CmpMode cmpMode)
+{
+    static_assert(std::is_same_v<typename TileDataSrc0::DType, typename TileDataSrc1::DType>,
+                  "Fix: TCMPS src0 and src1 must have the same data type.");
+    using T = typename TileDataSrc0::DType;
+
+    unsigned dstValidRow = dst.GetValidRow();
+    unsigned dstValidCol = dst.GetValidCol();
+
+    unsigned srcValidRow = src0.GetValidRow();
+    unsigned srcValidCol = src0.GetValidCol();
+
+    unsigned dstStride = TileDataDst::RowStride;
+    unsigned srcStride = TileDataSrc0::RowStride;
+    unsigned src1Stride = TileDataSrc1::RowStride;
+
+    size_t H = TileDataSrc0::Rows;
+    size_t W = TileDataSrc0::Cols;
+    std::vector<uint8_t> golden(H * W, 0);
+
+    for (size_t i = 0; i < srcValidRow; i++) {
+        for (size_t j = 0; j < srcValidCol; j++) {
+            T a = src0.data()[i * srcStride + j];
+            T b = src1.data()[i * src1Stride + j];
+            golden[i * W + j] = CmpCall<T>(a, b, cmpMode);
+        }
+    }
+
+    std::vector<uint8_t> out_uint8;
+    size_t bits_per_row = W / 8;
+
+    for (size_t h = 0; h < H; ++h) {
+        for (size_t i = 0; i < bits_per_row; ++i) {
+            uint8_t packed_byte = 0;
+            for (size_t bit = 0; bit < 8; ++bit) {
+                uint8_t bit_val = golden[h * W + (i * 8 + bit)];
+                packed_byte |= (bit_val << bit);
+            }
+            out_uint8.push_back(packed_byte);
+        }
+    }
+
+    int c = 0;
+    for (size_t i = 0; i < dstValidRow && c < out_uint8.size(); i++) {
+        for (size_t j = 0; j < dstValidCol && c < out_uint8.size(); j++) {
+            dst.data()[GetTileElementOffset<TileDataDst>(i, j)] = out_uint8[c++];
+        }
+    }
 }
 } // namespace pto
 #endif

--- a/include/pto/cpu/TDiv.hpp
+++ b/include/pto/cpu/TDiv.hpp
@@ -16,56 +16,65 @@ See LICENSE in the root of the software repository for the full text of the Lice
 #include "pto/cpu/parallel.hpp"
 
 namespace pto {
-template <typename tile_shape, int stride>
-void TDiv_Impl(typename tile_shape::TileDType dst, typename tile_shape::TileDType src0,
-               typename tile_shape::TileDType src1, unsigned validRow, unsigned validCol)
+template <typename TileDataDst, typename TileDataSrc0, typename TileDataSrc1>
+void TDiv_Impl(typename TileDataDst::TileDType dst, typename TileDataSrc0::TileDType src0,
+               typename TileDataSrc1::TileDType src1, unsigned validRow, unsigned validCol)
 {
-    if constexpr (tile_shape::SFractal == SLayout::NoneBox) {
-        if constexpr (tile_shape::isRowMajor) {
+    static_assert(std::is_same_v<typename TileDataDst::DType, typename TileDataSrc0::DType> &&
+                      std::is_same_v<typename TileDataDst::DType, typename TileDataSrc1::DType>,
+                  "Fix: TDIV the data type of dst must be consistent with src0 and src1.");
+    if constexpr (TileDataDst::SFractal == SLayout::NoneBox) {
+        if constexpr (TileDataDst::isRowMajor) {
             cpu::parallel_for_rows(validRow, validCol, [&](std::size_t r) {
-                const std::size_t base = r * tile_shape::Cols;
+                const std::size_t dstBase = r * TileDataDst::Cols;
+                const std::size_t src0Base = r * TileDataSrc0::Cols;
+                const std::size_t src1Base = r * TileDataSrc1::Cols;
                 PTO_CPU_VECTORIZE_LOOP
                 for (std::size_t c = 0; c < validCol; ++c) {
-                    const std::size_t idx = base + c;
-                    dst[idx] = src0[idx] / src1[idx];
+                    dst[dstBase + c] = src0[src0Base + c] / src1[src1Base + c];
                 }
             });
         } else {
             cpu::parallel_for_rows(validCol, validRow, [&](std::size_t c) {
-                const std::size_t base = c * tile_shape::Rows;
+                const std::size_t dstBase = c * TileDataDst::Rows;
+                const std::size_t src0Base = c * TileDataSrc0::Rows;
+                const std::size_t src1Base = c * TileDataSrc1::Rows;
                 PTO_CPU_VECTORIZE_LOOP
                 for (std::size_t r = 0; r < validRow; ++r) {
-                    const std::size_t idx = base + r;
-                    dst[idx] = src0[idx] / src1[idx];
+                    dst[dstBase + r] = src0[src0Base + r] / src1[src1Base + r];
                 }
             });
         }
     } else {
-        if constexpr (tile_shape::isRowMajor) {
+        if constexpr (TileDataDst::isRowMajor) {
             cpu::parallel_for_rows(validRow, validCol, [&](std::size_t r) {
                 for (std::size_t c = 0; c < validCol; ++c) {
-                    const std::size_t idx = GetTileElementOffset<tile_shape>(r, c);
-                    dst[idx] = src0[idx] / src1[idx];
+                    dst[GetTileElementOffset<TileDataDst>(r, c)] =
+                        src0[GetTileElementOffset<TileDataSrc0>(r, c)] / src1[GetTileElementOffset<TileDataSrc1>(r, c)];
                 }
             });
         } else {
             cpu::parallel_for_rows(validCol, validRow, [&](std::size_t c) {
                 for (std::size_t r = 0; r < validRow; ++r) {
-                    const std::size_t idx = GetTileElementOffset<tile_shape>(r, c);
-                    dst[idx] = src0[idx] / src1[idx];
+                    dst[GetTileElementOffset<TileDataDst>(r, c)] =
+                        src0[GetTileElementOffset<TileDataSrc0>(r, c)] / src1[GetTileElementOffset<TileDataSrc1>(r, c)];
                 }
             });
         }
     }
 }
 
-template <auto PrecisionType = DivAlgorithm::DEFAULT, typename tile_shape>
-PTO_INTERNAL void TDIV_IMPL(tile_shape &dst, tile_shape &src0, tile_shape &src1)
+template <auto PrecisionType = DivAlgorithm::DEFAULT, typename TileDataDst, typename TileDataSrc0,
+          typename TileDataSrc1>
+PTO_INTERNAL void TDIV_IMPL(TileDataDst &dst, TileDataSrc0 &src0, TileDataSrc1 &src1)
 {
     unsigned row = dst.GetValidRow();
     unsigned col = dst.GetValidCol();
-    constexpr unsigned stride = tile_shape::RowStride;
-    TDiv_Impl<tile_shape, stride>(dst.data(), src0.data(), src1.data(), row, col);
+    PTO_ASSERT(src0.GetValidRow() == row && src0.GetValidCol() == col,
+               "Fix: TDIV input tile src0 valid shape mismatch with output tile dst shape.");
+    PTO_ASSERT(src1.GetValidRow() == row && src1.GetValidCol() == col,
+               "Fix: TDIV input tile src1 valid shape mismatch with output tile dst shape.");
+    TDiv_Impl<TileDataDst, TileDataSrc0, TileDataSrc1>(dst.data(), src0.data(), src1.data(), row, col);
 }
 } // namespace pto
 #endif

--- a/include/pto/cpu/TExpands.hpp
+++ b/include/pto/cpu/TExpands.hpp
@@ -50,7 +50,7 @@ void TExpands_Impl(typename tile_shape::TileDType dst, typename tile_shape::DTyp
 }
 
 template <typename tile_shape>
-PTO_INTERNAL void TEXPANDS_IMPL(tile_shape &dst, typename tile_shape::DType &src)
+PTO_INTERNAL void TEXPANDS_IMPL(tile_shape &dst, typename tile_shape::DType src)
 {
     unsigned row = dst.GetValidRow();
     unsigned col = dst.GetValidCol();

--- a/include/pto/cpu/TMatmul.hpp
+++ b/include/pto/cpu/TMatmul.hpp
@@ -151,9 +151,10 @@ PTO_INTERNAL void CheckBiasValid()
                   "Non-conforming bias fractal");
 }
 
-template <typename TileAcc, typename TileLeft, typename TileRight>
+template <AccPhase Phase = AccPhase::Unspecified, typename TileAcc, typename TileLeft, typename TileRight>
 PTO_INTERNAL void TMATMUL_IMPL(TileAcc &cMatrix, TileLeft &aMatrix, TileRight &bMatrix)
 {
+    (void)Phase;
     CheckMadValid<TileAcc, TileLeft, TileRight>();
 
     uint16_t m = aMatrix.GetValidRow();
@@ -163,9 +164,10 @@ PTO_INTERNAL void TMATMUL_IMPL(TileAcc &cMatrix, TileLeft &aMatrix, TileRight &b
     TMatmulNzZn<TileAcc, TileLeft, TileRight>(cMatrix.data(), nullptr, aMatrix.data(), bMatrix.data(), m, n, k);
 }
 
-template <typename TileAcc, typename TileLeft, typename TileRight>
+template <AccPhase Phase = AccPhase::Unspecified, typename TileAcc, typename TileLeft, typename TileRight>
 PTO_INTERNAL void TMATMUL_ACC_IMPL(TileAcc &cOutMatrix, TileAcc &cInMatrix, TileLeft &aMatrix, TileRight &bMatrix)
 {
+    (void)Phase;
     CheckMadValid<TileAcc, TileLeft, TileRight>();
 
     uint16_t m = aMatrix.GetValidRow();
@@ -176,9 +178,24 @@ PTO_INTERNAL void TMATMUL_ACC_IMPL(TileAcc &cOutMatrix, TileAcc &cInMatrix, Tile
                                               k);
 }
 
-template <typename TileAcc, typename TileLeft, typename TileRight, typename TileBias>
+template <AccPhase Phase = AccPhase::Unspecified, typename TileAcc, typename TileLeft, typename TileRight>
+PTO_INTERNAL void TMATMUL_ACC_IMPL(TileAcc &cMatrix, TileLeft &aMatrix, TileRight &bMatrix)
+{
+    (void)Phase;
+    CheckMadValid<TileAcc, TileLeft, TileRight>();
+
+    uint16_t m = aMatrix.GetValidRow();
+    uint16_t k = aMatrix.GetValidCol();
+    uint16_t n = bMatrix.GetValidCol();
+
+    TMatmulNzZn<TileAcc, TileLeft, TileRight>(cMatrix.data(), cMatrix.data(), aMatrix.data(), bMatrix.data(), m, n, k);
+}
+
+template <AccPhase Phase = AccPhase::Unspecified, typename TileAcc, typename TileLeft, typename TileRight,
+          typename TileBias>
 PTO_INTERNAL void TMATMUL_BIAS_IMPL(TileAcc &cMatrix, TileLeft &aMatrix, TileRight &bMatrix, TileBias &biasMatrix)
 {
+    (void)Phase;
     CheckMadValid<TileAcc, TileLeft, TileRight>();
     CheckBiasValid<TileAcc, TileBias>();
 

--- a/include/pto/cpu/TMax.hpp
+++ b/include/pto/cpu/TMax.hpp
@@ -16,56 +16,64 @@ See LICENSE in the root of the software repository for the full text of the Lice
 #include "pto/cpu/parallel.hpp"
 
 namespace pto {
-template <typename tile_shape, int stride>
-void TMAX_Impl(typename tile_shape::TileDType dst, typename tile_shape::TileDType src0,
-               typename tile_shape::TileDType src1, unsigned validRow, unsigned validCol)
+template <typename TileDataDst, typename TileDataSrc0, typename TileDataSrc1>
+void TMAX_Impl(typename TileDataDst::TileDType dst, typename TileDataSrc0::TileDType src0,
+               typename TileDataSrc1::TileDType src1, unsigned validRow, unsigned validCol)
 {
-    if constexpr (tile_shape::SFractal == SLayout::NoneBox) {
-        if constexpr (tile_shape::isRowMajor) {
+    static_assert(std::is_same_v<typename TileDataDst::DType, typename TileDataSrc0::DType> &&
+                      std::is_same_v<typename TileDataDst::DType, typename TileDataSrc1::DType>,
+                  "Fix: TMAX the data type of dst must be consistent with src0 and src1.");
+    if constexpr (TileDataDst::SFractal == SLayout::NoneBox) {
+        if constexpr (TileDataDst::isRowMajor) {
             cpu::parallel_for_rows(validRow, validCol, [&](std::size_t r) {
-                const std::size_t base = r * tile_shape::Cols;
+                const std::size_t dstBase = r * TileDataDst::Cols;
+                const std::size_t src0Base = r * TileDataSrc0::Cols;
+                const std::size_t src1Base = r * TileDataSrc1::Cols;
                 PTO_CPU_VECTORIZE_LOOP
                 for (std::size_t c = 0; c < validCol; ++c) {
-                    const std::size_t idx = base + c;
-                    dst[idx] = std::max(src0[idx], src1[idx]);
+                    dst[dstBase + c] = std::max(src0[src0Base + c], src1[src1Base + c]);
                 }
             });
         } else {
             cpu::parallel_for_rows(validCol, validRow, [&](std::size_t c) {
-                const std::size_t base = c * tile_shape::Rows;
+                const std::size_t dstBase = c * TileDataDst::Rows;
+                const std::size_t src0Base = c * TileDataSrc0::Rows;
+                const std::size_t src1Base = c * TileDataSrc1::Rows;
                 PTO_CPU_VECTORIZE_LOOP
                 for (std::size_t r = 0; r < validRow; ++r) {
-                    const std::size_t idx = base + r;
-                    dst[idx] = std::max(src0[idx], src1[idx]);
+                    dst[dstBase + r] = std::max(src0[src0Base + r], src1[src1Base + r]);
                 }
             });
         }
     } else {
-        if constexpr (tile_shape::isRowMajor) {
+        if constexpr (TileDataDst::isRowMajor) {
             cpu::parallel_for_rows(validRow, validCol, [&](std::size_t r) {
                 for (std::size_t c = 0; c < validCol; ++c) {
-                    const std::size_t idx = GetTileElementOffset<tile_shape>(r, c);
-                    dst[idx] = std::max(src0[idx], src1[idx]);
+                    dst[GetTileElementOffset<TileDataDst>(r, c)] = std::max(
+                        src0[GetTileElementOffset<TileDataSrc0>(r, c)], src1[GetTileElementOffset<TileDataSrc1>(r, c)]);
                 }
             });
         } else {
             cpu::parallel_for_rows(validCol, validRow, [&](std::size_t c) {
                 for (std::size_t r = 0; r < validRow; ++r) {
-                    const std::size_t idx = GetTileElementOffset<tile_shape>(r, c);
-                    dst[idx] = std::max(src0[idx], src1[idx]);
+                    dst[GetTileElementOffset<TileDataDst>(r, c)] = std::max(
+                        src0[GetTileElementOffset<TileDataSrc0>(r, c)], src1[GetTileElementOffset<TileDataSrc1>(r, c)]);
                 }
             });
         }
     }
 }
 
-template <typename tile_shape>
-PTO_INTERNAL void TMAX_IMPL(tile_shape &dst, tile_shape &src0, tile_shape &src1)
+template <typename TileDataDst, typename TileDataSrc0, typename TileDataSrc1>
+PTO_INTERNAL void TMAX_IMPL(TileDataDst &dst, TileDataSrc0 &src0, TileDataSrc1 &src1)
 {
     unsigned row = dst.GetValidRow();
     unsigned col = dst.GetValidCol();
-    constexpr unsigned stride = tile_shape::RowStride;
-    TMAX_Impl<tile_shape, stride>(dst.data(), src0.data(), src1.data(), row, col);
+    PTO_ASSERT(src0.GetValidRow() == row && src0.GetValidCol() == col,
+               "Fix: TMAX input tile src0 valid shape mismatch with output tile dst shape.");
+    PTO_ASSERT(src1.GetValidRow() == row && src1.GetValidCol() == col,
+               "Fix: TMAX input tile src1 valid shape mismatch with output tile dst shape.");
+    TMAX_Impl<TileDataDst, TileDataSrc0, TileDataSrc1>(dst.data(), src0.data(), src1.data(), row, col);
 }
 } // namespace pto
 #endif

--- a/include/pto/cpu/TMul.hpp
+++ b/include/pto/cpu/TMul.hpp
@@ -16,56 +16,64 @@ See LICENSE in the root of the software repository for the full text of the Lice
 #include "pto/cpu/parallel.hpp"
 
 namespace pto {
-template <typename tile_shape, int stride>
-void TMul_Impl(typename tile_shape::TileDType dst, typename tile_shape::TileDType src0,
-               typename tile_shape::TileDType src1, unsigned validRow, unsigned validCol)
+template <typename TileDataDst, typename TileDataSrc0, typename TileDataSrc1>
+void TMul_Impl(typename TileDataDst::TileDType dst, typename TileDataSrc0::TileDType src0,
+               typename TileDataSrc1::TileDType src1, unsigned validRow, unsigned validCol)
 {
-    if constexpr (tile_shape::SFractal == SLayout::NoneBox) {
-        if constexpr (tile_shape::isRowMajor) {
+    static_assert(std::is_same_v<typename TileDataDst::DType, typename TileDataSrc0::DType> &&
+                      std::is_same_v<typename TileDataDst::DType, typename TileDataSrc1::DType>,
+                  "Fix: TMUL the data type of dst must be consistent with src0 and src1.");
+    if constexpr (TileDataDst::SFractal == SLayout::NoneBox) {
+        if constexpr (TileDataDst::isRowMajor) {
             cpu::parallel_for_rows(validRow, validCol, [&](std::size_t r) {
-                const std::size_t base = r * tile_shape::Cols;
+                const std::size_t dstBase = r * TileDataDst::Cols;
+                const std::size_t src0Base = r * TileDataSrc0::Cols;
+                const std::size_t src1Base = r * TileDataSrc1::Cols;
                 PTO_CPU_VECTORIZE_LOOP
                 for (std::size_t c = 0; c < validCol; ++c) {
-                    const std::size_t idx = base + c;
-                    dst[idx] = src0[idx] * src1[idx];
+                    dst[dstBase + c] = src0[src0Base + c] * src1[src1Base + c];
                 }
             });
         } else {
             cpu::parallel_for_rows(validCol, validRow, [&](std::size_t c) {
-                const std::size_t base = c * tile_shape::Rows;
+                const std::size_t dstBase = c * TileDataDst::Rows;
+                const std::size_t src0Base = c * TileDataSrc0::Rows;
+                const std::size_t src1Base = c * TileDataSrc1::Rows;
                 PTO_CPU_VECTORIZE_LOOP
                 for (std::size_t r = 0; r < validRow; ++r) {
-                    const std::size_t idx = base + r;
-                    dst[idx] = src0[idx] * src1[idx];
+                    dst[dstBase + r] = src0[src0Base + r] * src1[src1Base + r];
                 }
             });
         }
     } else {
-        if constexpr (tile_shape::isRowMajor) {
+        if constexpr (TileDataDst::isRowMajor) {
             cpu::parallel_for_rows(validRow, validCol, [&](std::size_t r) {
                 for (std::size_t c = 0; c < validCol; ++c) {
-                    const std::size_t idx = GetTileElementOffset<tile_shape>(r, c);
-                    dst[idx] = src0[idx] * src1[idx];
+                    dst[GetTileElementOffset<TileDataDst>(r, c)] =
+                        src0[GetTileElementOffset<TileDataSrc0>(r, c)] * src1[GetTileElementOffset<TileDataSrc1>(r, c)];
                 }
             });
         } else {
             cpu::parallel_for_rows(validCol, validRow, [&](std::size_t c) {
                 for (std::size_t r = 0; r < validRow; ++r) {
-                    const std::size_t idx = GetTileElementOffset<tile_shape>(r, c);
-                    dst[idx] = src0[idx] * src1[idx];
+                    dst[GetTileElementOffset<TileDataDst>(r, c)] =
+                        src0[GetTileElementOffset<TileDataSrc0>(r, c)] * src1[GetTileElementOffset<TileDataSrc1>(r, c)];
                 }
             });
         }
     }
 }
 
-template <typename tile_shape>
-PTO_INTERNAL void TMUL_IMPL(tile_shape &dst, tile_shape &src0, tile_shape &src1)
+template <typename TileDataDst, typename TileDataSrc0, typename TileDataSrc1>
+PTO_INTERNAL void TMUL_IMPL(TileDataDst &dst, TileDataSrc0 &src0, TileDataSrc1 &src1)
 {
     unsigned row = dst.GetValidRow();
     unsigned col = dst.GetValidCol();
-    constexpr unsigned stride = tile_shape::RowStride;
-    TMul_Impl<tile_shape, stride>(dst.data(), src0.data(), src1.data(), row, col);
+    PTO_ASSERT(src0.GetValidRow() == row && src0.GetValidCol() == col,
+               "Fix: TMUL input tile src0 valid shape mismatch with output tile dst shape.");
+    PTO_ASSERT(src1.GetValidRow() == row && src1.GetValidCol() == col,
+               "Fix: TMUL input tile src1 valid shape mismatch with output tile dst shape.");
+    TMul_Impl<TileDataDst, TileDataSrc0, TileDataSrc1>(dst.data(), src0.data(), src1.data(), row, col);
 }
 } // namespace pto
 #endif

--- a/include/pto/cpu/TPrint.hpp
+++ b/include/pto/cpu/TPrint.hpp
@@ -10,30 +10,64 @@ See LICENSE in the root of the software repository for the full text of the Lice
 #ifndef TPRINT_CPU_HPP
 #define TPRINT_CPU_HPP
 
+#include <iomanip>
 #include <iostream>
 #include <pto/common/pto_tile.hpp>
 #include "pto/cpu/tile_offsets.hpp"
 
 namespace pto {
+
 template <typename T>
+constexpr bool is_half_type_v = std::is_same_v<T, half> || std::is_same_v<T, bfloat16_t>;
+
+template <PrintFormat Format, typename T>
+PTO_INTERNAL void PrintValue(std::ostream &os, T val)
+{
+    if constexpr (std::is_floating_point_v<T> || is_half_type_v<T>) {
+        if constexpr (Format == PrintFormat::Width8_Precision4) {
+            os << std::setw(8) << std::fixed << std::setprecision(4) << static_cast<float>(val);
+        } else if constexpr (Format == PrintFormat::Width8_Precision2) {
+            os << std::setw(8) << std::fixed << std::setprecision(2) << static_cast<float>(val);
+        } else if constexpr (Format == PrintFormat::Width10_Precision6) {
+            os << std::setw(10) << std::fixed << std::setprecision(6) << static_cast<float>(val);
+        }
+    } else if constexpr (std::is_signed_v<T>) {
+        if constexpr (Format == PrintFormat::Width10_Precision6) {
+            os << std::setw(10) << static_cast<int>(val);
+        } else {
+            os << std::setw(8) << static_cast<int>(val);
+        }
+    } else if constexpr (std::is_unsigned_v<T>) {
+        if constexpr (Format == PrintFormat::Width10_Precision6) {
+            os << std::setw(10) << static_cast<unsigned int>(val);
+        } else {
+            os << std::setw(8) << static_cast<unsigned int>(val);
+        }
+    } else {
+        os << val;
+    }
+}
+
+template <PrintFormat Format = PrintFormat::Width8_Precision4, typename T>
 PTO_INTERNAL void TPRINT_IMPL(T &src)
 {
+    using DType = typename T::DType;
     std::cout << "TPRINT " << src.GetValidRow() << "x" << src.GetValidCol() << '\n';
     for (unsigned r = 0; r < src.GetValidRow(); ++r) {
         for (unsigned c = 0; c < src.GetValidCol(); ++c) {
             if (c != 0) {
                 std::cout << ' ';
             }
-            std::cout << src.data()[GetTileElementOffset<T>(r, c)];
+            PrintValue<Format>(std::cout, static_cast<DType>(src.data()[GetTileElementOffset<T>(r, c)]));
         }
         std::cout << '\n';
     }
 }
 
-template <typename TileData, typename GlobalData>
+template <PrintFormat Format = PrintFormat::Width8_Precision4, typename TileData, typename GlobalData>
 PTO_INTERNAL void TPRINT_IMPL(TileData &src, GlobalData &tmp)
 {
-    TPRINT_IMPL(src);
+    TPRINT_IMPL<Format>(src);
 }
 
 } // namespace pto

--- a/include/pto/cpu/TSub.hpp
+++ b/include/pto/cpu/TSub.hpp
@@ -16,56 +16,64 @@ See LICENSE in the root of the software repository for the full text of the Lice
 #include "pto/cpu/parallel.hpp"
 
 namespace pto {
-template <typename tile_shape, int stride>
-void TSub_Impl(typename tile_shape::TileDType dst, typename tile_shape::TileDType src0,
-               typename tile_shape::TileDType src1, unsigned validRow, unsigned validCol)
+template <typename TileDataDst, typename TileDataSrc0, typename TileDataSrc1>
+void TSub_Impl(typename TileDataDst::TileDType dst, typename TileDataSrc0::TileDType src0,
+               typename TileDataSrc1::TileDType src1, unsigned validRow, unsigned validCol)
 {
-    if constexpr (tile_shape::SFractal == SLayout::NoneBox) {
-        if constexpr (tile_shape::isRowMajor) {
+    static_assert(std::is_same_v<typename TileDataDst::DType, typename TileDataSrc0::DType> &&
+                      std::is_same_v<typename TileDataDst::DType, typename TileDataSrc1::DType>,
+                  "Fix: TSUB the data type of dst must be consistent with src0 and src1.");
+    if constexpr (TileDataDst::SFractal == SLayout::NoneBox) {
+        if constexpr (TileDataDst::isRowMajor) {
             cpu::parallel_for_rows(validRow, validCol, [&](std::size_t r) {
-                const std::size_t base = r * tile_shape::Cols;
+                const std::size_t dstBase = r * TileDataDst::Cols;
+                const std::size_t src0Base = r * TileDataSrc0::Cols;
+                const std::size_t src1Base = r * TileDataSrc1::Cols;
                 PTO_CPU_VECTORIZE_LOOP
                 for (std::size_t c = 0; c < validCol; ++c) {
-                    const std::size_t idx = base + c;
-                    dst[idx] = src0[idx] - src1[idx];
+                    dst[dstBase + c] = src0[src0Base + c] - src1[src1Base + c];
                 }
             });
         } else {
             cpu::parallel_for_rows(validCol, validRow, [&](std::size_t c) {
-                const std::size_t base = c * tile_shape::Rows;
+                const std::size_t dstBase = c * TileDataDst::Rows;
+                const std::size_t src0Base = c * TileDataSrc0::Rows;
+                const std::size_t src1Base = c * TileDataSrc1::Rows;
                 PTO_CPU_VECTORIZE_LOOP
                 for (std::size_t r = 0; r < validRow; ++r) {
-                    const std::size_t idx = base + r;
-                    dst[idx] = src0[idx] - src1[idx];
+                    dst[dstBase + r] = src0[src0Base + r] - src1[src1Base + r];
                 }
             });
         }
     } else {
-        if constexpr (tile_shape::isRowMajor) {
+        if constexpr (TileDataDst::isRowMajor) {
             cpu::parallel_for_rows(validRow, validCol, [&](std::size_t r) {
                 for (std::size_t c = 0; c < validCol; ++c) {
-                    const std::size_t idx = GetTileElementOffset<tile_shape>(r, c);
-                    dst[idx] = src0[idx] - src1[idx];
+                    dst[GetTileElementOffset<TileDataDst>(r, c)] =
+                        src0[GetTileElementOffset<TileDataSrc0>(r, c)] - src1[GetTileElementOffset<TileDataSrc1>(r, c)];
                 }
             });
         } else {
             cpu::parallel_for_rows(validCol, validRow, [&](std::size_t c) {
                 for (std::size_t r = 0; r < validRow; ++r) {
-                    const std::size_t idx = GetTileElementOffset<tile_shape>(r, c);
-                    dst[idx] = src0[idx] - src1[idx];
+                    dst[GetTileElementOffset<TileDataDst>(r, c)] =
+                        src0[GetTileElementOffset<TileDataSrc0>(r, c)] - src1[GetTileElementOffset<TileDataSrc1>(r, c)];
                 }
             });
         }
     }
 }
 
-template <typename tile_shape>
-PTO_INTERNAL void TSUB_IMPL(tile_shape &dst, tile_shape &src0, tile_shape &src1)
+template <typename TileDataDst, typename TileDataSrc0, typename TileDataSrc1>
+PTO_INTERNAL void TSUB_IMPL(TileDataDst &dst, TileDataSrc0 &src0, TileDataSrc1 &src1)
 {
     unsigned row = dst.GetValidRow();
     unsigned col = dst.GetValidCol();
-    constexpr unsigned stride = tile_shape::RowStride;
-    TSub_Impl<tile_shape, stride>(dst.data(), src0.data(), src1.data(), row, col);
+    PTO_ASSERT(src0.GetValidRow() == row && src0.GetValidCol() == col,
+               "Fix: TSUB input tile src0 valid shape mismatch with output tile dst shape.");
+    PTO_ASSERT(src1.GetValidRow() == row && src1.GetValidCol() == col,
+               "Fix: TSUB input tile src1 valid shape mismatch with output tile dst shape.");
+    TSub_Impl<TileDataDst, TileDataSrc0, TileDataSrc1>(dst.data(), src0.data(), src1.data(), row, col);
 }
 } // namespace pto
 #endif


### PR DESCRIPTION
## Summary
- Generalize TAdd, TSub, TMul, TDiv, TMax from single `tile_shape` template parameter to separate `TileDataDst`/`TileDataSrc0`/`TileDataSrc1`, allowing dst and src operands to have different tile layouts (Rows/Cols/RowStride); add `static_assert` to enforce matching data types across operands
- Compute per-operand base offsets (`dstBase`, `src0Base`, `src1Base`) instead of a shared index, enabling correct element addressing when tile shapes differ
- Remove unused `stride` template parameter from TDiv, TMul, TMax, TSub impls
- Add tile-typed `TCMPS_IMPL` overload accepting `TileDataSrc1` instead of scalar, with per-element comparison and bit-packing into uint8 output
- Add `AccPhase Phase` template parameter (defaulting to `AccPhase::Unspecified`) to `TMATMUL_IMPL`, `TMATMUL_ACC_IMPL`, and `TMATMUL_BIAS_IMPL`; add 3-arg in-place `TMATMUL_ACC_IMPL` overload
- Add `PrintFormat Format` template parameter to `TPRINT_IMPL` (defaulting to `PrintFormat::Width8_Precision4`)
- Fix `TEXPANDS_IMPL` to accept scalar `src` by value instead of by reference

Closes #113