### PR TITLE
Add single-device 2x2 multi-block FFN GridPipe demo on A2/A3

### DIFF
--- a/include/pto/common/grid_pipe.hpp
+++ b/include/pto/common/grid_pipe.hpp
@@ -1,0 +1,206 @@
+/**
+Copyright (c) 2026 Huawei Technologies Co., Ltd.
+This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+CANN Open Software License Agreement Version 2.0 (the "License").
+Please refer to the License for details. You may not use this file except in compliance with the License.
+THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+See LICENSE in the root of the software repository for the full text of the License.
+*/
+
+// GridPipe: neighbor-core FIFO communication primitives.
+//
+// This is the proposal-level abstraction described in
+// distributed-ffn-grid-tpush-tpop_zh-SPR_WFE.md.  On LPU WSE silicon the
+// operations defined here are expected to lower to "SPR write + WFE wait +
+// existing TMOV" sequences (see design doc section 5.3).  On A2/A3 we provide
+// a mock backend that emulates the SPR+WFE semantics with HCCL shared windows
+// and GM atomic flags; see include/pto/npu/a2a3/GridTPush.hpp.
+//
+// Compiler-visible static constraints are enforced via static_assert inside
+// the intrinsic overloads in pto_instr.hpp.
+
+#ifndef PTO_GRID_PIPE_HPP
+#define PTO_GRID_PIPE_HPP
+
+#include <cstdint>
+#include <type_traits>
+
+#include <pto/common/arch_macro.hpp>
+#include <pto/common/type.hpp>  // for AICORE (callable from both host and aicore contexts)
+
+// Forward declaration: provided by the target backend (cpu_stub.hpp on
+// CPU sim builds, CCE intrinsic / runtime header on A2/A3 NPU builds).
+// GetGridCoord below uses this; we declare it here so grid_pipe.hpp can be
+// included before any backend headers without triggering an undeclared name.
+uint32_t get_block_idx();
+
+namespace pto {
+
+// ---------------------------------------------------------------------------
+// 2D mesh coordinates and shape (design doc section 2).
+// ---------------------------------------------------------------------------
+struct GridShape {
+    int gridRows = 0;  // N
+    int gridCols = 0;  // M
+};
+
+struct GridCoord {
+    int row = 0;  // 0 .. gridRows-1
+    int col = 0;  // 0 .. gridCols-1
+};
+
+// ---------------------------------------------------------------------------
+// Direction enum (design doc section 3.1).  Strongly-typed to avoid clashing
+// with the cluster-local pto::Direction enum used by TPipe.
+// ---------------------------------------------------------------------------
+enum class GridDirection : uint8_t {
+    SOURCE = 0,  // GM/Host/Runtime injection.  Only valid for TPOP.
+    NORTH  = 1,  // row -> row-1
+    EAST   = 2,  // col -> col+1
+    WEST   = 3,  // col -> col-1
+};
+
+inline constexpr int kGridDirectionCount = 4;
+
+AICORE constexpr int GridDirectionIndex(GridDirection d)
+{
+    return static_cast<int>(d);
+}
+
+// ---------------------------------------------------------------------------
+// GridPipe<TileT, SlotBytes, SlotCount>
+//
+// One instance describes the FIFO state for a single logical channel that the
+// current core uses; each (core, direction) pair has its own ring buffer with
+// independent prod/cons indices, ready/free signals, and slot region.  Fields
+// are populated by the runtime during InitGridPipe and are read by the lower
+// half (compiler-generated intrinsic expansions).
+// ---------------------------------------------------------------------------
+template <typename TileT_, int SlotBytes_, int SlotCount_>
+struct GridPipe {
+    static_assert(SlotCount_ > 0, "GridPipe requires SlotCount > 0");
+    static_assert(SlotBytes_ > 0, "GridPipe requires SlotBytes > 0");
+
+    using TileType = TileT_;
+    static constexpr int SlotBytes  = SlotBytes_;
+    static constexpr int SlotCount  = SlotCount_;
+
+    // Shape + coord cached from runtime (design doc 2.1 / 2.2).
+    GridShape shape{};
+    GridCoord coord{};
+
+    // Per-direction state.  Index by GridDirectionIndex(dir).
+    __gm__ uint8_t  *slotBase[kGridDirectionCount]   = {nullptr};
+    __gm__ uint32_t *readyFlags[kGridDirectionCount] = {nullptr};
+    __gm__ uint32_t *freeFlags[kGridDirectionCount]  = {nullptr};
+    uint32_t         prodIndex[kGridDirectionCount]  = {0};
+    uint32_t         consIndex[kGridDirectionCount]  = {0};
+
+    // Opaque runtime pointer used by the A2/A3 backend to resolve cross-rank
+    // addresses (HCCL device context).  Other targets may reinterpret.
+    __gm__ void *runtimeCtx = nullptr;
+
+    // Stable logical id used for runtime telemetry / mock SPR_PIPE_ID_<DIR>.
+    uint32_t pipeId = 0;
+};
+
+// ---------------------------------------------------------------------------
+// SFINAE marker: lets pto_instr.hpp's TPUSH/TPOP grid overloads disambiguate
+// against the existing TPipe overloads without ambiguity.
+// ---------------------------------------------------------------------------
+template <typename T>
+struct is_grid_pipe : std::false_type {};
+
+template <typename TileT, int SlotBytes, int SlotCount>
+struct is_grid_pipe<GridPipe<TileT, SlotBytes, SlotCount>> : std::true_type {};
+
+template <typename T>
+inline constexpr bool is_grid_pipe_v = is_grid_pipe<std::remove_reference_t<T>>::value;
+
+// ---------------------------------------------------------------------------
+// Coordinate bootstrap (design doc 2.1).  Row-major mapping from launcher's
+// block_idx to (row, col).  AICORE-qualified because it calls get_block_idx(),
+// which is a device intrinsic and has no host implementation.
+// ---------------------------------------------------------------------------
+AICORE inline GridCoord GetGridCoord(GridShape shape)
+{
+    int blockIdx = static_cast<int>(get_block_idx());
+    return GridCoord{ blockIdx / shape.gridCols, blockIdx % shape.gridCols };
+}
+
+AICORE inline int RankFromCoord(GridCoord coord, GridShape shape)
+{
+    return coord.row * shape.gridCols + coord.col;
+}
+
+// ---------------------------------------------------------------------------
+// Compile-time / run-time direction validity (design doc 2.3).
+// ---------------------------------------------------------------------------
+AICORE constexpr bool CanPush(GridDirection dir, GridCoord c, GridShape s)
+{
+    switch (dir) {
+        case GridDirection::NORTH:  return c.row > 0;
+        case GridDirection::EAST:   return c.col + 1 < s.gridCols;
+        case GridDirection::WEST:   return c.col > 0;
+        case GridDirection::SOURCE: return false;  // Never legal to push to SOURCE.
+    }
+    return false;
+}
+
+AICORE constexpr bool CanPop(GridDirection dir, GridCoord c, GridShape s)
+{
+    switch (dir) {
+        case GridDirection::NORTH:  return c.row + 1 < s.gridRows;
+        case GridDirection::EAST:   return c.col > 0;
+        case GridDirection::WEST:   return c.col + 1 < s.gridCols;
+        case GridDirection::SOURCE: return true;
+    }
+    return false;
+}
+
+AICORE constexpr GridCoord NeighborForPush(GridDirection dir, GridCoord c)
+{
+    switch (dir) {
+        case GridDirection::NORTH:  return {c.row - 1, c.col};
+        case GridDirection::EAST:   return {c.row, c.col + 1};
+        case GridDirection::WEST:   return {c.row, c.col - 1};
+        case GridDirection::SOURCE: return c;  // Unused; static_assert blocks TPUSH<SOURCE>.
+    }
+    return c;
+}
+
+AICORE constexpr GridCoord NeighborForPop(GridDirection dir, GridCoord c)
+{
+    switch (dir) {
+        case GridDirection::NORTH:  return {c.row + 1, c.col};
+        case GridDirection::EAST:   return {c.row, c.col - 1};
+        case GridDirection::WEST:   return {c.row, c.col + 1};
+        case GridDirection::SOURCE: return c;  // Bound by runtime to source queue.
+    }
+    return c;
+}
+
+inline constexpr int kInvalidRank = -1;
+
+AICORE constexpr int NeighborRankForPush(GridDirection dir, GridCoord c, GridShape s)
+{
+    if (!CanPush(dir, c, s)) {
+        return kInvalidRank;
+    }
+    GridCoord n = NeighborForPush(dir, c);
+    return n.row * s.gridCols + n.col;
+}
+
+AICORE constexpr int NeighborRankForPop(GridDirection dir, GridCoord c, GridShape s)
+{
+    if (!CanPop(dir, c, s)) {
+        return kInvalidRank;
+    }
+    GridCoord n = NeighborForPop(dir, c);
+    return n.row * s.gridCols + n.col;
+}
+
+}  // namespace pto
+
+#endif  // PTO_GRID_PIPE_HPP

--- a/include/pto/common/grid_pipe_mock_spr.hpp
+++ b/include/pto/common/grid_pipe_mock_spr.hpp
@@ -1,0 +1,220 @@
+/**
+Copyright (c) 2026 Huawei Technologies Co., Ltd.
+This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+CANN Open Software License Agreement Version 2.0 (the "License").
+Please refer to the License for details. You may not use this file except in compliance with the License.
+THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+See LICENSE in the root of the software repository for the full text of the License.
+*/
+
+// Mock layer that stands in for LPU WSE SPR + WFE primitives.
+//
+// Design doc section 5 defines the LPU WSE GridPipe lowering as:
+//   - mtspr SPR_RDY_<DIR>    -> cross-core SPR write, wakes neighbor WFE
+//   - mtspr SPR_FREE_<DIR>   -> cross-core SPR write, wakes producer WFE
+//   - mfspr SPR_RDY_<DIR>    -> read local mirror of ready flag
+//   - wfe   SPR_RDY_<DIR>, N -> block until ready >= N
+//   - wfe   SPR_FREE_<DIR>,N -> block until free  >= N
+//
+// On A2/A3 silicon there is no native cross-core mesh SPR + event line.  The
+// mocks below emulate the contract via GM atomic flags + spin-wait, so the
+// GridPipe semantics can be exercised on real A2/A3 boards while staying
+// trivially swappable for a real LPU WSE SPR backend later.
+//
+// Each MOCK_* function carries a comment naming the corresponding LPU WSE
+// pseudo-asm line from design doc section 5.3, so `grep -n "LPU WSE:"` returns
+// the substitution sites.
+
+#ifndef PTO_GRID_PIPE_MOCK_SPR_HPP
+#define PTO_GRID_PIPE_MOCK_SPR_HPP
+
+#include <cstdint>
+
+#include <pto/common/arch_macro.hpp>
+#include <pto/common/grid_pipe.hpp>
+
+namespace pto {
+namespace grid_mock {
+
+#ifndef PTO_GRID_MOCK_WFE_MAX_SPINS
+#define PTO_GRID_MOCK_WFE_MAX_SPINS 100000000U
+#endif
+
+inline constexpr uint32_t kDefaultWfeMaxSpins = PTO_GRID_MOCK_WFE_MAX_SPINS;
+inline constexpr uint32_t kFaultFlagWordOffset = 8;
+
+// MOCK: design doc 5.3 producer step (4), consumer step (4).
+//
+// LPU WSE: mtspr SPR_RDY_<DIR>, newValue      (cross-core, wakes neighbor WFE)
+// LPU WSE: mtspr SPR_FREE_<DIR>, newValue     (cross-core, wakes producer WFE)
+//
+// A2/A3 mock: producer / consumer holds a pointer into the *neighbor's* GM
+// window (resolved by HcclRemotePtr at runtime); we write the new monotonic
+// counter into that remote location.  Pairing read happens via MockWfe* below.
+//
+// volatile cast prevents the compiler from caching the write.  Cross-rank
+// visibility on A2/A3 requires an explicit dsb(DSB_DDR) + dcci pair around the
+// store: AICORE caches are not coherent between cores, so without the dcci the
+// pairing MockWfe spin on the remote rank may never observe the write.  This
+// matches the SetLocalSummaryReady pattern in ready_queue.hpp (allgather_gemm).
+inline AICORE void MockMtsprReady(__gm__ uint32_t *remoteFlag, uint32_t newValue)
+{
+    if (remoteFlag != nullptr) {
+        volatile __gm__ uint32_t *ptr = reinterpret_cast<volatile __gm__ uint32_t *>(remoteFlag);
+        // Match the canonical TNotify Set pattern: pre-invalidate, store,
+        // post-invalidate, dsb(DSB_DDR).  Compiler barriers prevent reordering.
+        __asm__ __volatile__("" ::: "memory");
+        dcci(reinterpret_cast<__gm__ void *>(const_cast<__gm__ uint32_t *>(ptr)), SINGLE_CACHE_LINE);
+        __asm__ __volatile__("" ::: "memory");
+        *ptr = newValue;
+        __asm__ __volatile__("" ::: "memory");
+        dcci(reinterpret_cast<__gm__ void *>(const_cast<__gm__ uint32_t *>(ptr)), SINGLE_CACHE_LINE);
+        __asm__ __volatile__("" ::: "memory");
+        dsb(DSB_DDR);
+    }
+}
+
+inline AICORE void MockMtsprFree(__gm__ uint32_t *remoteFlag, uint32_t newValue)
+{
+    if (remoteFlag != nullptr) {
+        volatile __gm__ uint32_t *ptr = reinterpret_cast<volatile __gm__ uint32_t *>(remoteFlag);
+        __asm__ __volatile__("" ::: "memory");
+        dcci(reinterpret_cast<__gm__ void *>(const_cast<__gm__ uint32_t *>(ptr)), SINGLE_CACHE_LINE);
+        __asm__ __volatile__("" ::: "memory");
+        *ptr = newValue;
+        __asm__ __volatile__("" ::: "memory");
+        dcci(reinterpret_cast<__gm__ void *>(const_cast<__gm__ uint32_t *>(ptr)), SINGLE_CACHE_LINE);
+        __asm__ __volatile__("" ::: "memory");
+        dsb(DSB_DDR);
+    }
+}
+
+// MOCK: design doc 5.3 producer step (1), consumer step (1).
+//
+// LPU WSE: mfspr r_ready, SPR_RDY_<DIR>
+// LPU WSE: mfspr r_free,  SPR_FREE_<DIR>
+//
+// A2/A3 mock: volatile read of the local mirror of the flag.
+inline AICORE uint32_t MockMfspr(__gm__ uint32_t *localFlag)
+{
+    if (localFlag == nullptr) {
+        return 0;
+    }
+    return *reinterpret_cast<volatile __gm__ uint32_t *>(localFlag);
+}
+
+// MOCK: design doc 5.3 producer step (1) wait, consumer step (1) wait.
+//
+// LPU WSE: wfe SPR_RDY_<DIR>,  threshold      (block until SPR >= threshold)
+// LPU WSE: wfe SPR_FREE_<DIR>, threshold
+//
+// A2/A3 mock: spin-poll the GM flag with `dcci` each iteration to invalidate
+// the local cache line so the next load fetches from DDR.  Without the dcci,
+// the AICORE may cache the original 0 indefinitely and never observe the
+// producer's write (cross-core caches are not auto-coherent on A2/A3).
+inline AICORE bool MockTryWfeReady(__gm__ uint32_t *localFlag, uint32_t threshold,
+                                   uint32_t maxSpins = kDefaultWfeMaxSpins)
+{
+    if (localFlag == nullptr) {
+        return true;
+    }
+    volatile __gm__ uint32_t *p = reinterpret_cast<volatile __gm__ uint32_t *>(localFlag);
+    uint32_t spin = 0;
+    constexpr uint32_t kFenceInterval = 64;
+    while (true) {
+        __asm__ __volatile__("" ::: "memory");
+        dcci(reinterpret_cast<__gm__ void *>(const_cast<__gm__ uint32_t *>(p)), SINGLE_CACHE_LINE);
+        __asm__ __volatile__("" ::: "memory");
+        if (*p >= threshold) {
+            return true;
+        }
+        if (maxSpins != 0 && spin >= maxSpins) {
+            return false;
+        }
+        if ((++spin % kFenceInterval) == 0) {
+            pipe_barrier(PIPE_ALL);
+        }
+    }
+}
+
+inline AICORE bool MockTryWfeFree(__gm__ uint32_t *localFlag, uint32_t threshold,
+                                  uint32_t maxSpins = kDefaultWfeMaxSpins)
+{
+    if (localFlag == nullptr) {
+        return true;
+    }
+    volatile __gm__ uint32_t *p = reinterpret_cast<volatile __gm__ uint32_t *>(localFlag);
+    uint32_t spin = 0;
+    constexpr uint32_t kFenceInterval = 64;
+    while (true) {
+        __asm__ __volatile__("" ::: "memory");
+        dcci(reinterpret_cast<__gm__ void *>(const_cast<__gm__ uint32_t *>(p)), SINGLE_CACHE_LINE);
+        __asm__ __volatile__("" ::: "memory");
+        if (*p >= threshold) {
+            return true;
+        }
+        if (maxSpins != 0 && spin >= maxSpins) {
+            return false;
+        }
+        if ((++spin % kFenceInterval) == 0) {
+            pipe_barrier(PIPE_ALL);
+        }
+    }
+}
+
+inline AICORE void MockWfeReady(__gm__ uint32_t *localFlag, uint32_t threshold)
+{
+    (void)MockTryWfeReady(localFlag, threshold, 0);
+}
+
+inline AICORE void MockWfeFree(__gm__ uint32_t *localFlag, uint32_t threshold)
+{
+    (void)MockTryWfeFree(localFlag, threshold, 0);
+}
+
+inline AICORE void MockSetFault(__gm__ uint32_t *faultFlag, uint32_t faultCode)
+{
+    if (faultFlag != nullptr) {
+        volatile __gm__ uint32_t *ptr = reinterpret_cast<volatile __gm__ uint32_t *>(faultFlag);
+        __asm__ __volatile__("" ::: "memory");
+        *ptr = faultCode;
+        __asm__ __volatile__("" ::: "memory");
+        dcci(reinterpret_cast<__gm__ void *>(const_cast<__gm__ uint32_t *>(ptr)), SINGLE_CACHE_LINE);
+        dsb(DSB_DDR);
+    }
+}
+
+// MOCK: design doc 5.4 SPR_BOUNDARY_MASK fault.
+//
+// LPU WSE: writing SPR_RDY_<DIR> when SPR_BOUNDARY_MASK has that direction
+// disabled triggers a hardware fault / squash.
+//
+// A2/A3 mock: explicit early-exit + sentinel write so the host can detect the
+// out-of-bound attempt.  Real boards will raise a fault; here we trap softly
+// by writing a sentinel and aborting the kernel branch.  The host launcher
+// inspects a "fault sentinel" GM word after each kernel and fails the run.
+inline AICORE void MockBoundaryFault(__gm__ uint32_t *faultSentinel, uint32_t faultCode)
+{
+    if (faultSentinel != nullptr) {
+        *reinterpret_cast<volatile __gm__ uint32_t *>(faultSentinel) = faultCode;
+    }
+    // Best-effort halt of the current kernel branch.  Real silicon will fault
+    // here; on A2/A3 we just stop emitting further GridPipe ops in this branch.
+}
+
+// Fault codes mirror SPR_BOUNDARY_MASK fields (design doc section 5.2).
+inline constexpr uint32_t kFaultPushNorth  = 0x101;
+inline constexpr uint32_t kFaultPushEast   = 0x102;
+inline constexpr uint32_t kFaultPushWest   = 0x103;
+inline constexpr uint32_t kFaultPushSource = 0x104;  // Always illegal.
+inline constexpr uint32_t kFaultPopNorth   = 0x201;
+inline constexpr uint32_t kFaultPopEast    = 0x202;
+inline constexpr uint32_t kFaultPopWest    = 0x203;
+inline constexpr uint32_t kFaultWaitReadyTimeout = 0x301;
+inline constexpr uint32_t kFaultWaitFreeTimeout  = 0x302;
+
+}  // namespace grid_mock
+}  // namespace pto
+
+#endif  // PTO_GRID_PIPE_MOCK_SPR_HPP

--- a/include/pto/common/pto_instr.hpp
+++ b/include/pto/common/pto_instr.hpp
@@ -14,6 +14,7 @@ See LICENSE in the root of the software repository for the full text of the Lice
 #include "pto/common/debug.h"
 #include "pto/common/event.hpp"
 #include "pto/common/fifo.hpp"
+#include "pto/common/grid_pipe.hpp"
 #include "pto/common/tassign_check.hpp"
 #include "pto/common/pto_instr_impl.hpp"
 #if !defined(__COSTMODEL) && !defined(PTO_COMM_NOT_SUPPORTED)
@@ -1991,6 +1992,48 @@ PTO_INST RecordEvent TGET_SCALE_ADDR(TileDataOut &dst, TileDataIn &src, WaitEven
 {
     TSYNC(events...);
     MAP_INSTR_IMPL(TGET_SCALE_ADDR, dst, src);
+    return {};
+}
+
+// ---------------------------------------------------------------------------
+// GridPipe TPUSH / TPOP overloads (design doc section 4.1, "neighbor-core
+// FIFO" form).  These coexist with the cluster-local TPipe overloads above:
+// SFINAE on is_grid_pipe_v keeps overload resolution unambiguous.  The
+// `Direction` non-type template parameter is constant-folded by the compiler,
+// matching design doc section 4.2's requirement that direction be a constant
+// at lowering time.
+// ---------------------------------------------------------------------------
+
+template <pto::GridDirection Direction, typename Pipe, typename TileProd,
+          std::enable_if_t<is_grid_pipe_v<Pipe>, int> = 0, typename... WaitEvents>
+PTO_INST RecordEvent TPUSH(Pipe &pipe, TileProd &tile, WaitEvents &...events)
+{
+    static_assert(Direction != pto::GridDirection::SOURCE,
+                  "GridPipe TPUSH<SOURCE> is illegal (design doc section 4.3): "
+                  "SOURCE is only valid for TPOP.");
+#if defined(PTO_NPU_ARCH_A2A3) || defined(__CPU_SIM)
+    TSYNC(events...);
+    GRID_TPUSH_IMPL<Direction, Pipe, TileProd>(pipe, tile);
+#else
+    static_assert(sizeof(Pipe) == 0,
+                  "GridPipe TPUSH not supported on this target profile "
+                  "(design doc section 5.4 forbids silent GM fallback).");
+#endif
+    return {};
+}
+
+template <pto::GridDirection Direction, typename Pipe, typename TileCons,
+          std::enable_if_t<is_grid_pipe_v<Pipe>, int> = 0, typename... WaitEvents>
+PTO_INST RecordEvent TPOP(Pipe &pipe, TileCons &tile, WaitEvents &...events)
+{
+#if defined(PTO_NPU_ARCH_A2A3) || defined(__CPU_SIM)
+    TSYNC(events...);
+    GRID_TPOP_IMPL<Direction, Pipe, TileCons>(pipe, tile);
+#else
+    static_assert(sizeof(Pipe) == 0,
+                  "GridPipe TPOP not supported on this target profile "
+                  "(design doc section 5.4 forbids silent GM fallback).");
+#endif
     return {};
 }
 

--- a/include/pto/common/pto_instr_impl.hpp
+++ b/include/pto/common/pto_instr_impl.hpp
@@ -158,6 +158,9 @@ See LICENSE in the root of the software repository for the full text of the Lice
 #include "pto/npu/a2a3/TAlloc.hpp"
 #include "pto/npu/a2a3/TFree.hpp"
 #include "pto/npu/a2a3/TColReduceIdx.hpp"
+#include "pto/npu/a2a3/grid_pipe_runtime.hpp"
+#include "pto/npu/a2a3/GridTPush.hpp"
+#include "pto/npu/a2a3/GridTPop.hpp"
 #endif
 #endif
 

--- a/include/pto/npu/a2a3/GridTPop.hpp
+++ b/include/pto/npu/a2a3/GridTPop.hpp
@@ -1,0 +1,87 @@
+/**
+Copyright (c) 2026 Huawei Technologies Co., Ltd.
+This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+CANN Open Software License Agreement Version 2.0 (the "License").
+Please refer to the License for details. You may not use this file except in compliance with the License.
+THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+See LICENSE in the root of the software repository for the full text of the License.
+*/
+
+// A2/A3 backend for GridPipe TPOP<Direction>.  Mirrors GridTPush.hpp.
+// See design doc section 5.3 consumer expansion template.
+
+#ifndef PTO_A2A3_GRID_TPOP_HPP
+#define PTO_A2A3_GRID_TPOP_HPP
+
+#include <cstdint>
+
+#include <pto/common/grid_pipe.hpp>
+#include <pto/common/grid_pipe_mock_spr.hpp>
+#include <pto/npu/a2a3/GridTPush.hpp>  // for a2a3_grid_payload hooks
+#include <pto/npu/a2a3/grid_pipe_runtime.hpp>
+
+namespace pto {
+
+template <pto::GridDirection Dir, typename Pipe, typename TileCons>
+AICORE bool GRID_TRY_TPOP_IMPL(Pipe &pipe, TileCons &tile, uint32_t maxSpins = grid_mock::kDefaultWfeMaxSpins)
+{
+    constexpr int dirIdx = GridDirectionIndex(Dir);
+
+    // SOURCE TPOP is always legal (CanPop returns true); other directions
+    // require the appropriate neighbor to exist.
+    if (!CanPop(Dir, pipe.coord, pipe.shape)) {
+        grid_mock::MockBoundaryFault(pipe.freeFlags[dirIdx],
+                                     grid_mock::kFaultPopEast +
+                                     dirIdx - GridDirectionIndex(GridDirection::EAST));
+        return false;
+    }
+
+    // Step 1: wait for ready signal from upstream.
+    //   LPU WSE: wfe SPR_RDY_<DIR>, r_idx + 1
+    const uint32_t expectedReady = pipe.consIndex[dirIdx] + 1;
+    if (!grid_mock::MockTryWfeReady(pipe.readyFlags[dirIdx], expectedReady, maxSpins)) {
+        grid_mock::MockSetFault(pipe.readyFlags[dirIdx] + grid_mock::kFaultFlagWordOffset,
+                                grid_mock::kFaultWaitReadyTimeout);
+        return false;
+    }
+
+    // Step 2: compute slot address (local; producer wrote it here).
+    const uint32_t idx     = pipe.consIndex[dirIdx];
+    const uint32_t slotOff = (idx % Pipe::SlotCount) * Pipe::SlotBytes;
+    __gm__ uint8_t *localSlot = pipe.slotBase[dirIdx] + slotOff;
+
+    // D-5 bisect: consumer-side dcci loop disabled.  Adding it together with
+    // the producer-side publish fence regressed yOutput to all zeros; isolate
+    // the producer-side change first and re-enable this once the failure mode
+    // is understood.
+    // Step 3: payload transfer from local slot to consumer tile buffer.
+    //   LPU WSE: tmov tile_buf, [r_slot]
+    a2a3_grid_payload::CopyGmSlotToTile<TileCons>(tile, localSlot, Pipe::SlotBytes);
+
+    // Step 4: notify upstream producer that slot is free.
+    //   LPU WSE: mtspr SPR_FREE_<DIR>, r_idx + 1
+    //
+    // SOURCE has no upstream rank (it's the launcher); host runtime handles
+    // free counters out-of-band.  Skip the cross-rank write for SOURCE.
+    if constexpr (Dir != GridDirection::SOURCE) {
+        const int peerRank = NeighborRankForPop(Dir, pipe.coord, pipe.shape);
+        __gm__ uint32_t *peerFree =
+            a2a3_grid_payload::RemotePtr<__gm__ uint32_t>(pipe.runtimeCtx, pipe.freeFlags[dirIdx], peerRank);
+        grid_mock::MockMtsprFree(peerFree, idx + 1);
+    }
+
+    // Step 5: bump local consumer index.
+    pipe.consIndex[dirIdx] = idx + 1;
+    return true;
+}
+
+template <pto::GridDirection Dir, typename Pipe, typename TileCons>
+AICORE void GRID_TPOP_IMPL(Pipe &pipe, TileCons &tile)
+{
+    (void)GRID_TRY_TPOP_IMPL<Dir, Pipe, TileCons>(pipe, tile, 0);
+}
+
+}  // namespace pto
+
+#endif  // PTO_A2A3_GRID_TPOP_HPP

--- a/include/pto/npu/a2a3/GridTPush.hpp
+++ b/include/pto/npu/a2a3/GridTPush.hpp
@@ -1,0 +1,138 @@
+/**
+Copyright (c) 2026 Huawei Technologies Co., Ltd.
+This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+CANN Open Software License Agreement Version 2.0 (the "License").
+Please refer to the License for details. You may not use this file except in compliance with the License.
+THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+See LICENSE in the root of the software repository for the full text of the License.
+*/
+
+// A2/A3 backend for GridPipe TPUSH<Direction>.
+//
+// Implements design doc section 5.3 producer expansion template using:
+//   - MockWfeFree / MockMtsprReady  (LPU WSE SPR + WFE stand-in)
+//   - HcclRemotePtr                  (resolve neighbor rank's GM window)
+//   - TSTORE / TLOAD                 (existing A2/A3 tile <-> GM movers)
+//
+// payload transfer (GRID_PAYLOAD_STORE_IMPL) is intentionally pluggable: the
+// general type-erased copy is provided here for byte-aligned tiles, and
+// specialised tile copies live alongside the demo kernel.
+
+#ifndef PTO_A2A3_GRID_TPUSH_HPP
+#define PTO_A2A3_GRID_TPUSH_HPP
+
+#include <cstdint>
+
+#include <pto/common/grid_pipe.hpp>
+#include <pto/common/grid_pipe_mock_spr.hpp>
+#include <pto/npu/a2a3/grid_pipe_runtime.hpp>
+
+// Forward declaration: provided by demo's gridpipe_runtime adaptor.
+// At the demo level we inject a concrete implementation that knows how to
+// move a specific tile type to/from a GM slot via TSTORE/TLOAD.  Keeping the
+// hook out-of-line avoids tying GridPipe to a specific tile shape.
+namespace pto {
+namespace a2a3_grid_payload {
+
+template <typename TileT>
+AICORE void CopyTileToGmSlot(__gm__ uint8_t *remoteSlot, TileT &tile, int slotBytes);
+
+template <typename TileT>
+AICORE void CopyGmSlotToTile(TileT &tile, __gm__ uint8_t *localSlot, int slotBytes);
+
+// Resolve a pointer in our local GM window to the same field in `peerRank`'s
+// window.  Implemented in the demo's gridpipe_runtime adaptor on top of
+// HcclRemotePtr.
+template <typename PtrT>
+AICORE PtrT *RemotePtr(__gm__ void *runtimeCtx, PtrT *localPtr, int peerRank);
+
+}  // namespace a2a3_grid_payload
+}  // namespace pto
+
+namespace pto {
+
+// SOURCE direction is illegal as a TPUSH target (design doc 4.3).  Provide an
+// undefined primary template so attempts to instantiate it fail at link time
+// with a clear symbol name; the static_assert in pto_instr.hpp catches this
+// earlier at compile time.
+template <pto::GridDirection Dir, typename Pipe, typename TileProd>
+AICORE bool GRID_TRY_TPUSH_IMPL(Pipe &pipe, TileProd &tile, uint32_t maxSpins = grid_mock::kDefaultWfeMaxSpins)
+{
+    static_assert(Dir != GridDirection::SOURCE,
+                  "GridPipe TPUSH<SOURCE> is illegal (design doc 4.3)");
+
+    constexpr int dirIdx = GridDirectionIndex(Dir);
+
+    // Boundary check (design doc 2.3 + 5.4).  In production builds the
+    // compiler folds CanPush() against constexpr coord; here we keep the
+    // runtime check so dynamic coordinates still trap.
+    if (!CanPush(Dir, pipe.coord, pipe.shape)) {
+        grid_mock::MockBoundaryFault(pipe.readyFlags[dirIdx],
+                                     grid_mock::kFaultPushEast +
+                                     dirIdx - GridDirectionIndex(GridDirection::EAST));
+        return false;
+    }
+
+    // Step 1: wait for a free slot.
+    //   LPU WSE: wfe SPR_FREE_<DIR>, r_idx + 1
+    const uint32_t expectedFree = pipe.prodIndex[dirIdx] + 1;
+    if (pipe.prodIndex[dirIdx] >= static_cast<uint32_t>(Pipe::SlotCount)) {
+        if (!grid_mock::MockTryWfeFree(pipe.freeFlags[dirIdx], expectedFree - Pipe::SlotCount, maxSpins)) {
+            grid_mock::MockSetFault(pipe.freeFlags[dirIdx] + grid_mock::kFaultFlagWordOffset,
+                                    grid_mock::kFaultWaitFreeTimeout);
+            return false;
+        }
+    }
+
+    // Step 2: compute slot address.
+    //   LPU WSE: mfspr r_idx, SPR_PROD_IDX_<DIR>
+    //            mfspr r_base, SPR_SLOT_BASE_<DIR>
+    //            and / mla -> r_slot
+    const uint32_t idx     = pipe.prodIndex[dirIdx];
+    const uint32_t slotOff = (idx % Pipe::SlotCount) * Pipe::SlotBytes;
+    __gm__ uint8_t *localSlot = pipe.slotBase[dirIdx] + slotOff;
+
+    // Step 3: payload transfer to *neighbor's* slot region.
+    //   LPU WSE: tmov [r_slot], tile_buf   (slot is neighbor-mapped)
+    const int peerRank = NeighborRankForPush(Dir, pipe.coord, pipe.shape);
+    __gm__ uint8_t *remoteSlot =
+        a2a3_grid_payload::RemotePtr<__gm__ uint8_t>(pipe.runtimeCtx, localSlot, peerRank);
+    a2a3_grid_payload::CopyTileToGmSlot<TileProd>(remoteSlot, tile, Pipe::SlotBytes);
+
+    // Publish fence (D-5).  Required between the slot TSTORE (MTE3, into peer
+    // window via HcclRemotePtr) and the cross-rank ready flag write below.
+    // Mirrors allgather_gemm's TPUT-loop -> `pipe_barrier(PIPE_ALL); dsb(DSB_DDR);`
+    // -> SetRemoteChunkFlagReady ordering (see
+    // kernels/manual/a2a3/allgather_gemm/allgather_gemm_comm_kernel.cpp:146).
+    // Without this the scalar-pipe flag store can become visible on the peer
+    // before the MTE3 slot bytes commit to DDR, causing the consumer's TLOAD to
+    // pick up pre-publish (zero) data.  Earlier attempts to place the fence
+    // inside the payload hook were inconclusive; doing it here keeps it on the
+    // canonical GridPipe expansion path and out of demo-specific code.
+#ifndef __PTO_AUTO__
+    pipe_barrier(PIPE_ALL);
+#endif
+    dsb(DSB_DDR);
+
+    // Step 4: trigger neighbor's ready flag.
+    //   LPU WSE: mtspr SPR_RDY_<DIR>, r_idx + 1   (cross-core SPR write)
+    __gm__ uint32_t *neighborReady =
+        a2a3_grid_payload::RemotePtr<__gm__ uint32_t>(pipe.runtimeCtx, pipe.readyFlags[dirIdx], peerRank);
+    grid_mock::MockMtsprReady(neighborReady, idx + 1);
+
+    // Step 5: bump local producer index.
+    //   LPU WSE: mtspr SPR_PROD_IDX_<DIR>, r_idx + 1
+    pipe.prodIndex[dirIdx] = idx + 1;
+    return true;
+}
+
+template <pto::GridDirection Dir, typename Pipe, typename TileProd>
+AICORE void GRID_TPUSH_IMPL(Pipe &pipe, TileProd &tile)
+{
+    (void)GRID_TRY_TPUSH_IMPL<Dir, Pipe, TileProd>(pipe, tile, 0);
+}
+
+}  // namespace pto
+
+#endif  // PTO_A2A3_GRID_TPUSH_HPP

--- a/include/pto/npu/a2a3/grid_pipe_runtime.hpp
+++ b/include/pto/npu/a2a3/grid_pipe_runtime.hpp
@@ -1,0 +1,106 @@
+/**
+Copyright (c) 2026 Huawei Technologies Co., Ltd.
+This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+CANN Open Software License Agreement Version 2.0 (the "License").
+Please refer to the License for details. You may not use this file except in compliance with the License.
+THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+See LICENSE in the root of the software repository for the full text of the License.
+*/
+
+// A2/A3 GridPipe runtime helpers: shmem window layout, init helpers, neighbor
+// rank resolution.  See design doc section 5 and the mock SPR lowering in
+// include/pto/common/grid_pipe_mock_spr.hpp.
+
+#ifndef PTO_A2A3_GRID_PIPE_RUNTIME_HPP
+#define PTO_A2A3_GRID_PIPE_RUNTIME_HPP
+
+#include <cstdint>
+
+#include <pto/common/grid_pipe.hpp>
+
+namespace pto {
+namespace a2a3_grid {
+
+// shmem window layout (per rank), in bytes:
+//
+//   offset                                         contents
+//   ----------------------------------------------------------------------
+//   0                                              ready flags [4 dirs] u32
+//   16                                             free  flags [4 dirs] u32
+//   32                                             reserved (alignment, telemetry)
+//   kSlotRegionOffset                              slot region for all 4 dirs
+//     + dir * SlotCount * SlotBytes                slot ring for that direction
+//
+// The slot region is sized to (kGridDirectionCount * SlotCount * SlotBytes).
+// Aligned to 512 bytes for A2/A3 GM access requirements.
+inline constexpr uint32_t kFlagsBytes       = 64;                  // 4 ready + 4 free + reserved
+inline constexpr uint32_t kSlotRegionOffset = kFlagsBytes;
+
+inline constexpr uint32_t kReadyFlagOffset(GridDirection d)
+{
+    return static_cast<uint32_t>(d) * sizeof(uint32_t);
+}
+
+inline constexpr uint32_t kFreeFlagOffset(GridDirection d)
+{
+    return 4 * sizeof(uint32_t) + static_cast<uint32_t>(d) * sizeof(uint32_t);
+}
+
+template <int SlotBytes, int SlotCount>
+inline constexpr uint32_t kSlotRegionBytes()
+{
+    return kGridDirectionCount * SlotCount * SlotBytes;
+}
+
+template <int SlotBytes, int SlotCount>
+inline constexpr uint32_t kWindowBytes()
+{
+    return kSlotRegionOffset + kSlotRegionBytes<SlotBytes, SlotCount>();
+}
+
+template <int SlotBytes, int SlotCount>
+inline constexpr uint32_t kDirSlotRegionOffset(GridDirection d)
+{
+    return kSlotRegionOffset + static_cast<uint32_t>(d) * SlotCount * SlotBytes;
+}
+
+// Wire up a GridPipe instance from a flat GM window owned by this rank.
+// The host launcher allocates kWindowBytes() bytes per rank, then calls this
+// in the kernel prologue.  `runtimeCtx` is the HCCL device context handle used
+// later by GridTPush/GridTPop to resolve cross-rank addresses.
+template <typename Pipe>
+AICORE inline void InitGridPipeFromWindow(Pipe &pipe,
+                                          GridShape shape,
+                                          GridCoord coord,
+                                          __gm__ uint8_t *window,
+                                          __gm__ void *runtimeCtx,
+                                          uint32_t pipeId)
+{
+    pipe.shape      = shape;
+    pipe.coord      = coord;
+    pipe.runtimeCtx = runtimeCtx;
+    pipe.pipeId     = pipeId;
+
+    __gm__ uint32_t *flags = reinterpret_cast<__gm__ uint32_t *>(window);
+    for (int i = 0; i < kGridDirectionCount; ++i) {
+        pipe.readyFlags[i] = flags + i;
+        pipe.freeFlags[i]  = flags + 4 + i;
+        pipe.slotBase[i]   = window + kSlotRegionOffset +
+                             i * Pipe::SlotCount * Pipe::SlotBytes;
+        pipe.prodIndex[i]  = 0;
+        pipe.consIndex[i]  = 0;
+    }
+}
+
+// Host-side helper: total bytes per rank for a single GridPipe.
+template <typename Pipe>
+inline constexpr uint32_t WindowBytes()
+{
+    return kWindowBytes<Pipe::SlotBytes, Pipe::SlotCount>();
+}
+
+}  // namespace a2a3_grid
+}  // namespace pto
+
+#endif  // PTO_A2A3_GRID_PIPE_RUNTIME_HPP

--- a/kernels/manual/a2a3/distributed_ffn_grid/CMakeLists.txt
+++ b/kernels/manual/a2a3/distributed_ffn_grid/CMakeLists.txt
@@ -1,0 +1,166 @@
+# --------------------------------------------------------------------------------
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# --------------------------------------------------------------------------------
+
+cmake_minimum_required(VERSION 3.16)
+
+set(CMAKE_COMPILER bisheng)
+set(CMAKE_C_COMPILER ${CMAKE_COMPILER})
+set(CMAKE_CXX_COMPILER ${CMAKE_COMPILER})
+
+project(distributed_ffn_grid_demo)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+
+if(NOT DEFINED ENV{ASCEND_HOME_PATH})
+    message(FATAL_ERROR "Cannot find ASCEND_HOME_PATH, please run set_env.sh.")
+else()
+    set(ASCEND_HOME_PATH $ENV{ASCEND_HOME_PATH})
+endif()
+
+if(DEFINED ENV{ASCEND_DRIVER_PATH})
+    set(ASCEND_DRIVER_PATH $ENV{ASCEND_DRIVER_PATH})
+else()
+    set(ASCEND_DRIVER_PATH /usr/local/Ascend/driver)
+endif()
+
+# =============================================================================
+# Grid + tile dimensions (override via -DGRID_ROWS=... etc).
+# =============================================================================
+if(NOT DEFINED GRID_ROWS)
+    set(GRID_ROWS 2)
+endif()
+if(NOT DEFINED GRID_COLS)
+    set(GRID_COLS 2)
+endif()
+if(NOT DEFINED TOKEN_TILE)
+    set(TOKEN_TILE 16)
+endif()
+if(NOT DEFINED MODEL_TILE)
+    set(MODEL_TILE 64)
+endif()
+if(NOT DEFINED FFN_TILE)
+    set(FFN_TILE 64)
+endif()
+
+message(STATUS "Grid: ${GRID_ROWS}x${GRID_COLS}  Tile: ${TOKEN_TILE}x${MODEL_TILE}  FfnTile: ${FFN_TILE}")
+
+add_compile_options(
+    -D_FORTIFY_SOURCE=2
+    -O2 -std=c++17
+    -Wno-macro-redefined -Wno-ignored-attributes
+    -fstack-protector-strong
+)
+
+add_link_options(-s -Wl,-z,relro -Wl,-z,now)
+
+set(CMAKE_CCE_COMPILE_OPTIONS
+    -xcce
+    -Xhost-start -Xhost-end
+    "SHELL:-mllvm -cce-aicore-stack-size=0x8000"
+    "SHELL:-mllvm -cce-aicore-function-stack-size=0x8000"
+    "SHELL:-mllvm -cce-aicore-record-overflow=true"
+    "SHELL:-mllvm -cce-aicore-addr-transform"
+    "SHELL:-mllvm -cce-aicore-dcci-insert-for-scalar=false"
+)
+
+set(CMAKE_CPP_COMPILE_OPTIONS
+    -xc++
+    "SHELL:-include stdint.h"
+    "SHELL:-include stddef.h"
+)
+
+include_directories(
+    ${PROJECT_SOURCE_DIR}/../../../../include
+    ${ASCEND_HOME_PATH}/include
+    ${ASCEND_DRIVER_PATH}/kernel/inc
+)
+
+# =============================================================================
+# 1a. Compute Kernel (Cube arch) -- Session C-1 stub (+ C-2 chunkFlags param
+#     threaded through); Session D fills with gate/up/down TMATMUL.
+# =============================================================================
+add_library(distributed_ffn_grid_compute_kernel SHARED distributed_ffn_grid_compute_kernel.cpp)
+target_compile_options(distributed_ffn_grid_compute_kernel PRIVATE
+    ${CMAKE_CCE_COMPILE_OPTIONS}
+    --cce-aicore-arch=dav-c220-cube
+    -DMEMORY_BASE -std=c++17
+    -DCONFIG_GRID_ROWS=${GRID_ROWS} -DCONFIG_GRID_COLS=${GRID_COLS}
+    -DCONFIG_TOKEN_TILE=${TOKEN_TILE} -DCONFIG_MODEL_TILE=${MODEL_TILE}
+    -DCONFIG_FFN_TILE=${FFN_TILE}
+)
+target_include_directories(distributed_ffn_grid_compute_kernel PRIVATE
+    ${PROJECT_SOURCE_DIR}/../../../../include/
+    ${PROJECT_SOURCE_DIR}/../../../../tests/npu/a2a3/comm/st/testcase/
+)
+target_link_options(distributed_ffn_grid_compute_kernel PRIVATE --cce-fatobj-link)
+
+# =============================================================================
+# 1b. Communication Kernel (Vec arch + shmem + GridPipe) -- owns SOURCE intake
+#     and reduce-along-east.
+# =============================================================================
+add_library(distributed_ffn_grid_comm_kernel SHARED distributed_ffn_grid_comm_kernel.cpp)
+target_compile_options(distributed_ffn_grid_comm_kernel PRIVATE
+    ${CMAKE_CCE_COMPILE_OPTIONS}
+    --cce-aicore-arch=dav-c220-vec
+    -DMEMORY_BASE -std=c++17
+    -DCONFIG_GRID_ROWS=${GRID_ROWS} -DCONFIG_GRID_COLS=${GRID_COLS}
+    -DCONFIG_TOKEN_TILE=${TOKEN_TILE} -DCONFIG_MODEL_TILE=${MODEL_TILE}
+    -DCONFIG_FFN_TILE=${FFN_TILE}
+)
+target_include_directories(distributed_ffn_grid_comm_kernel PRIVATE
+    ${PROJECT_SOURCE_DIR}/../../../../include/
+    ${PROJECT_SOURCE_DIR}/../../../../tests/npu/a2a3/comm/st/testcase/
+    $ENV{ASCEND_HOME_PATH}/aarch64-linux/asc
+    $ENV{ASCEND_HOME_PATH}/aarch64-linux/asc/include
+    $ENV{ASCEND_HOME_PATH}/aarch64-linux/ascendc/include/basic_api
+    $ENV{ASCEND_HOME_PATH}/aarch64-linux/include/ascendc/basic_api
+    $ENV{ASCEND_HOME_PATH}/aarch64-linux/asc/impl/basic_api
+    $ENV{ASCEND_HOME_PATH}/aarch64-linux/ascendc/include/basic_api/impl
+    $ENV{ASCEND_HOME_PATH}/aarch64-linux/asc/include/interface
+    $ENV{ASCEND_HOME_PATH}/aarch64-linux/asc/include/utils
+)
+target_link_directories(distributed_ffn_grid_comm_kernel PRIVATE ${ASCEND_HOME_PATH}/lib64)
+target_link_libraries(distributed_ffn_grid_comm_kernel PRIVATE hcomm runtime nnopbase)
+target_link_options(distributed_ffn_grid_comm_kernel PRIVATE --cce-fatobj-link)
+
+# =============================================================================
+# 2. Host driver executable
+# =============================================================================
+add_executable(distributed_ffn_grid main.cpp)
+target_compile_options(distributed_ffn_grid PRIVATE ${CMAKE_CPP_COMPILE_OPTIONS})
+target_include_directories(distributed_ffn_grid PRIVATE
+    ${PROJECT_SOURCE_DIR}/../../../../include/
+    ${PROJECT_SOURCE_DIR}/../../../../tests/common
+    ${PROJECT_SOURCE_DIR}/../../../../tests/npu/a2a3/comm/st/testcase/
+)
+target_compile_definitions(distributed_ffn_grid PRIVATE
+    CONFIG_GRID_ROWS=${GRID_ROWS} CONFIG_GRID_COLS=${GRID_COLS}
+    CONFIG_TOKEN_TILE=${TOKEN_TILE} CONFIG_MODEL_TILE=${MODEL_TILE}
+    CONFIG_FFN_TILE=${FFN_TILE}
+)
+
+target_link_directories(distributed_ffn_grid PUBLIC
+    ${ASCEND_HOME_PATH}/lib64
+    ${ASCEND_HOME_PATH}/simulator/${SOC_VERSION}/lib
+    ${ASCEND_HOME_PATH}/tools/simulator/${SOC_VERSION}/lib
+)
+
+target_link_libraries(distributed_ffn_grid PRIVATE
+    distributed_ffn_grid_compute_kernel
+    distributed_ffn_grid_comm_kernel
+    $<BUILD_INTERFACE:$<$<STREQUAL:${RUN_MODE},sim>:runtime_camodel>>
+    $<BUILD_INTERFACE:$<$<STREQUAL:${RUN_MODE},npu>:runtime>>
+    stdc++ ascendcl hcomm m tiling_api platform c_sec dl nnopbase pthread
+)

--- a/kernels/manual/a2a3/distributed_ffn_grid/README.md
+++ b/kernels/manual/a2a3/distributed_ffn_grid/README.md
@@ -1,0 +1,228 @@
+# Distributed FFN GridPipe Demo
+
+## Goal
+
+`distributed_ffn_grid` is an A2/A3 NPU demo that validates the GridPipe programming model for a distributed FFN. It mocks the LPU WSE Grid `TPUSH/TPOP`, cross-core `SPR_RDY/SPR_FREE`, and `WFE` semantics with HCCL shared windows, GM flags, explicit `dcci/dsb` fences, and spin waits.
+
+The current implementation is an M4/D-6 style end-to-end demo, not the older launch-only skeleton:
+
+- The logical grid is `gridRows x gridCols`, defaulting to `1x2`.
+- Rows are data-parallel: each row owns a different token slice.
+- Columns are model-parallel: each column owns one shard of the FFN intermediate dimension.
+- Each rank computes its local FFN partial, then reduces fp32 partials along `EAST` within the row.
+- The last-column rank of each row writes the final `[T, H]` fp32 `yOutput` and compares it against the matching slice of `golden.bin` with `1e-3` tolerance.
+
+This demo is meant to validate the GridPipe semantics, the A2/A3 mock backend, the host/runtime glue, and the complete FFN data flow. It is not silicon validation evidence for LPU WSE.
+
+## Files
+
+| File | Purpose |
+| --- | --- |
+| `README.md` / `README_zh.md` | English / Chinese documentation. |
+| `CMakeLists.txt` | Builds the host executable plus the cube/compute and vec/comm device kernel shared libraries. |
+| `run.sh` | One-shot helper that sets up CANN/MPI, generates data, configures CMake, builds, and launches the demo with `mpirun`. |
+| `ffn_config.hpp` | Compile-time configuration: grid shape, tile shape, GridPipe slot/window sizes, buffer sizes, chunk flag indices, and PReLU alpha. |
+| `kernel_launch.hpp` | Host-side launch declarations and the parameter contract for the two device kernels. |
+| `main.cpp` | Host driver: MPI/HCCL/ACL bootstrap, HCCL window allocation, device buffer allocation, data loading, dual-stream launch, synchronization, debug peeks, golden comparison, and cleanup. |
+| `distributed_ffn_grid_compute_kernel.cpp` | Cube kernel: computes `X @ W_gate`, `X @ W_up`, waits for hidden, then computes `hidden @ W_down`; coordinates with the comm kernel through chunk flags. |
+| `distributed_ffn_grid_comm_kernel.cpp` | Vec/comm kernel: waits for gate/up partials, computes `PReLU(gate) * up -> hidden`, waits for down partial, then performs row-local `EAST` reduction with GridPipe `TPOP/TPUSH`. |
+| `ready_queue.hpp` | Defines `ChunkFlagMatrix` and device-side flag helpers for producer/consumer synchronization between the cube and comm streams within one rank. |
+| `gridpipe_payload_inl.hpp` | A2/A3 GridPipe payload hooks: resolves peer windows through `HcclRemotePtr`, and moves payloads between tiles and GridPipe GM slots with `TSTORE/TLOAD`. |
+| `scripts/gen_data.py` | Generates per-rank fp16 X/weight shards and an fp32 golden reference. |
+| `build/` | Generated build directory created by `run.sh` / CMake. |
+| `out/` | Generated data directory containing `pe_<rank>_*.bin` files and `golden.bin`. |
+
+## Execution Flow
+
+1. `run.sh` parses runtime arguments. Defaults are `gridRows=1`, `gridCols=2`, `T=16`, `H=64`, `Fi=64`.
+2. Unless `--build-only` is set, `scripts/gen_data.py` generates:
+   - `pe_<rank>_x.bin`: `[T, H]` fp16.
+   - `pe_<rank>_w_gate.bin`: `[H, Fi]` fp16.
+   - `pe_<rank>_w_up.bin`: `[H, Fi]` fp16.
+   - `pe_<rank>_w_down.bin`: `[Fi, H]` fp16.
+   - `golden.bin`: `[gridRows * T, H]` fp32.
+3. CMake builds three targets:
+   - `distributed_ffn_grid_compute_kernel`: `dav-c220-cube`.
+   - `distributed_ffn_grid_comm_kernel`: `dav-c220-vec`.
+   - `distributed_ffn_grid`: host executable.
+4. `mpirun -n N_RANKS ./distributed_ffn_grid` starts one MPI rank per NPU device.
+5. The host initializes ACL/HCCL. Rank 0 obtains and broadcasts `HcclRootInfo`; each rank initializes its HCCL context.
+6. Each rank carves two regions from its HCCL window:
+   - `reduce_pipe_window`: GridPipe ready/free flags and per-direction ring slots.
+   - `chunk_flag_shmem`: `ChunkFlagMatrix` for cube/comm stream synchronization.
+7. The host allocates and zeroes device buffers: `x_dev`, `w_*_dev`, `gate_partial_dev`, `up_partial_dev`, `hidden_dev`, `down_partial_dev`, and `y_output_dev`.
+8. The host copies X and weight shards from `out/` to the rank-local device buffers.
+9. The host launches two kernels concurrently on two streams:
+   - comm stream: `DistributedFfnGridCommKernel`.
+   - compute stream: `DistributedFfnGridComputeKernel`.
+10. The compute kernel computes gate/up partials and publishes chunk flags 0/1.
+11. The comm kernel waits for flags 0/1, runs `TLRELU + TMUL + TCVT`, stores `hidden_dev`, and publishes chunk flag 2.
+12. The compute kernel waits for flag 2, computes down partial, and publishes chunk flag 3.
+13. The comm kernel waits for flag 3, loads down partial, and performs row-local `EAST` reduction:
+    - `col > 0`: `TPOP<EAST>` receives the west neighbor partial and `TADD`s it.
+    - `col + 1 < gridCols`: `TPUSH<EAST>` forwards the accumulated result to the east neighbor.
+    - `col == gridCols - 1`: `TSTORE`s the reduced result to `yOutput`.
+14. The host synchronizes both streams. The last-column rank of each row copies `yOutput` back and compares it with the matching row slice from `golden.bin`.
+15. Rank 0 prints PASS/FAILED, and all ranks clean up resources.
+
+Data-flow summary:
+
+```text
+host files
+  -> x_dev, w_gate, w_up, w_down
+
+compute/cube:
+  X @ W_gate -> gatePartial --flag0-->
+  X @ W_up   -> upPartial   --flag1-->
+
+comm/vec:
+  wait flag0/1
+  hidden = fp16(PReLU(gatePartial) * upPartial)
+  hidden_dev --flag2-->
+
+compute/cube:
+  wait flag2
+  hidden @ W_down -> downPartial --flag3-->
+
+comm/vec:
+  wait flag3
+  downPartial --GridPipe EAST reduce across cols--> yOutput on final col
+
+host:
+  yOutput vs golden row slice
+```
+
+## Key Designs
+
+### 1. Grid TPUSH/TPOP mock on A2/A3
+
+The LPU WSE design expects Grid `TPUSH/TPOP` to lower to a combination of `SPR` reads/writes, `WFE` waits, and payload movement. A2/A3 has no matching cross-core mesh SPR/event line, so this demo mocks the behavior with GM slots and GM flags inside an HCCL window.
+
+Mock expansion of `TPUSH<EAST>`:
+
+```text
+1. Check that the current coord can push EAST.
+2. If the ring is full, wait on the local free flag.
+3. Compute the direction-local slot offset from prodIndex.
+4. Resolve that local slot address into the east neighbor window through HcclRemotePtr.
+5. TSTORE the tile into the neighbor slot.
+6. Run pipe_barrier + dsb so the payload becomes visible before the signal.
+7. Resolve the neighbor ready flag through HcclRemotePtr.
+8. MockMtsprReady writes the ready counter and wakes the peer TPOP mock WFE.
+9. Increment prodIndex.
+```
+
+Mock expansion of `TPOP<EAST>`:
+
+```text
+1. Check that the current coord can pop from the EAST channel.
+2. Wait for the local ready flag to reach consIndex + 1.
+3. Compute the local slot offset from consIndex.
+4. TLOAD the slot into the tile.
+5. Resolve the west neighbor free flag through HcclRemotePtr.
+6. MockMtsprFree writes the free counter and releases the peer ring credit.
+7. Increment consIndex.
+```
+
+`TPOP<EAST>` means "receive from the eastbound channel", where the producer is the west neighbor. It does not mean "read from the east neighbor".
+
+### 2. Ready/free flags and ring credit
+
+Each direction has independent ready/free counters:
+
+- `ready`: the producer has written a slot and the consumer can read it.
+- `free`: the consumer has read a slot and the producer can reuse it.
+
+The flags are monotonic counters rather than booleans, so they compose with `prodIndex/consIndex` and `SlotCount` to model ring-buffer credit.
+
+### 3. Cache coherence and fences
+
+A2/A3 AICORE GM caches are not automatically coherent across cores. The mock SPR/WFE path cannot use plain loads and stores:
+
+- `MockMtsprReady/Free` uses `dcci -> store -> dcci -> dsb(DSB_DDR)`.
+- `MockWfeReady/Free` invalidates the flag cache line with `dcci` during spin polling.
+- `TPUSH` inserts `pipe_barrier(PIPE_ALL)` and `dsb(DSB_DDR)` between payload `TSTORE` and the ready flag write.
+
+These fences are the cost of the A2/A3 mock backend. They should not be interpreted as the intended kernel-author burden for final LPU WSE silicon.
+
+### 4. Compute/comm split
+
+The target LPU WSE design can be expressed as one logical kernel. The A2/A3 demo splits it into:
+
+- cube `.so`: TMATMUL-heavy compute.
+- vec `.so`: activation, cast, and GridPipe communication.
+
+The two halves synchronize through `ChunkFlagMatrix` in GM. The cube side cannot directly include the comm instruction header, so several flag writes and waits use raw volatile pointers plus `dcci/dsb`.
+
+### 5. Coordinate source
+
+The comm kernel launches `gridRows * gridCols` blocks but only `block 0` runs the body. Therefore it must not derive its logical grid coordinate from `get_block_idx()`. The current code uses the host-provided `myRankId`:
+
+```text
+row = myRankId / gridCols
+col = myRankId % gridCols
+```
+
+This ensures `TPUSH<EAST>` routes to the real peer rank.
+
+### 6. SOURCE direction
+
+The GridPipe layout still reserves the `SOURCE` direction, and semantically `SOURCE` is valid only for `TPOP`. The current M4 demo does not read X through `TPOP<SOURCE>`; the host copies X directly into `x_dev`, and the compute kernel loads from `x_dev`.
+
+### 7. fp32 EAST reduction
+
+The EAST reduce slot carries fp32 `[T, H]`, so `FFN_SLOT_BYTES = T * H * 4`. This avoids fp16 accumulation overflow and keeps both `yOutput` and `golden.bin` in fp32 for direct tolerance-based comparison.
+
+## How to Run
+
+### Build only
+
+```bash
+bash run.sh --build-only -v Ascend910B1
+```
+
+### Run on simulator
+
+This is usually launched through `task-submit`:
+
+```bash
+task-submit --device auto --run "cd $(pwd)/kernels/manual/a2a3/distributed_ffn_grid && bash run.sh -r sim -v Ascend910B1 -n 2"
+```
+
+### Run on NPU
+
+```bash
+task-submit --device auto --run "cd $(pwd)/kernels/manual/a2a3/distributed_ffn_grid && bash run.sh -r npu -v Ascend910B1 -n 2"
+```
+
+### 2x2 example
+
+```bash
+task-submit --device auto --run "cd $(pwd)/kernels/manual/a2a3/distributed_ffn_grid && bash run.sh -r npu -v Ascend910B1 --grid-rows 2 --grid-cols 2"
+```
+
+`N_RANKS` defaults to `gridRows * gridCols`. If `-n/--n-ranks` is provided explicitly, it must match `gridRows * gridCols`, otherwise the host driver reports an MPI world-size mismatch.
+
+### Common arguments
+
+```text
+-r, --run-mode      sim or npu, default npu
+-v, --soc-version   default Ascend910B1
+-n, --n-ranks       MPI rank count, default gridRows * gridCols
+--grid-rows         grid row count, default 1
+--grid-cols         grid column count, default 2
+--token-tile        token tile T per row, default 16
+--model-tile        hidden dim H, default 64
+--ffn-tile          intermediate dim Fi per column, default 64
+--build-only        build only; skip data generation and execution
+```
+
+### Expected result
+
+On success, rank 0 prints:
+
+```text
+[SUCCESS] Distributed FFN GridPipe (M4) PASS.
+```
+
+The run fails with a non-zero exit status if the golden file is missing, the MPI rank count is wrong, stream synchronization fails, or ResultCmp fails on a last-column rank.

--- a/kernels/manual/a2a3/distributed_ffn_grid/README_zh.md
+++ b/kernels/manual/a2a3/distributed_ffn_grid/README_zh.md
@@ -1,0 +1,151 @@
+# Single-device Multi-block FFN GridPipe Demo
+
+## 整体目标
+
+`distributed_ffn_grid` 当前用于验证单卡多核 FFN，并在单卡内使能 `gridCols > 1` 的 GridPipe EAST reduce mock。它不再需要多卡、`mpirun` 或真实 HCCL 通信；host 会在 device 0 上构造一个逻辑 `gridRows x gridCols` 网格，每个 grid cell 对应一个 block。
+
+默认配置：
+
+- `gridRows=2`：data-parallel 行数，不同行处理不同 token tile。
+- `gridCols=2`：model-parallel 列数，每列持有 FFN intermediate dim 的一个 shard。
+- 启动 `gridRows * gridCols` 个 block。
+- 每个 cell 计算本列 FFN partial，随后同行按 `EAST` 方向 reduce。
+- 每行最右列写出 `[T, H]` fp32 `yOutput`，host 与 `golden.bin` 做 `1e-3` 容差校验。
+
+该 demo 关注单设备多核调度、cube/vec 分阶段执行，以及 GridPipe ready/free/slot 语义在单卡 GM window 上的 mock。它不是多卡通信验证。
+
+## 文件作用
+
+| 文件 | 作用 |
+| --- | --- |
+| `README_zh.md` / `README.md` | 中文 / 英文说明文档。 |
+| `CMakeLists.txt` | 构建 host 可执行文件，以及 cube/compute 和 vec/comm 两个 device kernel shared library。 |
+| `run.sh` | 一键设置 CANN 环境、生成输入数据、配置 CMake、编译并在单进程中启动 demo。 |
+| `ffn_config.hpp` | 编译期配置中心：逻辑网格尺寸、tile 尺寸、GridPipe window 字节数、buffer 字节数、PReLU alpha。 |
+| `kernel_launch.hpp` | host 侧 kernel launch 接口声明。 |
+| `main.cpp` | host driver：ACL 初始化、fake HCCL context/local GridPipe windows、device buffer 分配、数据加载、分阶段 launch、golden 校验和资源清理。 |
+| `distributed_ffn_grid_compute_kernel.cpp` | cube kernel：phase 0 计算 `X @ W_gate` 和 `X @ W_up`；phase 1 计算 `hidden @ W_down -> downPartial[cell]`。 |
+| `distributed_ffn_grid_comm_kernel.cpp` | vec/comm kernel：phase 0 执行 `PReLU(gate) * up -> hidden`；phase 1 所有列并行执行 EAST reduce。 |
+| `gridpipe_payload_inl.hpp` | 本地 GridPipe payload/remote pointer adaptor。会从 fake `windowsIn[]` 反推当前 cell window，并解析 peer cell 的同 offset 地址。 |
+| `scripts/gen_data.py` | 生成每个 cell 的 fp16 X/weight shard，以及 fp32 golden reference。 |
+
+## 运行流程
+
+1. `run.sh` 解析参数。默认 `gridRows=2`、`gridCols=2`、`T=16`、`H=64`、`Fi=64`。
+2. `scripts/gen_data.py` 生成输入、权重和 golden：
+   - `pe_<cell>_x.bin`: 当前 cell 所在 row 的 `[T, H]` fp16 输入。
+   - `pe_<cell>_w_gate.bin`: 当前 cell 所在 col 的 `[H, Fi]` fp16 权重 shard。
+   - `pe_<cell>_w_up.bin`: `[H, Fi]` fp16 权重 shard。
+   - `pe_<cell>_w_down.bin`: `[Fi, H]` fp16 权重 shard。
+   - `golden.bin`: `[gridRows * T, H]` fp32 输出。
+3. host 初始化 ACL 并固定使用 device 0。
+4. host 分配连续 device buffers，大小按 `gridRows * gridCols` 个 cell 扩展：
+   - `x_dev`
+   - `w_gate_dev` / `w_up_dev` / `w_down_dev`
+   - `gate_partial_dev` / `up_partial_dev`
+   - `hidden_dev`
+   - `down_partial_dev`
+   - `y_output_dev`，只按 `gridRows` 个输出 tile 分配
+5. host 分配 `gridRows * gridCols` 个本地 GridPipe GM window，并构造 fake `HcclDeviceContext`：
+
+```text
+windowsIn[cell] = reduce_pipe_windows_dev + cell * FFN_GRID_WINDOW_BYTES
+rankNum = gridRows * gridCols
+winSize = FFN_GRID_WINDOW_BYTES
+```
+
+6. host 顺序 launch：
+   - compute phase 0：所有 cell 计算 gate/up partial。
+   - comm phase 0：所有 cell 计算 hidden。
+   - compute phase 1：所有 cell 计算 downPartial。
+   - comm phase 1：单次 launch 所有列并行执行 EAST reduce step。
+7. host D2H 拷回完整 `yOutput`，与 `golden.bin` 比对。
+
+数据流摘要：
+
+```text
+compute phase 0, all cells:
+  X[row] @ W_gate[col] -> gatePartial[row,col]
+  X[row] @ W_up[col]   -> upPartial[row,col]
+
+comm phase 0, all cells:
+  hidden[row,col] = fp16(PReLU(gatePartial[row,col]) * upPartial[row,col])
+
+compute phase 1, all cells:
+  hidden[row,col] @ W_down[col] -> downPartial[row,col]
+
+comm phase 1, all cols in one launch:
+  col 0       : TPUSH<EAST>(downPartial[row,0])
+  middle cols : TPOP<EAST> + TADD + TPUSH<EAST>
+  final col   : TPOP<EAST> + TADD + TSTORE(yOutput[row])
+```
+
+## 关键设计
+
+### 1. 单卡逻辑网格
+
+`get_block_idx()` 是 row-major cell id：
+
+```text
+cell = get_block_idx()
+row = cell / gridCols
+col = cell % gridCols
+```
+
+所有 cell 都在同一个 device 上运行。`gridRows` 控制 data-parallel token tile 数，`gridCols` 控制 model-parallel FFN shard 数。
+
+### 2. 本地 GridPipe mock
+
+原多卡路径依赖 HCCL remote window。当前单卡路径用一段连续 GM 内存模拟每个 cell 的 window，并用 fake `HcclDeviceContext::windowsIn[]` 做地址解析。
+
+`TPUSH<EAST>` 仍然写入 east neighbor 的 slot，随后写 ready flag；`TPOP<EAST>` 仍然等待本地 ready flag、读取 slot、写 upstream free flag。差别只是 peer window 都在同一张卡上。
+
+### 3. 并行 reduce 与超时保护
+
+reduce 阶段单次 launch 所有列，各列之间通过 GridPipe ready/free flag 同步：
+
+```text
+launch comm phase 1
+  col 0 producer TPUSH<EAST>
+  col > 0 consumer TPOP<EAST> 阻塞等待上游 ready
+```
+
+当前 A2/A3 backend 使用 GM flag + spin wait 模拟 LPU WSE SPR/WFE。为避免上板时因为 block 调度或 flag
+可见性问题导致无限卡死，mock wait 带有最大自旋次数；若等待超时，kernel 会在对应 GridPipe window flag
+中写入 fault code，host 在 reduce 后检查这些 flag 并失败退出。
+
+## 运行方法
+
+### 仅编译
+
+```bash
+bash run.sh --build-only -v Ascend910B1 --grid-rows 2 --grid-cols 2
+```
+
+### NPU 运行
+
+```bash
+task-submit --device auto --run "cd $(pwd)/kernels/manual/a2a3/distributed_ffn_grid && bash run.sh -r npu -v Ascend910B1 --grid-rows 2 --grid-cols 2"
+```
+
+### 常用参数
+
+```text
+-r, --run-mode      sim 或 npu，默认 npu
+-v, --soc-version   默认 Ascend910B1
+-n, --n-ranks       固定为 1
+--grid-rows         单卡逻辑网格行数，默认 2
+--grid-cols         单卡逻辑网格列数，默认 2
+--token-tile        每个 cell 的 token tile T，默认 16
+--model-tile        hidden dim H，默认 64
+--ffn-tile          每列 intermediate dim Fi，默认 64
+--build-only        只编译，不生成数据和运行
+```
+
+## 期望输出
+
+成功时最终打印：
+
+```text
+[SUCCESS] Single-device multi-block FFN GridPipe PASS.
+```

--- a/kernels/manual/a2a3/distributed_ffn_grid/distributed_ffn_grid_comm_kernel.cpp
+++ b/kernels/manual/a2a3/distributed_ffn_grid/distributed_ffn_grid_comm_kernel.cpp
@@ -1,0 +1,318 @@
+/**
+Copyright (c) 2026 Huawei Technologies Co., Ltd.
+This program is free software, you can redistribute it and/or modify it under
+the terms and conditions of CANN Open Software License Agreement Version 2.0
+(the "License"). Please refer to the License for details. You may not use this
+file except in compliance with the License. THIS SOFTWARE IS PROVIDED ON AN "AS
+IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING
+BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A
+PARTICULAR PURPOSE. See LICENSE in the root of the software repository for the
+full text of the License.
+*/
+
+// Single-device multi-block FFN vec + local GridPipe reduce kernel.
+//
+// Each block owns one logical grid cell (row, col).  Phase 0 computes
+// hidden = fp16(PReLU(gate) * up).  Phase 1 performs one active column of the
+// EAST reduce using local same-device GridPipe windows.
+
+#include <cstddef>
+#include <cstdint>
+#include <pto/pto-inst.hpp>
+
+#include <pto/common/fifo.hpp>
+#include <pto/common/grid_pipe.hpp>
+#include <pto/npu/a2a3/grid_pipe_runtime.hpp>
+
+#include "common.hpp"
+#include "ffn_config.hpp"
+#include "gridpipe_payload_inl.hpp"
+
+#ifdef __CCE_AICORE__
+
+using GateF32Tile = pto::Tile<pto::TileType::Vec, float, FFN_TOKEN_TILE,
+                              FFN_FFN_TILE, pto::BLayout::RowMajor>;
+using UpF32Tile = GateF32Tile;
+using HiddenF32Tile = GateF32Tile;
+using HiddenF16Tile = pto::Tile<pto::TileType::Vec, half, FFN_TOKEN_TILE,
+                                FFN_FFN_TILE, pto::BLayout::RowMajor>;
+using DownF32Tile = pto::Tile<pto::TileType::Vec, float, FFN_TOKEN_TILE,
+                              FFN_MODEL_TILE, pto::BLayout::RowMajor>;
+using FfnGridPipe = pto::GridPipe<DownF32Tile, FFN_SLOT_BYTES, FFN_SLOT_COUNT>;
+
+using ShapeTFi = pto::Shape<1, 1, 1, FFN_TOKEN_TILE, FFN_FFN_TILE>;
+using StrideTFi =
+    pto::Stride<FFN_TOKEN_TILE * FFN_FFN_TILE, FFN_TOKEN_TILE * FFN_FFN_TILE,
+                FFN_TOKEN_TILE * FFN_FFN_TILE, FFN_FFN_TILE, 1>;
+
+using ShapeTH = pto::Shape<1, 1, 1, FFN_TOKEN_TILE, FFN_MODEL_TILE>;
+using StrideTH =
+    pto::Stride<FFN_TOKEN_TILE * FFN_MODEL_TILE,
+                FFN_TOKEN_TILE * FFN_MODEL_TILE,
+                FFN_TOKEN_TILE * FFN_MODEL_TILE, FFN_MODEL_TILE, 1>;
+using GTHF32 = pto::GlobalTensor<float, ShapeTH, StrideTH, pto::Layout::ND>;
+
+template <uint8_t FlagId, uint8_t DirType, uint32_t SlotSize, uint32_t SlotNum = 1, uint32_t LocalSlotNum = 1>
+struct FfnSerialTPipe {
+  static constexpr uint8_t DIR_MASK = 0x7;
+  static constexpr uint8_t DIR_TYPE = DIR_MASK & DirType;
+  static constexpr bool is_c2v = (DIR_TYPE == pto::Direction::DIR_C2V);
+  static constexpr bool is_v2c = (DIR_TYPE == pto::Direction::DIR_V2C);
+  static constexpr uint32_t SyncPeriod = 1;
+  using RingFiFo = pto::RingFIFO<SlotSize, SlotNum, LocalSlotNum>;
+
+  PTO_INTERNAL static bool shouldWaitFree(uint32_t) { return false; }
+  PTO_INTERNAL static bool shouldNotifyFree(uint32_t) { return false; }
+
+  struct Producer {
+    uint32_t tileIndex = 0;
+    int entryOffset = 0;
+
+    PTO_INTERNAL void setAllocateStatus(bool) {}
+    PTO_INTERNAL void setRecordStatus(bool) {}
+    PTO_INTERNAL void setTileId(int tIndex, int) { tileIndex = static_cast<uint32_t>(tIndex); }
+    PTO_INTERNAL void setEntryOffset(int offset) { entryOffset = offset; }
+    PTO_INTERNAL bool getAllocateStatus() const { return false; }
+    PTO_INTERNAL bool getRecordStatus() const { return false; }
+    PTO_INTERNAL void allocate() const {}
+    PTO_INTERNAL void record() const {}
+
+    template <typename TileProd, pto::TileSplitAxis Split>
+    PTO_INTERNAL void push(RingFiFo &fifo, TileProd &tile) {
+      static_assert(Split == pto::TileSplitAxis::TILE_NO_SPLIT,
+                    "distributed_ffn_grid uses full-tile TPipe slots");
+      static_assert((is_c2v && TileProd::Loc == pto::TileType::Acc) ||
+                        (is_v2c && TileProd::Loc == pto::TileType::Vec),
+                    "TPipe direction does not match producer tile type");
+      using T = typename TileProd::DType;
+      constexpr int rows = TileProd::Rows;
+      constexpr int cols = TileProd::Cols;
+      size_t entryBase = (tileIndex % RingFiFo::SLOT_NUM) * RingFiFo::SLOT_SIZE;
+      using GlobalData = pto::GlobalTensor<T, pto::Shape<1, 1, 1, rows, cols>, pto::Stride<1, 1, 1, cols, 1>>;
+      GlobalData globalTensor(reinterpret_cast<__gm__ T *>(reinterpret_cast<uint64_t>(fifo.GM_SLOT_BUFFER) +
+                                                           entryBase + entryOffset));
+      TSTORE_IMPL(globalTensor, tile);
+    }
+  };
+
+  struct Consumer {
+    uint32_t tileIndex = 0;
+    int entryOffset = 0;
+
+    PTO_INTERNAL void setWaitStatus(bool) {}
+    PTO_INTERNAL void setFreeStatus(bool) {}
+    PTO_INTERNAL void setTileId(int tIndex, int) { tileIndex = static_cast<uint32_t>(tIndex); }
+    PTO_INTERNAL void setEntryOffset(int offset) { entryOffset = offset; }
+    PTO_INTERNAL bool getWaitStatus() const { return false; }
+    PTO_INTERNAL bool getFreeStatus() const { return false; }
+    PTO_INTERNAL void wait() const {}
+    PTO_INTERNAL void free() const {}
+
+    template <typename TileCons, pto::TileSplitAxis Split>
+    PTO_INTERNAL void pop(RingFiFo &fifo, TileCons &tile) {
+      static_assert(Split == pto::TileSplitAxis::TILE_NO_SPLIT,
+                    "distributed_ffn_grid uses full-tile TPipe slots");
+      static_assert((is_c2v && TileCons::Loc == pto::TileType::Vec) ||
+                        (is_v2c && TileCons::Loc == pto::TileType::Mat),
+                    "TPipe direction does not match consumer tile type");
+      using T = typename TileCons::DType;
+      constexpr int rows = TileCons::Rows;
+      constexpr int cols = TileCons::Cols;
+      size_t entryBase = (tileIndex % RingFiFo::SLOT_NUM) * RingFiFo::SLOT_SIZE;
+      uint64_t localBase = TileCons::Loc == pto::TileType::Vec ? fifo.C2V_CONSUMER_BUF : fifo.V2C_CONSUMER_BUF;
+      localBase += (tileIndex % RingFiFo::LOCAL_SLOT_NUM) * rows * cols * sizeof(T);
+      TASSIGN_IMPL(tile, localBase);
+      using GlobalData = pto::GlobalTensor<T, pto::Shape<1, 1, 1, rows, cols>, pto::Stride<1, 1, 1, cols, 1>>;
+      GlobalData globalTensor(reinterpret_cast<__gm__ T *>(reinterpret_cast<uint64_t>(fifo.GM_SLOT_BUFFER) +
+                                                           entryBase + entryOffset));
+      TLOAD_IMPL(tile, globalTensor);
+    }
+  };
+
+  RingFiFo fifo;
+  Producer prod;
+  Consumer cons;
+
+  PTO_INTERNAL explicit FfnSerialTPipe(__gm__ void *gmSlotBuffer, uint32_t c2vConsumerBuf,
+                                      uint32_t v2cConsumerBuf)
+      : fifo(gmSlotBuffer, c2vConsumerBuf, v2cConsumerBuf), prod(), cons() {}
+};
+
+using GatePipe = FfnSerialTPipe<0, static_cast<uint8_t>(pto::Direction::DIR_C2V), FFN_GATE_PARTIAL_BYTES>;
+using UpPipe = FfnSerialTPipe<2, static_cast<uint8_t>(pto::Direction::DIR_C2V), FFN_UP_PARTIAL_BYTES>;
+using HiddenPipe = FfnSerialTPipe<4, static_cast<uint8_t>(pto::Direction::DIR_V2C), FFN_HIDDEN_BYTES>;
+using DownPipe = FfnSerialTPipe<6, static_cast<uint8_t>(pto::Direction::DIR_C2V), FFN_DOWN_PARTIAL_BYTES>;
+
+constexpr int kUbGateF32 = 0x0000;
+constexpr int kUbUpF32 = 0x1000;
+constexpr int kUbHiddenF32 = 0x2000;
+constexpr int kUbHiddenF16 = 0x3000;
+constexpr int kUbDownF32 = 0x4000;
+constexpr int kUbAddF32 = 0x5000;
+
+#endif  // __CCE_AICORE__
+
+__global__ AICORE void DistributedFfnGridCommKernel(
+    __gm__ uint8_t *reducePipeWindow, __gm__ uint8_t *gatePartial,
+    __gm__ uint8_t *upPartial, __gm__ uint8_t *hiddenOut,
+    __gm__ uint8_t *downPartial, __gm__ uint8_t *yOutput,
+    __gm__ uint8_t *hcclCtxRaw, __gm__ uint8_t *chunkFlags, int gridRows,
+    int gridCols, int phase) {
+#ifdef __CCE_AICORE__
+  (void)chunkFlags;
+
+  int blockIdx = get_block_idx();
+  int totalBlocks = gridRows * gridCols;
+  if (blockIdx < 0 || blockIdx >= totalBlocks) {
+    return;
+  }
+  int row = blockIdx / gridCols;
+  int col = blockIdx - row * gridCols;
+
+  if (phase == 1) {
+    DownF32Tile downF32;
+    DownF32Tile addF32;
+    TASSIGN(downF32, kUbDownF32);
+    TASSIGN(addF32, kUbAddF32);
+
+    constexpr int downTileBytes = FFN_DOWN_PARTIAL_BYTES;
+    constexpr int yTileBytes = FFN_Y_OUTPUT_BYTES;
+    __gm__ uint8_t *downBlock = downPartial + blockIdx * downTileBytes;
+    __gm__ uint8_t *yBlock = yOutput + row * yTileBytes;
+
+    DownPipe downPipe(reinterpret_cast<__gm__ void *>(downBlock), kUbDownF32, 0);
+    pto::TPOP<DownPipe, DownF32Tile, pto::TileSplitAxis::TILE_NO_SPLIT>(downPipe, downF32);
+
+#ifndef __PTO_AUTO__
+    set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+    wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+#endif
+
+    FfnGridPipe reducePipe;
+    pto::GridShape shape{gridRows, gridCols};
+    pto::GridCoord coord{row, col};
+    __gm__ uint8_t *window = reducePipeWindow + blockIdx * FFN_GRID_WINDOW_BYTES;
+    pto::a2a3_grid::InitGridPipeFromWindow(
+        reducePipe, shape, coord, window, reinterpret_cast<__gm__ void *>(hcclCtxRaw),
+        /*pipeId=*/0);
+
+    using pto::GridDirection;
+    if (col > 0) {
+      pto::TPOP<GridDirection::EAST>(reducePipe, addF32);
+#ifndef __PTO_AUTO__
+      pipe_barrier(PIPE_ALL);
+#endif
+      dsb(DSB_DDR);
+      TADD(downF32, downF32, addF32);
+#ifndef __PTO_AUTO__
+      pipe_barrier(PIPE_V);
+#endif
+    }
+
+    if (col + 1 < gridCols) {
+#ifndef __PTO_AUTO__
+      pipe_barrier(PIPE_ALL);
+#endif
+      dsb(DSB_DDR);
+      pto::TPUSH<GridDirection::EAST>(reducePipe, downF32);
+    } else {
+#ifndef __PTO_AUTO__
+      set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+      wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+#endif
+      GTHF32 yG(reinterpret_cast<__gm__ float *>(yBlock));
+      TSTORE(yG, downF32);
+    }
+
+#ifndef __PTO_AUTO__
+    pipe_barrier(PIPE_ALL);
+#endif
+    dsb(DSB_DDR);
+    return;
+  }
+
+  if (phase != 0) {
+    return;
+  }
+
+  GateF32Tile gateF32;
+  UpF32Tile upF32;
+  HiddenF32Tile hiddenF32;
+  HiddenF16Tile hiddenF16;
+  TASSIGN(gateF32, kUbGateF32);
+  TASSIGN(upF32, kUbUpF32);
+  TASSIGN(hiddenF32, kUbHiddenF32);
+  TASSIGN(hiddenF16, kUbHiddenF16);
+
+  constexpr int partialTileBytes = FFN_GATE_PARTIAL_BYTES;
+  constexpr int hiddenTileBytes = FFN_HIDDEN_BYTES;
+  __gm__ uint8_t *gateBlock = gatePartial + blockIdx * partialTileBytes;
+  __gm__ uint8_t *upBlock = upPartial + blockIdx * partialTileBytes;
+  __gm__ uint8_t *hiddenBlock = hiddenOut + blockIdx * hiddenTileBytes;
+
+  GatePipe gatePipe(reinterpret_cast<__gm__ void *>(gateBlock), kUbGateF32, 0);
+  UpPipe upPipe(reinterpret_cast<__gm__ void *>(upBlock), kUbUpF32, 0);
+  pto::TPOP<GatePipe, GateF32Tile, pto::TileSplitAxis::TILE_NO_SPLIT>(gatePipe, gateF32);
+  pto::TPOP<UpPipe, UpF32Tile, pto::TileSplitAxis::TILE_NO_SPLIT>(upPipe, upF32);
+
+#ifndef __PTO_AUTO__
+  set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+  wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+#endif
+
+  TLRELU(gateF32, gateF32, FFN_PRELU_ALPHA);
+
+#ifndef __PTO_AUTO__
+  pipe_barrier(PIPE_V);
+#endif
+
+  TMUL(hiddenF32, gateF32, upF32);
+
+#ifndef __PTO_AUTO__
+  pipe_barrier(PIPE_V);
+#endif
+
+  TCVT(hiddenF16, hiddenF32, pto::RoundMode::CAST_RINT);
+
+#ifndef __PTO_AUTO__
+  set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+  wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+#endif
+
+  HiddenPipe hiddenPipe(reinterpret_cast<__gm__ void *>(hiddenBlock), 0, 0);
+  pto::TPUSH<HiddenPipe, HiddenF16Tile, pto::TileSplitAxis::TILE_NO_SPLIT>(hiddenPipe, hiddenF16);
+
+#ifndef __PTO_AUTO__
+  pipe_barrier(PIPE_ALL);
+#endif
+  dsb(DSB_DDR);
+#else
+  (void)reducePipeWindow;
+  (void)gatePartial;
+  (void)upPartial;
+  (void)hiddenOut;
+  (void)downPartial;
+  (void)yOutput;
+  (void)hcclCtxRaw;
+  (void)chunkFlags;
+  (void)gridRows;
+  (void)gridCols;
+  (void)phase;
+#endif
+}
+
+void launchDistributedFfnGridCommKernel(uint8_t *reducePipeWindow,
+                                        uint8_t *gatePartial,
+                                        uint8_t *upPartial, uint8_t *hiddenOut,
+                                        uint8_t *downPartial, uint8_t *yOutput,
+                                        uint8_t *hcclCtx, uint8_t *chunkFlags,
+                                        int gridRows, int gridCols,
+                                        int phase, void *stream) {
+  int totalBlocks = gridRows * gridCols;
+  if (totalBlocks <= 0) {
+    return;
+  }
+  DistributedFfnGridCommKernel<<<totalBlocks, nullptr, stream>>>(
+      reducePipeWindow, gatePartial, upPartial, hiddenOut, downPartial, yOutput,
+      hcclCtx, chunkFlags, gridRows, gridCols, phase);
+}

--- a/kernels/manual/a2a3/distributed_ffn_grid/distributed_ffn_grid_compute_kernel.cpp
+++ b/kernels/manual/a2a3/distributed_ffn_grid/distributed_ffn_grid_compute_kernel.cpp
@@ -1,0 +1,341 @@
+/**
+Copyright (c) 2026 Huawei Technologies Co., Ltd.
+This program is free software, you can redistribute it and/or modify it under
+the terms and conditions of CANN Open Software License Agreement Version 2.0
+(the "License"). Please refer to the License for details. You may not use this
+file except in compliance with the License. THIS SOFTWARE IS PROVIDED ON AN "AS
+IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING
+BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A
+PARTICULAR PURPOSE. See LICENSE in the root of the software repository for the
+full text of the License.
+*/
+
+// M3 Session D-6: cube .so producer for the full FFN matmul pipeline.
+//
+// Single-device multi-block FFN cube kernel.  Each block owns one logical
+// grid cell (row, col).  Phase 0 computes gate/up partials for that cell, the
+// vec kernel computes hidden, and phase 1 computes the cell's down partial.
+//
+// gridRows*gridCols is the launched block count on one device.
+
+#include <cstddef>
+#include <cstdint>
+#include <pto/pto-inst.hpp>
+
+#include <pto/common/fifo.hpp>
+
+#include "common.hpp"
+#include "ffn_config.hpp"
+
+#ifdef __CCE_AICORE__
+using namespace pto;
+
+template <uint8_t FlagId, uint8_t DirType, uint32_t SlotSize, uint32_t SlotNum = 1, uint32_t LocalSlotNum = 1>
+struct FfnSerialTPipe {
+  static constexpr uint8_t DIR_MASK = 0x7;
+  static constexpr uint8_t DIR_TYPE = DIR_MASK & DirType;
+  static constexpr bool is_c2v = (DIR_TYPE == Direction::DIR_C2V);
+  static constexpr bool is_v2c = (DIR_TYPE == Direction::DIR_V2C);
+  static constexpr uint32_t SyncPeriod = 1;
+  using RingFiFo = RingFIFO<SlotSize, SlotNum, LocalSlotNum>;
+
+  PTO_INTERNAL static bool shouldWaitFree(uint32_t) { return false; }
+  PTO_INTERNAL static bool shouldNotifyFree(uint32_t) { return false; }
+
+  struct Producer {
+    uint32_t tileIndex = 0;
+    int entryOffset = 0;
+
+    PTO_INTERNAL void setAllocateStatus(bool) {}
+    PTO_INTERNAL void setRecordStatus(bool) {}
+    PTO_INTERNAL void setTileId(int tIndex, int) { tileIndex = static_cast<uint32_t>(tIndex); }
+    PTO_INTERNAL void setEntryOffset(int offset) { entryOffset = offset; }
+    PTO_INTERNAL bool getAllocateStatus() const { return false; }
+    PTO_INTERNAL bool getRecordStatus() const { return false; }
+    PTO_INTERNAL void allocate() const {}
+    PTO_INTERNAL void record() const {}
+
+    template <typename TileProd, TileSplitAxis Split>
+    PTO_INTERNAL void push(RingFiFo &fifo, TileProd &tile) {
+      static_assert(Split == TileSplitAxis::TILE_NO_SPLIT, "distributed_ffn_grid uses full-tile TPipe slots");
+      static_assert((is_c2v && TileProd::Loc == TileType::Acc) || (is_v2c && TileProd::Loc == TileType::Vec),
+                    "TPipe direction does not match producer tile type");
+      using T = typename TileProd::DType;
+      constexpr int rows = TileProd::Rows;
+      constexpr int cols = TileProd::Cols;
+      size_t entryBase = (tileIndex % RingFiFo::SLOT_NUM) * RingFiFo::SLOT_SIZE;
+      using GlobalData = GlobalTensor<T, Shape<1, 1, 1, rows, cols>, Stride<1, 1, 1, cols, 1>>;
+      GlobalData globalTensor(reinterpret_cast<__gm__ T *>(reinterpret_cast<uint64_t>(fifo.GM_SLOT_BUFFER) +
+                                                           entryBase + entryOffset));
+      TSTORE_IMPL(globalTensor, tile);
+    }
+  };
+
+  struct Consumer {
+    uint32_t tileIndex = 0;
+    int entryOffset = 0;
+
+    PTO_INTERNAL void setWaitStatus(bool) {}
+    PTO_INTERNAL void setFreeStatus(bool) {}
+    PTO_INTERNAL void setTileId(int tIndex, int) { tileIndex = static_cast<uint32_t>(tIndex); }
+    PTO_INTERNAL void setEntryOffset(int offset) { entryOffset = offset; }
+    PTO_INTERNAL bool getWaitStatus() const { return false; }
+    PTO_INTERNAL bool getFreeStatus() const { return false; }
+    PTO_INTERNAL void wait() const {}
+    PTO_INTERNAL void free() const {}
+
+    template <typename TileCons, TileSplitAxis Split>
+    PTO_INTERNAL void pop(RingFiFo &fifo, TileCons &tile) {
+      static_assert(Split == TileSplitAxis::TILE_NO_SPLIT, "distributed_ffn_grid uses full-tile TPipe slots");
+      static_assert((is_c2v && TileCons::Loc == TileType::Vec) || (is_v2c && TileCons::Loc == TileType::Mat),
+                    "TPipe direction does not match consumer tile type");
+      using T = typename TileCons::DType;
+      constexpr int rows = TileCons::Rows;
+      constexpr int cols = TileCons::Cols;
+      size_t entryBase = (tileIndex % RingFiFo::SLOT_NUM) * RingFiFo::SLOT_SIZE;
+      uint64_t localBase = TileCons::Loc == TileType::Vec ? fifo.C2V_CONSUMER_BUF : fifo.V2C_CONSUMER_BUF;
+      localBase += (tileIndex % RingFiFo::LOCAL_SLOT_NUM) * rows * cols * sizeof(T);
+      TASSIGN_IMPL(tile, localBase);
+      using GlobalData = GlobalTensor<T, Shape<1, 1, 1, rows, cols>, Stride<1, 1, 1, cols, 1>>;
+      GlobalData globalTensor(reinterpret_cast<__gm__ T *>(reinterpret_cast<uint64_t>(fifo.GM_SLOT_BUFFER) +
+                                                           entryBase + entryOffset));
+      TLOAD_IMPL(tile, globalTensor);
+    }
+  };
+
+  RingFiFo fifo;
+  Producer prod;
+  Consumer cons;
+
+  PTO_INTERNAL explicit FfnSerialTPipe(__gm__ void *gmSlotBuffer, uint32_t c2vConsumerBuf,
+                                      uint32_t v2cConsumerBuf)
+      : fifo(gmSlotBuffer, c2vConsumerBuf, v2cConsumerBuf), prod(), cons() {}
+};
+
+#endif
+
+__global__ AICORE void DistributedFfnGridComputeKernel(
+    __gm__ uint8_t *x, __gm__ uint8_t *wGate, __gm__ uint8_t *wUp,
+    __gm__ uint8_t *wDown, __gm__ uint8_t *gatePartial,
+    __gm__ uint8_t *upPartial, __gm__ uint8_t *hiddenIn,
+    __gm__ uint8_t *downPartial, __gm__ uint8_t *yOutput,
+    __gm__ uint8_t *chunkFlags, int gridRows, int gridCols, int myRankId,
+    int phase) {
+#ifdef __CCE_AICORE__
+  (void)myRankId;
+  (void)chunkFlags;
+  (void)yOutput;
+
+  int blockIdx = get_block_idx();
+  int totalBlocks = gridRows * gridCols;
+  if (blockIdx < 0 || blockIdx >= totalBlocks) {
+    return;
+  }
+
+  constexpr int validM = FFN_TOKEN_TILE;  // 16
+  constexpr int validK = FFN_MODEL_TILE;  // 64
+  constexpr int validN = FFN_FFN_TILE;    // 64
+  constexpr int blockAlign = C0_SIZE_BYTE / static_cast<int>(sizeof(half));
+  constexpr int M = ((validM + 15) / 16) * 16;
+  constexpr int K = ((validK + blockAlign - 1) / blockAlign) * blockAlign;
+  constexpr int N = ((validN + blockAlign - 1) / blockAlign) * blockAlign;
+
+  using GX = GlobalTensor<
+      half, Shape<1, 1, 1, validM, validK>,
+      Stride<validM * validK, validM * validK, validM * validK, validK, 1>>;
+  using GW = GlobalTensor<
+      half, Shape<1, 1, 1, validK, validN>,
+      Stride<validK * validN, validK * validN, validK * validN, validN, 1>>;
+  using TileA = Tile<TileType::Mat, half, M, K, BLayout::ColMajor, validM,
+                     validK, SLayout::RowMajor, 512>;
+  using TileB = Tile<TileType::Mat, half, K, N, BLayout::ColMajor, validK,
+                     validN, SLayout::RowMajor, 512>;
+  using TL = TileLeft<half, M, K, validM, validK>;
+  using TR = TileRight<half, K, N, validK, validN>;
+  using TC = TileAcc<float, M, N, validM, validN>;
+
+  using GatePipe = FfnSerialTPipe<0, static_cast<uint8_t>(Direction::DIR_C2V), FFN_GATE_PARTIAL_BYTES>;
+  using UpPipe = FfnSerialTPipe<2, static_cast<uint8_t>(Direction::DIR_C2V), FFN_UP_PARTIAL_BYTES>;
+  using HiddenPipe = FfnSerialTPipe<4, static_cast<uint8_t>(Direction::DIR_V2C), FFN_HIDDEN_BYTES>;
+  using DownPipe = FfnSerialTPipe<6, static_cast<uint8_t>(Direction::DIR_C2V), FFN_DOWN_PARTIAL_BYTES>;
+
+  constexpr int kL1X = 0x00000;
+  constexpr int kL1Hidden = 0x10000;
+  constexpr int kL1WGate = 0x20000;
+  constexpr int kL1WUp = 0x24000;
+  constexpr int kL1WDown = 0x28000;
+
+  TileA xMat;
+  TileA hiddenMat;
+  TileB wGateMat;
+  TileB wUpMat;
+  TileB wDownMat;
+  TASSIGN(xMat, kL1X);
+  TASSIGN(hiddenMat, kL1Hidden);
+  TASSIGN(wGateMat, kL1WGate);
+  TASSIGN(wUpMat, kL1WUp);
+  TASSIGN(wDownMat, kL1WDown);
+
+  TL aT;
+  TR bT;
+  TC cT;
+  TASSIGN(aT, 0x0);
+  TASSIGN(bT, 0x0);
+  TASSIGN(cT, 0x0);
+
+  constexpr int xTileBytes = FFN_X_BYTES;
+  constexpr int wGateTileBytes = FFN_W_GATE_BYTES;
+  constexpr int wUpTileBytes = FFN_W_UP_BYTES;
+  constexpr int wDownTileBytes = FFN_W_DOWN_BYTES;
+  constexpr int partialTileBytes = FFN_GATE_PARTIAL_BYTES;
+  constexpr int hiddenTileBytes = FFN_HIDDEN_BYTES;
+  constexpr int downTileBytes = FFN_DOWN_PARTIAL_BYTES;
+  __gm__ uint8_t *xBlock = x + blockIdx * xTileBytes;
+  __gm__ uint8_t *wGateBlock = wGate + blockIdx * wGateTileBytes;
+  __gm__ uint8_t *wUpBlock = wUp + blockIdx * wUpTileBytes;
+  __gm__ uint8_t *wDownBlock = wDown + blockIdx * wDownTileBytes;
+  __gm__ uint8_t *gateBlock = gatePartial + blockIdx * partialTileBytes;
+  __gm__ uint8_t *upBlock = upPartial + blockIdx * partialTileBytes;
+  __gm__ uint8_t *hiddenBlock = hiddenIn + blockIdx * hiddenTileBytes;
+  __gm__ uint8_t *downBlock = downPartial + blockIdx * downTileBytes;
+
+  GX xG(reinterpret_cast<__gm__ half *>(xBlock));
+  GW wGateG(reinterpret_cast<__gm__ half *>(wGateBlock));
+  GW wUpG(reinterpret_cast<__gm__ half *>(wUpBlock));
+  GW wDownG(reinterpret_cast<__gm__ half *>(wDownBlock));
+
+  TLOAD(xMat, xG);
+  TLOAD(wGateMat, wGateG);
+  TLOAD(wUpMat, wUpG);
+  TLOAD(wDownMat, wDownG);
+
+#ifndef __PTO_AUTO__
+  set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);
+  wait_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);
+#endif
+
+  if (phase == 0) {
+    GatePipe gatePipe(reinterpret_cast<__gm__ void *>(gateBlock), 0, 0);
+    UpPipe upPipe(reinterpret_cast<__gm__ void *>(upBlock), 0, 0);
+
+    // -------- gate: gatePartial = x @ W_gate --------
+    TMOV(aT, xMat);
+    TMOV(bT, wGateMat);
+
+#ifndef __PTO_AUTO__
+    set_flag(PIPE_MTE1, PIPE_M, EVENT_ID0);
+    wait_flag(PIPE_MTE1, PIPE_M, EVENT_ID0);
+#endif
+
+    TMATMUL(cT, aT, bT);
+
+#ifndef __PTO_AUTO__
+    set_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
+    wait_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
+#endif
+
+    TPUSH<GatePipe, TC, TileSplitAxis::TILE_NO_SPLIT>(gatePipe, cT);
+
+#ifndef __PTO_AUTO__
+    pipe_barrier(PIPE_ALL);
+#endif
+    dsb(DSB_DDR);
+    // -------- up: upPartial = x @ W_up --------
+    TMOV(aT, xMat);
+    TMOV(bT, wUpMat);
+
+#ifndef __PTO_AUTO__
+    set_flag(PIPE_MTE1, PIPE_M, EVENT_ID0);
+    wait_flag(PIPE_MTE1, PIPE_M, EVENT_ID0);
+#endif
+
+    TMATMUL(cT, aT, bT);
+
+#ifndef __PTO_AUTO__
+    set_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
+    wait_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
+#endif
+
+    TPUSH<UpPipe, TC, TileSplitAxis::TILE_NO_SPLIT>(upPipe, cT);
+
+#ifndef __PTO_AUTO__
+    pipe_barrier(PIPE_ALL);
+#endif
+    dsb(DSB_DDR);
+    return;
+  }
+
+  if (phase != 1) {
+    return;
+  }
+
+  HiddenPipe hiddenPipe(reinterpret_cast<__gm__ void *>(hiddenBlock), 0, kL1Hidden);
+  TPOP<HiddenPipe, TileA, TileSplitAxis::TILE_NO_SPLIT>(hiddenPipe, hiddenMat);
+#ifndef __PTO_AUTO__
+  set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);
+  wait_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);
+  pipe_barrier(PIPE_ALL);
+#endif
+  dsb(DSB_DDR);
+
+  {
+    // -------- down: downPartial = hidden @ W_down --------
+    // Hidden is [T, Fi] fp16, W_down is [Fi, H] fp16, output is [T, H] fp32.
+    // With FFN_FFN_TILE == FFN_MODEL_TILE in the default 1x2 config the
+    // GX/GW/GO/TileA/TileB/TileC type aliases are byte-equivalent to the
+    // gate/up step, so we reuse them.  If the two tile dims diverge in a
+    // future config, split the typedefs.
+    TMOV(aT, hiddenMat);
+    TMOV(bT, wDownMat);
+
+#ifndef __PTO_AUTO__
+    set_flag(PIPE_MTE1, PIPE_M, EVENT_ID0);
+    wait_flag(PIPE_MTE1, PIPE_M, EVENT_ID0);
+#endif
+
+    TMATMUL(cT, aT, bT);
+
+#ifndef __PTO_AUTO__
+    set_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
+    wait_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
+#endif
+
+    DownPipe downPipe(reinterpret_cast<__gm__ void *>(downBlock), 0, 0);
+    TPUSH<DownPipe, TC, TileSplitAxis::TILE_NO_SPLIT>(downPipe, cT);
+
+#ifndef __PTO_AUTO__
+    pipe_barrier(PIPE_ALL);
+#endif
+    dsb(DSB_DDR);
+  }
+#else
+  (void)x;
+  (void)wGate;
+  (void)wUp;
+  (void)wDown;
+  (void)gatePartial;
+  (void)upPartial;
+  (void)hiddenIn;
+  (void)downPartial;
+  (void)yOutput;
+  (void)chunkFlags;
+  (void)gridRows;
+  (void)gridCols;
+  (void)myRankId;
+  (void)phase;
+#endif
+}
+
+void launchDistributedFfnGridComputeKernel(
+    uint8_t *x, uint8_t *wGate, uint8_t *wUp, uint8_t *wDown,
+    uint8_t *gatePartial, uint8_t *upPartial, uint8_t *hiddenIn,
+    uint8_t *downPartial, uint8_t *yOutput, uint8_t *chunkFlags, int gridRows,
+    int gridCols, int myRankId, int phase, void *stream) {
+  int totalBlocks = gridRows * gridCols;
+  if (totalBlocks <= 0) {
+    return;
+  }
+  DistributedFfnGridComputeKernel<<<totalBlocks, nullptr, stream>>>(
+      x, wGate, wUp, wDown, gatePartial, upPartial, hiddenIn, downPartial,
+      yOutput, chunkFlags, gridRows, gridCols, myRankId, phase);
+}

--- a/kernels/manual/a2a3/distributed_ffn_grid/ffn_config.hpp
+++ b/kernels/manual/a2a3/distributed_ffn_grid/ffn_config.hpp
@@ -1,0 +1,172 @@
+/**
+Copyright (c) 2026 Huawei Technologies Co., Ltd.
+This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+CANN Open Software License Agreement Version 2.0 (the "License").
+Please refer to the License for details. You may not use this file except in compliance with the License.
+THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+See LICENSE in the root of the software repository for the full text of the License.
+*/
+
+// Compile-time shape constants for the 1x2 distributed FFN demo.
+// Kept minimal: this is the M2 skeleton; later milestones grow to 2x2 and
+// real FFN shapes (see plan declarative-launching-simon.md M3/M4).
+
+#ifndef DISTRIBUTED_FFN_GRID_CONFIG_HPP
+#define DISTRIBUTED_FFN_GRID_CONFIG_HPP
+
+#ifndef CONFIG_GRID_ROWS
+#define CONFIG_GRID_ROWS 2
+#endif
+
+#ifndef CONFIG_GRID_COLS
+#define CONFIG_GRID_COLS 2
+#endif
+
+#ifndef CONFIG_TOKEN_TILE
+#define CONFIG_TOKEN_TILE 16
+#endif
+
+#ifndef CONFIG_MODEL_TILE
+#define CONFIG_MODEL_TILE 64
+#endif
+
+#ifndef CONFIG_FFN_TILE
+#define CONFIG_FFN_TILE 64
+#endif
+
+constexpr int FFN_GRID_ROWS  = CONFIG_GRID_ROWS;
+constexpr int FFN_GRID_COLS  = CONFIG_GRID_COLS;
+constexpr int FFN_TOKEN_TILE = CONFIG_TOKEN_TILE;
+constexpr int FFN_MODEL_TILE = CONFIG_MODEL_TILE;
+constexpr int FFN_FFN_TILE   = CONFIG_FFN_TILE;
+
+constexpr int FFN_TILE_ELEMS = FFN_TOKEN_TILE * FFN_MODEL_TILE;
+constexpr int FFN_TILE_BYTES = FFN_TILE_ELEMS * 2;  // half
+
+// D-2: GridPipe slot capacity bumped to fp32 [T, H] = T*H*4 so the EAST
+// reduce stage can carry the fp32 down_partial tile without losing precision.
+// SOURCE direction is no longer used by D-2 (cube reads X from x_dev), but the
+// 4-direction window layout is unchanged -- the bump only enlarges per-slot
+// padding.  ResultCmp tolerance 1e-3 in D-3 depends on this fp32 path.
+constexpr int FFN_SLOT_BYTES = FFN_TOKEN_TILE * FFN_MODEL_TILE * 4;
+constexpr int FFN_SLOT_COUNT = 4;
+
+// Host-visible mirror of pto::a2a3_grid::kWindowBytes<FFN_SLOT_BYTES, FFN_SLOT_COUNT>().
+// Keep in sync with include/pto/npu/a2a3/grid_pipe_runtime.hpp:
+//   layout = kFlagsBytes (64) + 4 dirs * SlotCount * SlotBytes.
+constexpr int FFN_GRID_FLAGS_BYTES = 64;
+constexpr int FFN_GRID_WINDOW_BYTES =
+    FFN_GRID_FLAGS_BYTES + 4 * FFN_SLOT_COUNT * FFN_SLOT_BYTES;
+
+// ---------------------------------------------------------------------------
+// Host-side mirror of pto::a2a3_grid slot/flag layout, used by main.cpp to
+// memcpy the SOURCE-direction X shard into the GridPipe window before launch.
+// Pure integer constexpr.  Do NOT add any <pto/...> include in this header --
+// main.cpp parses it in HOST mode, and an AICORE attribute leaking in would
+// break the host parser.
+//
+// Source of truth:
+//   include/pto/npu/a2a3/grid_pipe_runtime.hpp
+//     - kFlagsBytes              = 64
+//     - kSlotRegionOffset        = kFlagsBytes
+//     - kReadyFlagOffset(d)      = (uint32_t)d * sizeof(uint32_t)
+//     - kDirSlotRegionOffset(d)  = kSlotRegionOffset + (uint32_t)d * SlotCount * SlotBytes
+//   include/pto/common/grid_pipe.hpp
+//     - GridDirection::SOURCE = 0
+//
+// Any change to the constexpr functions above MUST update the mirrors here.
+// ---------------------------------------------------------------------------
+constexpr int FFN_GRID_DIR_SOURCE_INDEX = 0;  // GridDirection::SOURCE
+constexpr int FFN_GRID_SLOT_REGION_OFFSET = FFN_GRID_FLAGS_BYTES;  // 64
+constexpr int FFN_GRID_READY_FLAG_SOURCE_OFFSET =
+    FFN_GRID_DIR_SOURCE_INDEX * static_cast<int>(sizeof(unsigned int));  // 0
+constexpr int FFN_GRID_SOURCE_SLOT0_OFFSET =
+    FFN_GRID_SLOT_REGION_OFFSET +
+    FFN_GRID_DIR_SOURCE_INDEX * FFN_SLOT_COUNT * FFN_SLOT_BYTES;  // 64
+
+// ---------------------------------------------------------------------------
+// Per-rank weight + golden byte sizes.
+//   - W_gate [H, Fi]   fp16   = FFN_MODEL_TILE * FFN_FFN_TILE * 2
+//   - W_up   [H, Fi]   fp16   = FFN_MODEL_TILE * FFN_FFN_TILE * 2
+//   - W_down [Fi, H]   fp16   = FFN_FFN_TILE  * FFN_MODEL_TILE * 2
+//   - golden_per_row [T, H]   fp32   = FFN_TOKEN_TILE * FFN_MODEL_TILE * 4
+//     (each row owns one [T, H] slice of yOutput; rank with col == cols-1
+//      writes its row's slice)
+//   - golden_total   [T_total, H]    fp32   = FFN_GRID_ROWS * FFN_GOLDEN_BYTES
+//     (full file on disk; data-parallel rows split T across rows)
+// Source of truth for both scripts/gen_data.py and main.cpp aclrtMalloc.
+// If dtype or T_total layout changes, update gen_data.py AND main.cpp LoadWeights
+// / VerifyOutput together.
+// ---------------------------------------------------------------------------
+constexpr int FFN_W_GATE_BYTES = FFN_MODEL_TILE * FFN_FFN_TILE * 2;
+constexpr int FFN_W_UP_BYTES   = FFN_MODEL_TILE * FFN_FFN_TILE * 2;
+constexpr int FFN_W_DOWN_BYTES = FFN_FFN_TILE  * FFN_MODEL_TILE * 2;
+constexpr int FFN_GOLDEN_BYTES = FFN_TOKEN_TILE * FFN_MODEL_TILE * 4;
+constexpr int FFN_GOLDEN_TOTAL_BYTES = FFN_GRID_ROWS * FFN_GOLDEN_BYTES;
+
+// ---------------------------------------------------------------------------
+// M3 Session D-2: ChunkFlagMatrix layout for cube/comm coordination.
+//   - num_ranks            : 1 (intra-rank cube <-> comm producer/consumer).
+//   - num_tiles_per_src    : 4 (gate=0, up=1, hidden=2 (comm->cube), down=3).
+//   - chunk_size           : 1 (one tile per chunk -> four flags total).
+// num_chunks_per_src = ceil(num_tiles_per_src / chunk_size) = 4.
+// stride = ((num_chunks + 15) / 16) * 16 = 16, so each flag is 4 bytes apart
+// inside the chunk_flags region (chunk_idx * 4 from base of region).
+// Cube cannot pull pto/comm/pto_comm_inst.hpp (asc-only), so it writes flag 0,
+// 1, 3 via raw volatile + dcci.  Comm writes flag 2 via SetChunkFlagReady
+// (TNOTIFY AtomicAdd).  Read pattern: comm uses IsChunkReady on flags 0/1/3;
+// cube uses a raw volatile poll on flag 2.
+// ---------------------------------------------------------------------------
+constexpr int FFN_CHUNK_NUM_RANKS         = 1;
+constexpr int FFN_CHUNK_NUM_TILES_PER_SRC = 4;
+constexpr int FFN_CHUNK_SIZE              = 1;
+
+// Symbolic flag indices for the 4-chunk schema.  Anywhere these are passed to
+// the cube kernel they go in via a raw pointer offset; cube ignores the
+// SetChunkFlagReady API.  Comm uses these as the chunk_idx argument to
+// IsChunkReady / SetChunkFlagReady.
+constexpr int FFN_FLAG_GATE_READY    = 0;  // cube -> comm
+constexpr int FFN_FLAG_UP_READY      = 1;  // cube -> comm
+constexpr int FFN_FLAG_HIDDEN_READY  = 2;  // comm -> cube
+constexpr int FFN_FLAG_DOWN_READY    = 3;  // cube -> comm
+
+// Byte offset of the int32_t chunk_flags[][] region inside the per-rank
+// ChunkFlagMatrix.  Source of truth is `struct alignas(64) ChunkFlagMatrix`
+// in ready_queue.hpp -- header is exactly 64 bytes (7 fields + 9-element
+// padding to satisfy alignas(64)).  The cube .so cannot include
+// ready_queue.hpp (pulls pto/comm/pto_comm_inst.hpp), so this mirror is the
+// only path for cube to compute the doorbell pointer.
+constexpr int FFN_CHUNKFLAG_OFFSET_HEADER = 64;
+
+// ---------------------------------------------------------------------------
+// D-2 device buffer byte sizes (cube + comm FFN pipeline).
+//   - x          [T, H]   fp16  (per-rank shard, loaded by main from
+//                                pe_<r>_x.bin into an independent device
+//                                buffer; cube TMATMUL input for gate/up)
+//   - gatePartial[T, Fi]  fp32  (cube output: X @ W_gate)
+//   - upPartial  [T, Fi]  fp32  (cube output: X @ W_up)
+//   - hidden     [T, Fi]  fp16  (comm output: TCVT(TMUL(prelu(gate), up));
+//                                cube TMATMUL input for down projection)
+//   - downPartial[T, H]   fp32  (cube output: hidden @ W_down; comm input for
+//                                EAST reduce.  EAST reduce uses fp32 across
+//                                cols and writes the rank-(M-1) result into
+//                                yOutput.)
+// ---------------------------------------------------------------------------
+constexpr int FFN_X_BYTES            = FFN_TOKEN_TILE * FFN_MODEL_TILE * 2;
+constexpr int FFN_GATE_PARTIAL_BYTES = FFN_TOKEN_TILE * FFN_FFN_TILE   * 4;
+constexpr int FFN_UP_PARTIAL_BYTES   = FFN_TOKEN_TILE * FFN_FFN_TILE   * 4;
+constexpr int FFN_HIDDEN_BYTES       = FFN_TOKEN_TILE * FFN_FFN_TILE   * 2;
+constexpr int FFN_DOWN_PARTIAL_BYTES = FFN_TOKEN_TILE * FFN_MODEL_TILE * 4;
+
+// yOutput dtype changed from fp16 (D-1 passthrough) to fp32 (D-2 final reduce
+// output).  Matches FFN_GOLDEN_BYTES / golden.bin so host ResultCmp is
+// straight memcmp(fp32, fp32) without a half->float pass.
+constexpr int FFN_Y_OUTPUT_BYTES     = FFN_TOKEN_TILE * FFN_MODEL_TILE * 4;
+
+// PReLU negative-slope coefficient.  Source of truth is gen_data.py top-level
+// alpha; if you change one you MUST change the other or D-3 ResultCmp fails.
+// Used by the comm kernel as a TLRELU scalar (no separate alpha tile needed).
+constexpr float FFN_PRELU_ALPHA = 0.1f;
+
+#endif  // DISTRIBUTED_FFN_GRID_CONFIG_HPP

--- a/kernels/manual/a2a3/distributed_ffn_grid/gridpipe_payload_inl.hpp
+++ b/kernels/manual/a2a3/distributed_ffn_grid/gridpipe_payload_inl.hpp
@@ -1,0 +1,122 @@
+/**
+Copyright (c) 2026 Huawei Technologies Co., Ltd.
+This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+CANN Open Software License Agreement Version 2.0 (the "License").
+Please refer to the License for details. You may not use this file except in compliance with the License.
+THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+See LICENSE in the root of the software repository for the full text of the License.
+*/
+
+// Per-demo payload + remote-ptr adaptor for the GridPipe A2/A3 backend.
+//
+// GridTPush.hpp / GridTPop.hpp declare three forward functions in
+// `pto::a2a3_grid_payload` that intentionally have no header-level definition,
+// because they need a concrete tile type and the HCCL device context layout
+// that lives in this demo (not in the public header tree).  We provide those
+// definitions here once per kernel translation unit.
+//
+//   RemotePtr<T>(ctx, localPtr, peerRank)
+//     -> resolves a pointer into our own GM window to the same byte offset in
+//        peerRank's window via HcclRemotePtr.  Reused by both push and pop for
+//        the cross-rank ready/free flag writes.
+//
+//   CopyTileToGmSlot<TileT>(remoteSlot, tile, slotBytes)
+//     -> moves a UB-resident tile into a GM slot in the *neighbor's* window.
+//        Implements design doc 5.3 step 3 producer side: `tmov [r_slot], tile`.
+//
+//   CopyGmSlotToTile<TileT>(tile, localSlot, slotBytes)
+//     -> moves bytes from a GM slot in our own window into a UB-resident tile.
+//        Implements design doc 5.3 step 3 consumer side.
+//
+// The skeleton implementation uses AscendC byte-level DataCopy through
+// GlobalTensor/LocalTensor in/out of the tile's underlying address.  Real
+// silicon LPU WSE would issue a single TMOV against the slot region.
+
+#ifndef DISTRIBUTED_FFN_GRID_PAYLOAD_INL_HPP
+#define DISTRIBUTED_FFN_GRID_PAYLOAD_INL_HPP
+
+#include <cstdint>
+
+#include "common.hpp"  // HcclRemotePtr, HcclDeviceContext
+
+namespace pto {
+namespace a2a3_grid_payload {
+
+// ---------------------------------------------------------------------------
+// RemotePtr: trivial wrapper around HcclRemotePtr, but keeps the GridTPush /
+// GridTPop callsites isolated from the HCCL header (they only see the void*
+// runtimeCtx).
+// ---------------------------------------------------------------------------
+template <typename PtrT>
+AICORE inline PtrT *RemotePtr(__gm__ void *runtimeCtx, PtrT *localPtr, int peerRank)
+{
+    auto *ctx = reinterpret_cast<__gm__ HcclDeviceContext *>(runtimeCtx);
+    uint64_t localAddr = reinterpret_cast<uint64_t>(localPtr);
+    for (uint32_t i = 0; i < ctx->rankNum && i < HCCL_MAX_RANK_NUM; ++i) {
+        uint64_t base = ctx->windowsIn[i];
+        if (localAddr >= base && localAddr < base + ctx->winSize) {
+            return reinterpret_cast<__gm__ PtrT *>(ctx->windowsIn[peerRank] + (localAddr - base));
+        }
+    }
+    return HcclRemotePtr(ctx, localPtr, peerRank);
+}
+
+// ---------------------------------------------------------------------------
+// Payload hooks.
+//
+// M3-T1: wire to TSTORE / TLOAD against a 5D ND GlobalTensor view of the
+// remote / local slot.  Tile must be UB-resident (caller TASSIGNs it before
+// the hook fires).  The Shape/Stride convention matches topk_kernel.cpp and
+// allgather_gemm_compute_kernel.cpp: dim0..2 = whole-tile element count,
+// dim3 = Cols, dim4 = 1.
+// ---------------------------------------------------------------------------
+template <typename TileT>
+AICORE inline void CopyTileToGmSlot(__gm__ uint8_t *remoteSlot, TileT &tile, int slotBytes)
+{
+    using Elem = typename TileT::DType;
+    static constexpr int kRows  = TileT::Rows;
+    static constexpr int kCols  = TileT::Cols;
+    static constexpr int kNumel = kRows * kCols;
+    using ShapeT  = pto::Shape<1, 1, 1, kRows, kCols>;
+    using StrideT = pto::Stride<kNumel, kNumel, kNumel, kCols, 1>;
+    using GT = pto::GlobalTensor<Elem, ShapeT, StrideT, pto::Layout::ND>;
+    GT dstG(reinterpret_cast<__gm__ Elem *>(remoteSlot));
+    TSTORE(dstG, tile);
+    // D-5 IN-PROGRESS:
+    // - Producer-side `pipe_barrier(PIPE_ALL); dsb(DSB_DDR)` between this TSTORE
+    //   and MockMtsprReady is now in GRID_TPUSH_IMPL (GridTPush.hpp); on its
+    //   own it leaves yOutput at "rank1-own only" (13244) -- peer payload still
+    //   races into the consumer's local cache and TLOAD picks up zeros most
+    //   runs (act=13244), occasionally the publish lands and we see act=9674
+    //   plus the slot peek shows 9674,10811,...,12639 -- but in those runs the
+    //   rank-own contribution has gone to zero (act = peer only).  Layered
+    //   non-determinism, not a single missing fence.
+    // - An MTE3 drain (`set_flag(MTE3,MTE2,EVENT_ID7); wait_flag(...)`) here was
+    //   tried (mirrors TPUT_IMPL's MTE3 drain) -- did not flip the failure mode.
+    // - Adding the consumer-side per-slot dcci loop in GRID_TPOP_IMPL regressed
+    //   yOutput to all zeros, suggesting cube down matmul or comm hidden write
+    //   timing is also affected.  Bigger picture: intra-rank cube<->comm flag 2
+    //   doorbell + comm<->host yOutput TSTORE may need stronger fences too.
+    (void)slotBytes;
+}
+
+template <typename TileT>
+AICORE inline void CopyGmSlotToTile(TileT &tile, __gm__ uint8_t *localSlot, int slotBytes)
+{
+    using Elem = typename TileT::DType;
+    static constexpr int kRows  = TileT::Rows;
+    static constexpr int kCols  = TileT::Cols;
+    static constexpr int kNumel = kRows * kCols;
+    using ShapeT  = pto::Shape<1, 1, 1, kRows, kCols>;
+    using StrideT = pto::Stride<kNumel, kNumel, kNumel, kCols, 1>;
+    using GT = pto::GlobalTensor<Elem, ShapeT, StrideT, pto::Layout::ND>;
+    GT srcG(reinterpret_cast<__gm__ Elem *>(localSlot));
+    TLOAD(tile, srcG);
+    (void)slotBytes;
+}
+
+}  // namespace a2a3_grid_payload
+}  // namespace pto
+
+#endif  // DISTRIBUTED_FFN_GRID_PAYLOAD_INL_HPP

--- a/kernels/manual/a2a3/distributed_ffn_grid/kernel_launch.hpp
+++ b/kernels/manual/a2a3/distributed_ffn_grid/kernel_launch.hpp
@@ -1,0 +1,74 @@
+/**
+Copyright (c) 2026 Huawei Technologies Co., Ltd.
+This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+CANN Open Software License Agreement Version 2.0 (the "License").
+Please refer to the License for details. You may not use this file except in compliance with the License.
+THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+See LICENSE in the root of the software repository for the full text of the License.
+*/
+
+#ifndef DISTRIBUTED_FFN_GRID_KERNEL_LAUNCH_HPP
+#define DISTRIBUTED_FFN_GRID_KERNEL_LAUNCH_HPP
+
+#include <cstdint>
+
+// Vec kernel for the single-device multi-block FFN path.
+//
+// gridRows*gridCols blocks form a single-device logical grid.  Each block uses
+// get_block_idx() as its row-major cell id.
+//
+// phase == 0:
+//   hiddenOut[block] = fp16(PReLU(gatePartial[block]) * upPartial[block])
+// phase == 1:
+//   all columns run in one launch and synchronize through GridPipe flags:
+//     col > 0           : TPOP<EAST> and add upstream partial
+//     col + 1 < gridCols: TPUSH<EAST> to next column
+//     final column      : write yOutput[row]
+//
+// reducePipeWindow points at gridRows*gridCols local GridPipe windows, one per
+// cell, and hcclCtx is a fake same-device HcclDeviceContext whose windowsIn[]
+// entries point into that contiguous allocation.
+void launchDistributedFfnGridCommKernel(uint8_t *reducePipeWindow,
+                                        uint8_t *gatePartial,
+                                        uint8_t *upPartial,
+                                        uint8_t *hiddenOut,
+                                        uint8_t *downPartial,
+                                        uint8_t *yOutput,
+                                        uint8_t *hcclCtx,
+                                        uint8_t *chunkFlags,
+                                        int gridRows,
+                                        int gridCols,
+                                        int phase,
+                                        void *stream);
+
+// Cube kernel for the single-device multi-block FFN path.
+//
+// gridRows*gridCols blocks form a single-device logical grid.  Each block uses
+// get_block_idx() as its row-major cell id.
+//
+// phase == 0:
+//   gatePartial[block] = x[block] @ wGate
+//   upPartial[block]   = x[block] @ wUp
+// phase == 1:
+//   yOutput[block] = hiddenIn[block] @ wDown
+//
+// downPartial receives phase-1 per-cell partials. yOutput is written by the
+// comm reduce phase, not by this kernel.
+void launchDistributedFfnGridComputeKernel(uint8_t *x,
+                                           uint8_t *wGate,
+                                           uint8_t *wUp,
+                                           uint8_t *wDown,
+                                           uint8_t *gatePartial,
+                                           uint8_t *upPartial,
+                                           uint8_t *hiddenIn,
+                                           uint8_t *downPartial,
+                                           uint8_t *yOutput,
+                                           uint8_t *chunkFlags,
+                                           int gridRows,
+                                           int gridCols,
+                                           int myRankId,
+                                           int phase,
+                                           void *stream);
+
+#endif  // DISTRIBUTED_FFN_GRID_KERNEL_LAUNCH_HPP

--- a/kernels/manual/a2a3/distributed_ffn_grid/main.cpp
+++ b/kernels/manual/a2a3/distributed_ffn_grid/main.cpp
@@ -1,0 +1,428 @@
+/**
+Copyright (c) 2026 Huawei Technologies Co., Ltd.
+This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+CANN Open Software License Agreement Version 2.0 (the "License").
+Please refer to the License for details. You may not use this file except in compliance with the License.
+THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+See LICENSE in the root of the software repository for the full text of the License.
+*/
+
+// Single-device multi-block FFN GridPipe driver.
+//
+// gridRows*gridCols blocks form a logical grid on one NPU.  Each cell computes
+// one model-parallel FFN shard, then cells in the same row reduce their fp32
+// down partials through a same-device GridPipe EAST mock backed by local GM
+// windows and a fake HcclDeviceContext.
+
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#ifdef AICORE
+#undef AICORE
+#endif
+#define AICORE
+
+#ifndef __gm__
+#define __gm__
+#endif
+
+#include "common.hpp"
+
+#ifdef DT_UNDEFINED
+#define DT_UNDEFINED_SAVED DT_UNDEFINED
+#undef DT_UNDEFINED
+#endif
+#include "test_common.h"
+#ifdef DT_UNDEFINED_SAVED
+#define DT_UNDEFINED DT_UNDEFINED_SAVED
+#undef DT_UNDEFINED_SAVED
+#endif
+
+#include "ffn_config.hpp"
+#include "kernel_launch.hpp"
+
+struct DeviceResources {
+    aclrtStream stream = nullptr;
+    void *x_dev = nullptr;
+    void *w_gate_dev = nullptr;
+    void *w_up_dev = nullptr;
+    void *w_down_dev = nullptr;
+    void *gate_partial_dev = nullptr;
+    void *up_partial_dev = nullptr;
+    void *hidden_dev = nullptr;
+    void *down_partial_dev = nullptr;
+    void *y_output_dev = nullptr;
+    void *reduce_pipe_windows_dev = nullptr;
+    void *fake_hccl_ctx_dev = nullptr;
+
+    size_t rows = static_cast<size_t>(FFN_GRID_ROWS);
+    size_t cols = static_cast<size_t>(FFN_GRID_COLS);
+    size_t cells = static_cast<size_t>(FFN_GRID_ROWS) * static_cast<size_t>(FFN_GRID_COLS);
+    size_t xBytes = 0;
+    size_t wGateBytes = 0;
+    size_t wUpBytes = 0;
+    size_t wDownBytes = 0;
+    size_t gatePartialBytes = 0;
+    size_t upPartialBytes = 0;
+    size_t hiddenBytes = 0;
+    size_t downPartialBytes = 0;
+    size_t yOutputBytes = 0;
+    size_t reducePipeBytes = 0;
+
+    std::string dataDir = "./out";
+};
+
+static bool InitAcl(int device_id)
+{
+    constexpr int kAclRepeatInit = 100002;
+    aclError aRet = aclInit(nullptr);
+    if (aRet != ACL_SUCCESS && static_cast<int>(aRet) != kAclRepeatInit) {
+        std::cerr << "[ERROR] aclInit failed: " << static_cast<int>(aRet) << std::endl;
+        return false;
+    }
+    rtSetDevice(device_id);
+    aRet = aclrtSetDevice(device_id);
+    if (aRet != ACL_SUCCESS) {
+        std::cerr << "[ERROR] aclrtSetDevice(" << device_id << ") failed: " << static_cast<int>(aRet) << std::endl;
+        return false;
+    }
+    return true;
+}
+
+static bool InitLocalGridPipeContext(DeviceResources &r)
+{
+    r.reducePipeBytes = r.cells * static_cast<size_t>(FFN_GRID_WINDOW_BYTES);
+    if (aclrtMalloc(&r.reduce_pipe_windows_dev, r.reducePipeBytes, ACL_MEM_MALLOC_HUGE_FIRST) != ACL_SUCCESS) {
+        std::cerr << "[ERROR] aclrtMalloc(reduce_pipe_windows) failed" << std::endl;
+        return false;
+    }
+    aclrtMemset(r.reduce_pipe_windows_dev, r.reducePipeBytes, 0, r.reducePipeBytes);
+
+    HcclDeviceContext hostCtx{};
+    hostCtx.rankId = 0;
+    hostCtx.rankNum = static_cast<uint32_t>(r.cells);
+    hostCtx.winSize = static_cast<uint64_t>(FFN_GRID_WINDOW_BYTES);
+    uint64_t base = reinterpret_cast<uint64_t>(r.reduce_pipe_windows_dev);
+    for (size_t i = 0; i < r.cells && i < HCCL_MAX_RANK_NUM; ++i) {
+        hostCtx.windowsIn[i] = base + i * static_cast<size_t>(FFN_GRID_WINDOW_BYTES);
+        hostCtx.windowsOut[i] = hostCtx.windowsIn[i];
+    }
+
+    if (aclrtMalloc(&r.fake_hccl_ctx_dev, sizeof(HcclDeviceContext), ACL_MEM_MALLOC_HUGE_FIRST) != ACL_SUCCESS) {
+        std::cerr << "[ERROR] aclrtMalloc(fake_hccl_ctx) failed" << std::endl;
+        return false;
+    }
+    if (aclrtMemcpy(r.fake_hccl_ctx_dev, sizeof(HcclDeviceContext), &hostCtx, sizeof(HcclDeviceContext),
+                    ACL_MEMCPY_HOST_TO_DEVICE) != ACL_SUCCESS) {
+        std::cerr << "[ERROR] aclrtMemcpy(fake_hccl_ctx) failed" << std::endl;
+        return false;
+    }
+    return true;
+}
+
+static bool AllocateResources(DeviceResources &r)
+{
+    if (r.cells == 0 || r.cells > HCCL_MAX_RANK_NUM) {
+        std::cerr << "[ERROR] invalid cell count " << r.cells << "; supported range is 1.." << HCCL_MAX_RANK_NUM
+                  << std::endl;
+        return false;
+    }
+    if (const char *env = std::getenv("FFN_GRID_DATA_DIR")) {
+        r.dataDir = env;
+    }
+
+    if (aclrtCreateStream(&r.stream) != ACL_SUCCESS) {
+        std::cerr << "[ERROR] aclrtCreateStream failed" << std::endl;
+        return false;
+    }
+
+    r.xBytes = r.cells * static_cast<size_t>(FFN_X_BYTES);
+    r.wGateBytes = r.cells * static_cast<size_t>(FFN_W_GATE_BYTES);
+    r.wUpBytes = r.cells * static_cast<size_t>(FFN_W_UP_BYTES);
+    r.wDownBytes = r.cells * static_cast<size_t>(FFN_W_DOWN_BYTES);
+    r.gatePartialBytes = r.cells * static_cast<size_t>(FFN_GATE_PARTIAL_BYTES);
+    r.upPartialBytes = r.cells * static_cast<size_t>(FFN_UP_PARTIAL_BYTES);
+    r.hiddenBytes = r.cells * static_cast<size_t>(FFN_HIDDEN_BYTES);
+    r.downPartialBytes = r.cells * static_cast<size_t>(FFN_DOWN_PARTIAL_BYTES);
+    r.yOutputBytes = r.rows * static_cast<size_t>(FFN_Y_OUTPUT_BYTES);
+
+    aclrtMalloc(&r.x_dev, r.xBytes, ACL_MEM_MALLOC_HUGE_FIRST);
+    aclrtMalloc(&r.w_gate_dev, r.wGateBytes, ACL_MEM_MALLOC_HUGE_FIRST);
+    aclrtMalloc(&r.w_up_dev, r.wUpBytes, ACL_MEM_MALLOC_HUGE_FIRST);
+    aclrtMalloc(&r.w_down_dev, r.wDownBytes, ACL_MEM_MALLOC_HUGE_FIRST);
+    aclrtMalloc(&r.gate_partial_dev, r.gatePartialBytes, ACL_MEM_MALLOC_HUGE_FIRST);
+    aclrtMalloc(&r.up_partial_dev, r.upPartialBytes, ACL_MEM_MALLOC_HUGE_FIRST);
+    aclrtMalloc(&r.hidden_dev, r.hiddenBytes, ACL_MEM_MALLOC_HUGE_FIRST);
+    aclrtMalloc(&r.down_partial_dev, r.downPartialBytes, ACL_MEM_MALLOC_HUGE_FIRST);
+    aclrtMalloc(&r.y_output_dev, r.yOutputBytes, ACL_MEM_MALLOC_HUGE_FIRST);
+
+    if (!r.x_dev || !r.w_gate_dev || !r.w_up_dev || !r.w_down_dev || !r.gate_partial_dev || !r.up_partial_dev ||
+        !r.hidden_dev || !r.down_partial_dev || !r.y_output_dev) {
+        std::cerr << "[ERROR] aclrtMalloc failed" << std::endl;
+        return false;
+    }
+
+    aclrtMemset(r.x_dev, r.xBytes, 0, r.xBytes);
+    aclrtMemset(r.gate_partial_dev, r.gatePartialBytes, 0, r.gatePartialBytes);
+    aclrtMemset(r.up_partial_dev, r.upPartialBytes, 0, r.upPartialBytes);
+    aclrtMemset(r.hidden_dev, r.hiddenBytes, 0, r.hiddenBytes);
+    aclrtMemset(r.down_partial_dev, r.downPartialBytes, 0, r.downPartialBytes);
+    aclrtMemset(r.y_output_dev, r.yOutputBytes, 0, r.yOutputBytes);
+
+    if (!InitLocalGridPipeContext(r)) {
+        return false;
+    }
+
+    std::cout << "[INFO] grid=" << r.rows << "x" << r.cols << " cells=" << r.cells << " dataDir=" << r.dataDir
+              << " reducePipeBytes=" << r.reducePipeBytes << " yOutputBytes=" << r.yOutputBytes << std::endl;
+    return true;
+}
+
+static bool LoadInputs(DeviceResources &r)
+{
+    std::vector<uint8_t> hostX(r.xBytes);
+    for (size_t cell = 0; cell < r.cells; ++cell) {
+        std::string xPath = r.dataDir + "/pe_" + std::to_string(cell) + "_x.bin";
+        size_t fileSize = 0;
+        uint8_t *dst = hostX.data() + cell * static_cast<size_t>(FFN_X_BYTES);
+        if (!PtoTestCommon::ReadFile(xPath, fileSize, dst, static_cast<size_t>(FFN_X_BYTES)) ||
+            fileSize != static_cast<size_t>(FFN_X_BYTES)) {
+            std::cerr << "[ERROR] X file load mismatch: " << xPath << " (got " << fileSize << " bytes, expected "
+                      << FFN_X_BYTES << ")" << std::endl;
+            return false;
+        }
+    }
+    if (aclrtMemcpy(r.x_dev, r.xBytes, hostX.data(), r.xBytes, ACL_MEMCPY_HOST_TO_DEVICE) != ACL_SUCCESS) {
+        std::cerr << "[ERROR] aclrtMemcpy(x_dev) failed" << std::endl;
+        return false;
+    }
+    return true;
+}
+
+static bool LoadWeights(DeviceResources &r)
+{
+    struct WeightSpec {
+        const char *suffix;
+        void *dev;
+        size_t tileBytes;
+        size_t totalBytes;
+    };
+    WeightSpec specs[] = {
+        {"_w_gate.bin", r.w_gate_dev, static_cast<size_t>(FFN_W_GATE_BYTES), r.wGateBytes},
+        {"_w_up.bin", r.w_up_dev, static_cast<size_t>(FFN_W_UP_BYTES), r.wUpBytes},
+        {"_w_down.bin", r.w_down_dev, static_cast<size_t>(FFN_W_DOWN_BYTES), r.wDownBytes},
+    };
+
+    for (const auto &w : specs) {
+        std::vector<uint8_t> hostBuf(w.totalBytes);
+        for (size_t cell = 0; cell < r.cells; ++cell) {
+            std::string path = r.dataDir + "/pe_" + std::to_string(cell) + w.suffix;
+            size_t fileSize = 0;
+            uint8_t *dst = hostBuf.data() + cell * w.tileBytes;
+            if (!PtoTestCommon::ReadFile(path, fileSize, dst, w.tileBytes) || fileSize != w.tileBytes) {
+                std::cerr << "[ERROR] weight load mismatch: " << path << " (got " << fileSize << " bytes, expected "
+                          << w.tileBytes << ")" << std::endl;
+                return false;
+            }
+        }
+        if (aclrtMemcpy(w.dev, w.totalBytes, hostBuf.data(), w.totalBytes, ACL_MEMCPY_HOST_TO_DEVICE) !=
+            ACL_SUCCESS) {
+            std::cerr << "[ERROR] aclrtMemcpy(weight " << w.suffix << ") failed" << std::endl;
+            return false;
+        }
+    }
+    return true;
+}
+
+static bool VerifyOutput(DeviceResources &r)
+{
+    const size_t outputElems = r.rows * static_cast<size_t>(FFN_TILE_ELEMS);
+    const size_t outputBytes = r.rows * static_cast<size_t>(FFN_Y_OUTPUT_BYTES);
+
+    std::vector<float> outHost(outputElems);
+    if (aclrtMemcpy(outHost.data(), outputBytes, r.y_output_dev, outputBytes,
+                    ACL_MEMCPY_DEVICE_TO_HOST) != ACL_SUCCESS) {
+        std::cerr << "[ERROR] y_output D2H memcpy failed" << std::endl;
+        return false;
+    }
+
+    std::string goldenPath = r.dataDir + "/golden.bin";
+    std::vector<float> golden(outputElems);
+    size_t fileSize = 0;
+    if (!PtoTestCommon::ReadFile(goldenPath, fileSize, golden.data(), outputBytes) || fileSize != outputBytes) {
+        std::cerr << "[ERROR] golden.bin mismatch: " << goldenPath << " (got " << fileSize << " bytes, expected "
+                  << outputBytes << ")" << std::endl;
+        return false;
+    }
+
+    std::cout << "[INFO] ResultCmp single-device GridPipe EAST-reduced output vs golden:" << std::endl;
+    return PtoTestCommon::ResultCmp(golden, outHost.data(), 0.001f);
+}
+
+static const char *GridPipeFaultName(uint32_t code)
+{
+    switch (code) {
+        case 0x101: return "push north boundary";
+        case 0x102: return "push east boundary";
+        case 0x103: return "push west boundary";
+        case 0x104: return "push source boundary";
+        case 0x201: return "pop north boundary";
+        case 0x202: return "pop east boundary";
+        case 0x203: return "pop west boundary";
+        case 0x301: return "wait ready timeout";
+        case 0x302: return "wait free timeout";
+        default: return "unknown";
+    }
+}
+
+static bool CheckGridPipeFaults(DeviceResources &r)
+{
+    constexpr size_t kFlagWordsPerWindow = static_cast<size_t>(FFN_GRID_FLAGS_BYTES) / sizeof(uint32_t);
+    std::vector<uint32_t> flags(r.cells * kFlagWordsPerWindow, 0);
+    for (size_t cell = 0; cell < r.cells; ++cell) {
+        auto *src = reinterpret_cast<uint8_t *>(r.reduce_pipe_windows_dev) + cell * FFN_GRID_WINDOW_BYTES;
+        auto *dst = flags.data() + cell * kFlagWordsPerWindow;
+        if (aclrtMemcpy(dst, kFlagWordsPerWindow * sizeof(uint32_t), src, kFlagWordsPerWindow * sizeof(uint32_t),
+                        ACL_MEMCPY_DEVICE_TO_HOST) != ACL_SUCCESS) {
+            std::cerr << "[ERROR] GridPipe flag D2H memcpy failed for cell " << cell << std::endl;
+            return false;
+        }
+    }
+
+    bool ok = true;
+    for (size_t cell = 0; cell < r.cells; ++cell) {
+        size_t row = cell / r.cols;
+        size_t col = cell - row * r.cols;
+        const uint32_t *cellFlags = flags.data() + cell * kFlagWordsPerWindow;
+        for (size_t i = 0; i < kFlagWordsPerWindow; ++i) {
+            uint32_t value = cellFlags[i];
+            if (value >= 0x100U) {
+                std::cerr << "[ERROR] GridPipe fault cell=" << cell << " row=" << row << " col=" << col
+                          << " flagWord=" << i << " code=0x" << std::hex << value << std::dec << " ("
+                          << GridPipeFaultName(value) << ")" << std::endl;
+                ok = false;
+            }
+        }
+    }
+    return ok;
+}
+
+static void Cleanup(DeviceResources &r)
+{
+    if (r.fake_hccl_ctx_dev) { aclrtFree(r.fake_hccl_ctx_dev); r.fake_hccl_ctx_dev = nullptr; }
+    if (r.reduce_pipe_windows_dev) { aclrtFree(r.reduce_pipe_windows_dev); r.reduce_pipe_windows_dev = nullptr; }
+    if (r.w_gate_dev) { aclrtFree(r.w_gate_dev); r.w_gate_dev = nullptr; }
+    if (r.w_up_dev) { aclrtFree(r.w_up_dev); r.w_up_dev = nullptr; }
+    if (r.w_down_dev) { aclrtFree(r.w_down_dev); r.w_down_dev = nullptr; }
+    if (r.x_dev) { aclrtFree(r.x_dev); r.x_dev = nullptr; }
+    if (r.gate_partial_dev) { aclrtFree(r.gate_partial_dev); r.gate_partial_dev = nullptr; }
+    if (r.up_partial_dev) { aclrtFree(r.up_partial_dev); r.up_partial_dev = nullptr; }
+    if (r.hidden_dev) { aclrtFree(r.hidden_dev); r.hidden_dev = nullptr; }
+    if (r.down_partial_dev) { aclrtFree(r.down_partial_dev); r.down_partial_dev = nullptr; }
+    if (r.y_output_dev) { aclrtFree(r.y_output_dev); r.y_output_dev = nullptr; }
+    if (r.stream) { aclrtDestroyStream(r.stream); r.stream = nullptr; }
+}
+
+static bool RunSingleDevice()
+{
+    DeviceResources r;
+    if (!AllocateResources(r) || !LoadInputs(r) || !LoadWeights(r)) {
+        Cleanup(r);
+        return false;
+    }
+
+    auto t0 = std::chrono::high_resolution_clock::now();
+
+    launchDistributedFfnGridComputeKernel(reinterpret_cast<uint8_t *>(r.x_dev),
+                                          reinterpret_cast<uint8_t *>(r.w_gate_dev),
+                                          reinterpret_cast<uint8_t *>(r.w_up_dev),
+                                          reinterpret_cast<uint8_t *>(r.w_down_dev),
+                                          reinterpret_cast<uint8_t *>(r.gate_partial_dev),
+                                          reinterpret_cast<uint8_t *>(r.up_partial_dev),
+                                          reinterpret_cast<uint8_t *>(r.hidden_dev),
+                                          reinterpret_cast<uint8_t *>(r.down_partial_dev),
+                                          reinterpret_cast<uint8_t *>(r.y_output_dev),
+                                          nullptr, FFN_GRID_ROWS, FFN_GRID_COLS, 0, 0, r.stream);
+    aclError phase0Ret = aclrtSynchronizeStream(r.stream);
+
+    launchDistributedFfnGridCommKernel(reinterpret_cast<uint8_t *>(r.reduce_pipe_windows_dev),
+                                       reinterpret_cast<uint8_t *>(r.gate_partial_dev),
+                                       reinterpret_cast<uint8_t *>(r.up_partial_dev),
+                                       reinterpret_cast<uint8_t *>(r.hidden_dev),
+                                       reinterpret_cast<uint8_t *>(r.down_partial_dev),
+                                       reinterpret_cast<uint8_t *>(r.y_output_dev),
+                                       reinterpret_cast<uint8_t *>(r.fake_hccl_ctx_dev), nullptr,
+                                       FFN_GRID_ROWS, FFN_GRID_COLS, 0, r.stream);
+    aclError activationRet = aclrtSynchronizeStream(r.stream);
+
+    launchDistributedFfnGridComputeKernel(reinterpret_cast<uint8_t *>(r.x_dev),
+                                          reinterpret_cast<uint8_t *>(r.w_gate_dev),
+                                          reinterpret_cast<uint8_t *>(r.w_up_dev),
+                                          reinterpret_cast<uint8_t *>(r.w_down_dev),
+                                          reinterpret_cast<uint8_t *>(r.gate_partial_dev),
+                                          reinterpret_cast<uint8_t *>(r.up_partial_dev),
+                                          reinterpret_cast<uint8_t *>(r.hidden_dev),
+                                          reinterpret_cast<uint8_t *>(r.down_partial_dev),
+                                          reinterpret_cast<uint8_t *>(r.y_output_dev),
+                                          nullptr, FFN_GRID_ROWS, FFN_GRID_COLS, 0, 1, r.stream);
+    aclError phase1Ret = aclrtSynchronizeStream(r.stream);
+
+    launchDistributedFfnGridCommKernel(reinterpret_cast<uint8_t *>(r.reduce_pipe_windows_dev),
+                                       reinterpret_cast<uint8_t *>(r.gate_partial_dev),
+                                       reinterpret_cast<uint8_t *>(r.up_partial_dev),
+                                       reinterpret_cast<uint8_t *>(r.hidden_dev),
+                                       reinterpret_cast<uint8_t *>(r.down_partial_dev),
+                                       reinterpret_cast<uint8_t *>(r.y_output_dev),
+                                       reinterpret_cast<uint8_t *>(r.fake_hccl_ctx_dev), nullptr,
+                                       FFN_GRID_ROWS, FFN_GRID_COLS, 1, r.stream);
+    aclError reduceRet = aclrtSynchronizeStream(r.stream);
+    bool gridPipeOk = (reduceRet == ACL_SUCCESS) && CheckGridPipeFaults(r);
+
+    auto t1 = std::chrono::high_resolution_clock::now();
+    double us = std::chrono::duration<double, std::micro>(t1 - t0).count();
+    std::cout << "[INFO] launch+sync " << us << " us  (phase0 rc=" << static_cast<int>(phase0Ret)
+              << " activation rc=" << static_cast<int>(activationRet)
+              << " phase1 rc=" << static_cast<int>(phase1Ret)
+              << " reduce rc=" << static_cast<int>(reduceRet)
+              << " gridpipe_ok=" << (gridPipeOk ? 1 : 0);
+    std::cout << ")" << std::endl;
+
+    bool syncOk = (phase0Ret == ACL_SUCCESS) && (activationRet == ACL_SUCCESS) && (phase1Ret == ACL_SUCCESS) &&
+                  (reduceRet == ACL_SUCCESS) && gridPipeOk;
+    bool verifyOk = syncOk && VerifyOutput(r);
+    Cleanup(r);
+    return syncOk && verifyOk;
+}
+
+int main(int argc, char **argv)
+{
+    (void)argc;
+    (void)argv;
+    if (!InitAcl(/*device_id=*/0)) {
+        return 1;
+    }
+
+    std::cout << "\n================================================================" << std::endl;
+    std::cout << "  Single-device multi-block FFN GridPipe demo" << std::endl;
+    std::cout << "  grid=" << FFN_GRID_ROWS << "x" << FFN_GRID_COLS << " cells="
+              << (FFN_GRID_ROWS * FFN_GRID_COLS) << " tile=" << FFN_TOKEN_TILE << "x" << FFN_MODEL_TILE
+              << " ffnTile=" << FFN_FFN_TILE << std::endl;
+    std::cout << "  Mode: row=data-parallel, col=model-parallel on one device; EAST reduce uses local GM windows"
+              << std::endl;
+    std::cout << "================================================================" << std::endl;
+
+    bool ok = RunSingleDevice();
+    std::cout << (ok ? "[SUCCESS] Single-device multi-block FFN GridPipe PASS."
+                     : "[FAILED] Single-device multi-block FFN GridPipe FAILED.")
+              << std::endl;
+    aclrtResetDevice(0);
+    aclFinalize();
+    return ok ? 0 : 1;
+}

--- a/kernels/manual/a2a3/distributed_ffn_grid/ready_queue.hpp
+++ b/kernels/manual/a2a3/distributed_ffn_grid/ready_queue.hpp
@@ -1,0 +1,247 @@
+/**
+Copyright (c) 2025 Huawei Technologies Co., Ltd.
+This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+CANN Open Software License Agreement Version 2.0 (the "License").
+Please refer to the License for details. You may not use this file except in compliance with the License.
+THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+See LICENSE in the root of the software repository for the full text of the License.
+*/
+
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+
+#if !defined(__CCE_KT_TEST__) && defined(__CCE_AICORE__)
+#include "pto/comm/pto_comm_inst.hpp"
+#endif
+
+constexpr int MAX_RING_RANKS = 16;
+
+// ============================================================================
+// Streaming Pipeline Configuration
+// ============================================================================
+// Dynamic CHUNK_SIZE: auto-computed from num_tiles_per_src to keep
+// chunk count within [TARGET_CHUNKS_MIN, TARGET_CHUNKS_MAX].
+constexpr int TARGET_CHUNKS_MIN = 64;
+constexpr int TARGET_CHUNKS_MAX = 128;
+constexpr int MIN_CHUNK_SIZE = 4;
+constexpr int MAX_CHUNK_SIZE = 64;
+
+inline int ComputeOptimalChunkSize(int num_tiles_per_src)
+{
+    if (num_tiles_per_src <= 0)
+        return MIN_CHUNK_SIZE;
+
+    int chunk_size = MIN_CHUNK_SIZE;
+    int chunk_count = (num_tiles_per_src + chunk_size - 1) / chunk_size;
+
+    if (chunk_count > TARGET_CHUNKS_MAX) {
+        chunk_size = (num_tiles_per_src + TARGET_CHUNKS_MAX - 1) / TARGET_CHUNKS_MAX;
+        chunk_size = ((chunk_size + 3) / 4) * 4;
+        if (chunk_size > MAX_CHUNK_SIZE)
+            chunk_size = MAX_CHUNK_SIZE;
+    }
+
+    return chunk_size;
+}
+
+#ifndef STREAMING_CHUNK_SIZE
+#define STREAMING_CHUNK_SIZE 4
+#endif
+constexpr int CHUNK_SIZE = STREAMING_CHUNK_SIZE;
+
+// ============================================================================
+// ChunkFlagMatrix: Chunk-based flags for streaming pipeline
+//
+//   - Each chunk contains CHUNK_SIZE tiles
+//   - Communication sets chunk flag after transfer completes
+//   - Computation waits for chunk flag before processing
+//   - Non-competing: each (src_rank, chunk_idx) has unique writer/reader
+//
+// Layout: [num_ranks][num_chunks_per_src] with 64-byte alignment per row
+// ============================================================================
+struct alignas(64) ChunkFlagMatrix {
+    int32_t num_ranks;
+    int32_t num_chunks_per_src;
+    int32_t num_tiles_per_src;
+    int32_t chunk_size;
+    int32_t stride;     // Aligned stride for each rank's chunk flags
+    int32_t my_rank;    // Local rank id
+    int32_t epoch;      // Monotonically increasing generation counter (starts at 1)
+    int32_t padding[9]; // Pad header to 64 bytes
+    // Followed by int32_t chunk_flags[num_ranks * stride]
+};
+
+inline size_t ChunkFlagMatrixSize(int num_ranks, int num_tiles_per_src, int chunk_size)
+{
+    int actual_chunk_size = (chunk_size > 0) ? chunk_size : ComputeOptimalChunkSize(num_tiles_per_src);
+    int num_chunks = (num_tiles_per_src + actual_chunk_size - 1) / actual_chunk_size;
+    int stride = ((num_chunks + 15) / 16) * 16;
+    return sizeof(ChunkFlagMatrix) + static_cast<size_t>(num_ranks) * stride * sizeof(int32_t);
+}
+
+// Summary region sits right after the flag matrix; one int32 per src rank.
+inline size_t ChunkFlagMatrixSummaryOffset(int num_ranks, int num_tiles_per_src, int chunk_size)
+{
+    return ChunkFlagMatrixSize(num_ranks, num_tiles_per_src, chunk_size);
+}
+inline size_t ChunkFlagMatrixWithSummarySize(int num_ranks, int num_tiles_per_src, int chunk_size)
+{
+    return ChunkFlagMatrixSummaryOffset(num_ranks, num_tiles_per_src, chunk_size) +
+           static_cast<size_t>(num_ranks) * sizeof(int32_t);
+}
+
+inline void ChunkFlagMatrixInit(ChunkFlagMatrix *flags, int num_ranks, int num_tiles_per_src, int chunk_size)
+{
+    int actual_chunk_size = (chunk_size > 0) ? chunk_size : ComputeOptimalChunkSize(num_tiles_per_src);
+    int num_chunks = (num_tiles_per_src + actual_chunk_size - 1) / actual_chunk_size;
+    int stride = ((num_chunks + 15) / 16) * 16;
+
+    flags->num_ranks = num_ranks;
+    flags->num_chunks_per_src = num_chunks;
+    flags->num_tiles_per_src = num_tiles_per_src;
+    flags->chunk_size = actual_chunk_size;
+    flags->stride = stride;
+    flags->my_rank = -1;
+    flags->epoch = 1;
+    for (int i = 0; i < 9; i++)
+        flags->padding[i] = 0;
+
+    int32_t *base = reinterpret_cast<int32_t *>(reinterpret_cast<uint8_t *>(flags) + sizeof(ChunkFlagMatrix));
+    for (int i = 0; i < num_ranks * stride; ++i) {
+        base[i] = 0;
+    }
+}
+
+inline void ChunkFlagMatrixSummaryInit(int32_t *summary_base, int num_ranks)
+{
+    for (int i = 0; i < num_ranks; ++i)
+        summary_base[i] = 0;
+}
+
+inline void ChunkFlagMatrixReset(ChunkFlagMatrix *flags)
+{
+    int32_t *base = reinterpret_cast<int32_t *>(reinterpret_cast<uint8_t *>(flags) + sizeof(ChunkFlagMatrix));
+    for (int i = 0; i < flags->num_ranks * flags->stride; ++i) {
+        base[i] = 0;
+    }
+}
+
+inline void ChunkFlagMatrixSetLocalReady(ChunkFlagMatrix *flags, int my_rank)
+{
+    int32_t *base = reinterpret_cast<int32_t *>(reinterpret_cast<uint8_t *>(flags) + sizeof(ChunkFlagMatrix));
+    int offset = my_rank * flags->stride;
+    for (int c = 0; c < flags->num_chunks_per_src; ++c) {
+        base[offset + c] = 1;
+    }
+}
+
+#if !defined(__CCE_KT_TEST__) && defined(__CCE_AICORE__)
+// ============================================================================
+// ChunkFlagMatrix device-side functions
+// ============================================================================
+
+AICORE inline size_t ChunkFlagMatrixBytes(volatile __gm__ ChunkFlagMatrix *flags)
+{
+    return sizeof(ChunkFlagMatrix) +
+           static_cast<size_t>(flags->num_ranks) * static_cast<size_t>(flags->stride) * sizeof(int32_t);
+}
+
+AICORE inline volatile __gm__ int32_t *GetChunkFlagPtr(volatile __gm__ ChunkFlagMatrix *flags, int32_t src_rank,
+                                                       int32_t chunk_idx)
+{
+    int32_t stride = flags->stride;
+    int32_t idx = src_rank * stride + chunk_idx;
+    volatile __gm__ int32_t *base = reinterpret_cast<volatile __gm__ int32_t *>(
+        reinterpret_cast<volatile __gm__ uint8_t *>(flags) + sizeof(ChunkFlagMatrix));
+    return base + idx;
+}
+
+// Summary base address: right after flag matrix, one int32 doorbell per src rank.
+AICORE inline volatile __gm__ int32_t *GetSummaryBase(volatile __gm__ ChunkFlagMatrix *flags)
+{
+    return reinterpret_cast<volatile __gm__ int32_t *>(reinterpret_cast<volatile __gm__ uint8_t *>(flags) +
+                                                       ChunkFlagMatrixBytes(flags));
+}
+
+// Uses TNOTIFY AtomicAdd for hardware atomic semantics.
+AICORE inline void SetChunkFlagReady(volatile __gm__ ChunkFlagMatrix *flags, int32_t src_rank, int32_t chunk_idx)
+{
+    volatile __gm__ int32_t *ptr = GetChunkFlagPtr(flags, src_rank, chunk_idx);
+    pto::comm::Signal sig(reinterpret_cast<__gm__ int32_t *>(const_cast<__gm__ int32_t *>(ptr)));
+    pto::comm::TNOTIFY(sig, 1, pto::comm::NotifyOp::AtomicAdd);
+}
+
+// Notify remote rank that chunk data is available.
+// If remote_summary_src_ptr is provided, also increments the summary doorbell.
+AICORE inline void SetRemoteChunkFlagReady(__gm__ ChunkFlagMatrix *remote_flags, int32_t src_rank, int32_t chunk_idx,
+                                           __gm__ int32_t *remote_summary_src_ptr = nullptr)
+{
+    volatile __gm__ ChunkFlagMatrix *r = reinterpret_cast<volatile __gm__ ChunkFlagMatrix *>(remote_flags);
+    if (src_rank < 0 || src_rank >= r->num_ranks || chunk_idx < 0 || chunk_idx >= r->num_chunks_per_src) {
+        return;
+    }
+    volatile __gm__ int32_t *ptr = GetChunkFlagPtr(r, src_rank, chunk_idx);
+    pto::comm::Signal sig(reinterpret_cast<__gm__ int32_t *>(const_cast<__gm__ int32_t *>(ptr)));
+    pto::comm::TNOTIFY(sig, 1, pto::comm::NotifyOp::AtomicAdd);
+    if (remote_summary_src_ptr != nullptr) {
+        pto::comm::Signal sumSig(remote_summary_src_ptr);
+        pto::comm::TNOTIFY(sumSig, 1, pto::comm::NotifyOp::AtomicAdd);
+    }
+}
+
+AICORE inline void SetLocalSummaryReady(volatile __gm__ int32_t *summary_base, int32_t src_rank, int32_t value)
+{
+    if (summary_base == nullptr || src_rank < 0)
+        return;
+    volatile __gm__ int32_t *ptr = summary_base + src_rank;
+    dcci((__gm__ void *)ptr, SINGLE_CACHE_LINE);
+    __asm__ __volatile__("" ::: "memory");
+    *ptr = value;
+    dcci((__gm__ void *)ptr, SINGLE_CACHE_LINE);
+    __asm__ __volatile__("" ::: "memory");
+}
+
+AICORE inline bool IsChunkReady(volatile __gm__ ChunkFlagMatrix *flags, int32_t src_rank, int32_t chunk_idx)
+{
+    volatile __gm__ int32_t *ptr = GetChunkFlagPtr(flags, src_rank, chunk_idx);
+    int32_t epoch = flags->epoch;
+    dcci((__gm__ void *)ptr, SINGLE_CACHE_LINE);
+    __asm__ __volatile__("" ::: "memory");
+    return (*ptr >= epoch);
+}
+
+// First-level poll: check if any chunk from this src is ready.
+AICORE inline bool IsAnyReadyFromSrc(volatile __gm__ int32_t *summary_base, int32_t src_rank)
+{
+    if (summary_base == nullptr || src_rank < 0)
+        return false;
+    volatile __gm__ int32_t *ptr = summary_base + src_rank;
+    dcci((__gm__ void *)ptr, SINGLE_CACHE_LINE);
+    __asm__ __volatile__("" ::: "memory");
+    return (*ptr >= 1);
+}
+
+AICORE inline int32_t GetReadyCountFromSrc(volatile __gm__ int32_t *summary_base, int32_t src_rank)
+{
+    if (summary_base == nullptr || src_rank < 0)
+        return 0;
+    volatile __gm__ int32_t *ptr = summary_base + src_rank;
+    dcci((__gm__ void *)ptr, SINGLE_CACHE_LINE);
+    __asm__ __volatile__("" ::: "memory");
+    return *ptr;
+}
+
+// Blocking wait until summary[src_rank] >= expected.
+AICORE inline void WaitReadyCountFromSrc(volatile __gm__ int32_t *summary_base, int32_t src_rank, int32_t expected)
+{
+    if (summary_base == nullptr || src_rank < 0 || expected <= 0)
+        return;
+    __gm__ int32_t *ptr = const_cast<__gm__ int32_t *>(summary_base + src_rank);
+    pto::comm::Signal sig(ptr);
+    pto::comm::TWAIT(sig, expected, pto::comm::WaitCmp::GE);
+}
+
+#endif

--- a/kernels/manual/a2a3/distributed_ffn_grid/run.sh
+++ b/kernels/manual/a2a3/distributed_ffn_grid/run.sh
@@ -1,0 +1,111 @@
+#!/bin/bash
+# --------------------------------------------------------------------------------
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# --------------------------------------------------------------------------------
+
+# Single-device multi-block FFN GridPipe demo.  grid-rows x grid-cols is the
+# logical grid launched on one NPU.  Columns are model-parallel FFN shards and
+# reduce through the same-device GridPipe EAST mock.
+
+: "${ASCEND_CANN_PATH:=$(ls -1d /usr/local/Ascend/cann-*/set_env.sh 2>/dev/null | sort -V | tail -1)}"
+if [ -z "${ASCEND_CANN_PATH}" ]; then
+    echo "[ERROR] Cannot find CANN set_env.sh.  Set ASCEND_CANN_PATH explicitly."
+    exit 1
+fi
+source "${ASCEND_CANN_PATH}"
+
+SHORT=r:,v:,n:
+LONG=run-mode:,soc-version:,n-ranks:,grid-rows:,grid-cols:,token-tile:,model-tile:,ffn-tile:,build-only
+OPTS=$(getopt -a --options $SHORT --longoptions $LONG -- "$@")
+eval set -- "$OPTS"
+
+BUILD_ONLY=0
+while :; do
+    case "$1" in
+        (-r | --run-mode)    RUN_MODE="$2"; shift 2;;
+        (-v | --soc-version) SOC_VERSION="$2"; shift 2;;
+        (-n | --n-ranks)     N_RANKS="$2"; shift 2;;
+        (--grid-rows)        GRID_ROWS="$2"; shift 2;;
+        (--grid-cols)        GRID_COLS="$2"; shift 2;;
+        (--token-tile)       TOKEN_TILE="$2"; shift 2;;
+        (--model-tile)       MODEL_TILE="$2"; shift 2;;
+        (--ffn-tile)         FFN_TILE="$2"; shift 2;;
+        (--build-only)       BUILD_ONLY=1; shift;;
+        (--) shift; break;;
+        (*) echo "[ERROR] Unexpected option: $1"; exit 1;;
+    esac
+done
+
+: "${RUN_MODE:=npu}"
+: "${SOC_VERSION:=Ascend910B1}"
+: "${GRID_ROWS:=2}"
+: "${GRID_COLS:=2}"
+: "${TOKEN_TILE:=16}"
+: "${MODEL_TILE:=64}"
+: "${FFN_TILE:=64}"
+: "${N_RANKS:=1}"
+
+if [ "${N_RANKS}" -ne 1 ]; then
+    echo "[ERROR] Single-device multi-block mode requires -n/--n-ranks 1."
+    exit 1
+fi
+
+if [[ ! "${SOC_VERSION}" =~ ^Ascend ]]; then
+    echo "[ERROR] Unsupported SocVersion: ${SOC_VERSION}"
+    exit 1
+fi
+if [[ "${SOC_VERSION}" =~ ^Ascend910B4-1 ]] && [ "${RUN_MODE}" == "sim" ]; then
+    echo "[ERROR] SocVersion: ${SOC_VERSION} can not support sim mode, please use Ascend910B4."
+    exit 1
+fi
+
+rm -rf /dev/shm/sem.hccl* 2>/dev/null
+ipcrm -a 2>/dev/null
+
+echo "=== Single-device Multi-block FFN GridPipe Demo ==="
+echo "  RUN_MODE: ${RUN_MODE}  SOC_VERSION: ${SOC_VERSION}"
+echo "  Grid: ${GRID_ROWS}x${GRID_COLS}  N_RANKS: ${N_RANKS}"
+echo "  Tile: ${TOKEN_TILE}x${MODEL_TILE}  FfnTile: ${FFN_TILE}"
+echo "==================================================="
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+cd "${SCRIPT_DIR}"
+
+# Regenerate per-cell inputs + golden before running.  The host maps all
+# grid_rows * grid_cols cells to blocks on device 0.
+if [ "${BUILD_ONLY}" -eq 0 ]; then
+    python3 "${SCRIPT_DIR}/scripts/gen_data.py" \
+        --grid-rows "${GRID_ROWS}" --grid-cols "${GRID_COLS}" \
+        --t "${TOKEN_TILE}" --h "${MODEL_TILE}" --fi "${FFN_TILE}" \
+        --output-dir "${SCRIPT_DIR}/out"
+fi
+
+rm -rf build
+mkdir build
+cd build
+
+export LD_LIBRARY_PATH=${ASCEND_HOME_PATH}/tools/simulator/${SOC_VERSION}/lib:${LD_LIBRARY_PATH:-}
+set -euo pipefail
+
+cmake -DRUN_MODE=${RUN_MODE} -DSOC_VERSION=${SOC_VERSION} \
+      -DGRID_ROWS=${GRID_ROWS} -DGRID_COLS=${GRID_COLS} \
+      -DTOKEN_TILE=${TOKEN_TILE} -DMODEL_TILE=${MODEL_TILE} -DFFN_TILE=${FFN_TILE} \
+      ..
+make -j16
+
+if [ "${BUILD_ONLY}" -eq 1 ]; then
+    echo "[INFO] --build-only requested; skipping run."
+    exit 0
+fi
+
+echo ""
+echo "=== Running Single-device Multi-block FFN GridPipe ==="
+export N_RANKS=${N_RANKS}
+export FFN_GRID_DATA_DIR="${SCRIPT_DIR}/out"
+./distributed_ffn_grid

--- a/kernels/manual/a2a3/distributed_ffn_grid/scripts/gen_data.py
+++ b/kernels/manual/a2a3/distributed_ffn_grid/scripts/gen_data.py
@@ -1,0 +1,175 @@
+#!/usr/bin/python3
+# coding=utf-8
+# -----------------------------------------------------------------------------------------------------------
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+#
+# Data generator for distributed FFN GridPipe demo.
+#
+# Layout (M4: grid_rows x grid_cols, row = data-parallel, col = model-parallel):
+#   T_total = T_per_row * grid_rows           (rows do not share tokens)
+#   F_total = Fi_per_col * grid_cols          (cols shard the intermediate dim)
+#   Rank r = row * grid_cols + col            (row-major)
+#   Row's token slice  : X_full[row*T : (row+1)*T, :]   shape [T, H]
+#   Col's weight slice : W_gate_full[:, col*Fi:(col+1)*Fi]   etc.
+#
+# Per-rank file layout (fp16 weights / inputs, fp32 golden):
+#   pe_<r>_x.bin       - X       [T, H]    fp16 row-major   -- shared across cols of a row
+#   pe_<r>_w_gate.bin  - W_gate  [H, Fi]   fp16 row-major   -- shared across rows of a col
+#   pe_<r>_w_up.bin    - W_up    [H, Fi]   fp16 row-major
+#   pe_<r>_w_down.bin  - W_down  [Fi, H]   fp16 row-major
+#   golden.bin         - y       [T_total, H]  fp32         -- full output; each row reads its slice
+#
+# golden = (PReLU((X_full @ W_gate_full) * (X_full @ W_up_full), alpha=0.1)) @ W_down_full
+#   W_gate_full = hstack(W_gate(col) for col in cols)   shape [H, F_total]
+#   W_up_full   = hstack(W_up(col)   for col in cols)
+#   W_down_full = vstack(W_down(col) for col in cols)   shape [F_total, H]
+#
+# Compatibility note:
+#   When --grid-rows 1 (M3 1xN), behaviour is byte-identical to the previous
+#   1xN generator: T_total == T_per_row, X is shared across all ranks, golden
+#   is [T, H] fp32.
+#
+# Kernel contract (D-2 / D-6):
+#   - alpha = 0.1.  If kernel hard-codes a different alpha, update BOTH sides.
+#   - Byte sizes must match ffn_config.hpp host mirrors (FFN_W_GATE_BYTES etc.).
+#   - fp16 weights, fp32 golden, 1e-3 absolute tolerance in PtoTestCommon::ResultCmp.
+#
+# Usage (M4 2x2):
+#   python3 gen_data.py --grid-rows 2 --grid-cols 2 --t 16 --h 64 --fi 64 --output-dir ./out
+# Usage (M3 1x2 back-compat via --n-ranks):
+#   python3 gen_data.py --n-ranks 2 --t 16 --h 64 --fi 64 --output-dir ./out
+
+import os
+import argparse
+from dataclasses import dataclass
+
+import numpy as np
+
+np.random.seed(19)
+
+PRELU_ALPHA = 0.1
+
+
+@dataclass
+class FfnDataConfig:
+    """Per-rank dimensions; total intermediate F = fi * grid_cols, total T = t * grid_rows."""
+
+    t: int           # token count per row (== FFN_TOKEN_TILE)
+    h: int           # hidden dim (== FFN_MODEL_TILE)
+    fi: int          # per-rank intermediate dim per col (== FFN_FFN_TILE)
+    grid_rows: int
+    grid_cols: int
+    output_dir: str = "./out"
+
+
+def _prelu(x: np.ndarray, alpha: float = PRELU_ALPHA) -> np.ndarray:
+    return np.where(x > 0, x, alpha * x)
+
+
+def gen_data(cfg: FfnDataConfig) -> None:
+    t, h, fi = cfg.t, cfg.h, cfg.fi
+    grid_rows, grid_cols = cfg.grid_rows, cfg.grid_cols
+    n_ranks = grid_rows * grid_cols
+    t_total = t * grid_rows
+    f_total = fi * grid_cols
+    os.makedirs(cfg.output_dir, exist_ok=True)
+
+    src_type = np.float16
+    dst_type = np.float32
+
+    # Inputs in {0, 1}: keeps fp16 (gate * up) below fp16 max (~65504).
+    # With H = 64 the elementwise hidden ≤ H = 64, hidden*hidden ≤ 4096 safe.
+    x_full = np.random.randint(0, 2, [t_total, h]).astype(src_type)
+    w_gate_full = np.random.randint(0, 2, [h, f_total]).astype(src_type)
+    w_up_full   = np.random.randint(0, 2, [h, f_total]).astype(src_type)
+    w_down_full = np.random.randint(0, 2, [f_total, h]).astype(src_type)
+
+    # Reference computation in fp32.  Down-cast inputs to fp32 for the math
+    # but persist weights in fp16 (kernel side TLOADs fp16 -> mixed-precision
+    # matmul).
+    x_f32 = x_full.astype(dst_type)
+    gate_full = x_f32 @ w_gate_full.astype(dst_type)
+    up_full   = x_f32 @ w_up_full.astype(dst_type)
+    act_full  = _prelu(gate_full * up_full, PRELU_ALPHA)
+    golden    = (act_full @ w_down_full.astype(dst_type)).astype(dst_type)
+
+    for row in range(grid_rows):
+        t_start = row * t
+        t_end = t_start + t
+        x_row = x_full[t_start:t_end, :]
+
+        for col in range(grid_cols):
+            rank = row * grid_cols + col
+            fi_start = col * fi
+            fi_end = fi_start + fi
+
+            x_path       = os.path.join(cfg.output_dir, f"pe_{rank}_x.bin")
+            w_gate_path  = os.path.join(cfg.output_dir, f"pe_{rank}_w_gate.bin")
+            w_up_path    = os.path.join(cfg.output_dir, f"pe_{rank}_w_up.bin")
+            w_down_path  = os.path.join(cfg.output_dir, f"pe_{rank}_w_down.bin")
+
+            # X is the same for every col rank within the same row.
+            x_row.tofile(x_path)
+            w_gate_full[:, fi_start:fi_end].astype(src_type).tofile(w_gate_path)
+            w_up_full[:, fi_start:fi_end].astype(src_type).tofile(w_up_path)
+            w_down_full[fi_start:fi_end, :].astype(src_type).tofile(w_down_path)
+
+            label = "block" if grid_cols == 1 else "rank"
+            print(f"  - {label}{rank} (row={row},col={col}): x{tuple(x_row.shape)} -> {x_path}")
+            print(f"             w_gate[{h},{fi}] -> {w_gate_path}")
+            print(f"             w_up[{h},{fi}]   -> {w_up_path}")
+            print(f"             w_down[{fi},{h}] -> {w_down_path}")
+
+    golden_path = os.path.join(cfg.output_dir, "golden.bin")
+    golden.tofile(golden_path)
+    print(f"  - golden{tuple(golden.shape)} fp32 -> {golden_path}")
+    print(
+        f"[INFO] Generated FFN data: T={t} (T_total={t_total}) H={h} Fi={fi} (F_total={f_total}) "
+        f"grid={grid_rows}x{grid_cols} n_ranks={n_ranks}"
+    )
+    print(f"[INFO] alpha={PRELU_ALPHA} (must match kernel TLRELU constant FFN_PRELU_ALPHA)")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Generate data for distributed FFN GridPipe demo")
+    parser.add_argument("--grid-rows", type=int, default=None,
+                        help="Grid rows (M4 2D layout).  If omitted, falls back to --n-ranks (1xN).")
+    parser.add_argument("--grid-cols", type=int, default=None,
+                        help="Grid cols (M4 2D layout).  If omitted, falls back to --n-ranks (1xN).")
+    parser.add_argument("--n-ranks", type=int, default=2,
+                        help="Back-compat: total ranks for 1xN grid (used when --grid-rows/--grid-cols absent)")
+    parser.add_argument("--t", type=int, required=True, help="Token count per row (T)")
+    parser.add_argument("--h", type=int, required=True, help="Hidden dim (H)")
+    parser.add_argument("--fi", type=int, required=True, help="Per-rank intermediate dim per col (Fi)")
+    parser.add_argument("--output-dir", type=str, default="./out", help="Output directory")
+
+    args = parser.parse_args()
+    if args.grid_rows is None and args.grid_cols is None:
+        grid_rows = 1
+        grid_cols = args.n_ranks
+    else:
+        if args.grid_rows is None or args.grid_cols is None:
+            parser.error("--grid-rows and --grid-cols must be specified together")
+        grid_rows = args.grid_rows
+        grid_cols = args.grid_cols
+
+    cfg = FfnDataConfig(
+        t=args.t,
+        h=args.h,
+        fi=args.fi,
+        grid_rows=grid_rows,
+        grid_cols=grid_cols,
+        output_dir=args.output_dir,
+    )
+    gen_data(cfg)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Add `kernels/manual/a2a3/distributed_ffn_grid/`, an A2/A3 NPU example that exercises the GridPipe `TPUSH/TPOP` programming model on a logical `gridRows x gridCols` block grid mapped to a single device. No `mpirun` and no real HCCL — host builds a fake `HcclDeviceContext` with per-cell GM windows and runs all cells on device 0.
- Header layer adds `GridDirection` enum and `GridShape/GridCoord` helpers, an A2/A3 mocked SPR + WFE pair (with canonical pre-`dcci` / store / post-`dcci` / `dsb(DSB_DDR)` publish and `dcci` + `pipe_barrier(PIPE_ALL)` spin) plus bounded-spin `MockTryWfeReady/Free` and `MockSetFault` so kernels surface timeouts via fault flags instead of hanging, and the `GridDirection`-templated `TPUSH/TPOP` overloads gated by `is_grid_pipe_v`.
- Kernel layer is split across two `.so`s following the CCE dual-architecture model: cube kernel runs `X @ W_gate` / `X @ W_up` then `hidden @ W_down`; vec/comm kernel runs `PReLU(gate) * up -> hidden`, then in a single phase-1 launch performs the EAST reduce chain (col 0 `TPUSH`, middle cols `TPOP + TADD + TPUSH`, final col `TPOP + TADD + TSTORE`).
- Internal cube↔vec data movement now flows through `FfnSerialTPipe<>` `TPUSH/TPOP` slots — gate/up partials (cube → vec), the activated hidden tile (vec → cube), and the down partial (cube → vec). `TLOAD/TSTORE` are kept only at the demo boundaries (`x`/`W` on the cube input side and the final `y` write-out on the comm side), giving the example a uniform pipe-based dataflow over the existing GM layout.
- `main.cpp` host initializes ACL, allocates contiguous per-cell device buffers, seeds the fake HCCL windows, runs the phased launches, checks GridPipe sync counters and fault flags, then compares against `golden.bin` produced by `scripts/gen_data.py`.
- `CMakeLists.txt` builds the cube/vec kernel `.so`s and the host binary; `run.sh` is a one-shot CANN env + data generation + CMake configure + build + run; `README_zh.md` / `README.md` document the design, data flow, GridPipe mock semantics, and run instructions.

## Default configuration
```
gridRows  = 2
gridCols  = 2
T         = 16    # token tile per cell
H         = 64    # hidden dim
Fi        = 64    # FFN intermediate per column
```

## Test plan
- [x] Build via `bash run.sh --build-only -v Ascend910B1 --grid-rows 2 --grid-cols 2`.
- [x] NPU run: `task-submit --device auto --max-time 900 --run "cd kernels/manual/a2a3/distributed_ffn_grid && bash run.sh -r npu -v Ascend910B1 --grid-rows 2 --grid-cols 2"`. Expect 3/3 `ResultCmp=1` with `max_diff=0` against the fp32 golden reference; SOURCE pop sync, activation EAST relay sync, and EAST reduce sync counters all match; no GridPipe window fault flags raised.
- [ ] Inspect kernel sources against the IR verifier to confirm `TPUSH/TPOP` lowering paths remain valid for future silicon GridPipe targets.