### PR TITLE
Add distributed FFN GridPipe TPUSH/TPOP example on A2/A3

### DIFF
--- a/include/pto/common/grid_counter_intrinsic.hpp
+++ b/include/pto/common/grid_counter_intrinsic.hpp
@@ -1,0 +1,101 @@
+/**
+Copyright (c) 2026 Huawei Technologies Co., Ltd.
+This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+CANN Open Software License Agreement Version 2.0 (the "License").
+Please refer to the License for details. You may not use this file except in compliance with the License.
+THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+See LICENSE in the root of the software repository for the full text of the License.
+*/
+
+// CCE-intrinsic-style API for neighbor-core monotonic counters.
+//
+// These two functions intentionally sit at the same layer as hardware-adapter
+// intrinsics such as dcci: callers pass the concrete backend operand, while the
+// function body is the only place that knows whether the target is native
+// hardware or today's GM-counter mock.
+//
+// When hardware support is available, define PTO_GRID_COUNTER_NATIVE_INTRINSIC
+// and provide compiler builtins with the same contract.  Call sites do not need
+// to change.
+
+#ifndef PTO_GRID_COUNTER_INTRINSIC_HPP
+#define PTO_GRID_COUNTER_INTRINSIC_HPP
+
+#include <cstdint>
+
+#include <pto/common/type.hpp>
+#if !defined(PTO_GRID_COUNTER_NATIVE_INTRINSIC)
+#include <pto/common/grid_pipe_mock_spr.hpp>
+#endif
+
+namespace pto {
+
+enum class NeighborCounterKind : uint8_t
+{
+    Ready = 0,
+    Free = 1,
+};
+
+// Backend operand for the neighbor-counter intrinsic.
+//
+// Native hardware: `addr` is ignored and the compiler lowers (kind, dir, value)
+// to SPR/WFE instructions.
+// Current mock: `addr` points to the GM counter that represents either the
+// peer-visible counter for set or the local mirror counter for wait.
+struct NeighborCounterOperand {
+    __gm__ uint32_t *addr = nullptr;
+};
+
+// Set a neighbor-visible monotonic counter.
+//
+// Hardware contract:
+//   mtspr_neighbor_counter(Ready, EAST, value) ~= mtspr SPR_RDY_EAST, value
+//   mtspr_neighbor_counter(Free,  EAST, value) ~= mtspr SPR_FREE_EAST, value
+//
+// Memory ordering: release.  Earlier payload writes must become visible before
+// the peer can observe this counter update.
+AICORE inline void mtspr_neighbor_counter(NeighborCounterOperand operand, NeighborCounterKind kind, uint32_t dir,
+                                          uint32_t value)
+{
+#if defined(PTO_GRID_COUNTER_NATIVE_INTRINSIC)
+    (void)operand;
+    __builtin_pto_mtspr_neighbor_counter(static_cast<uint32_t>(kind), dir, value);
+#else
+    (void)dir;
+    if (kind == NeighborCounterKind::Ready) {
+        grid_mock::MockMtsprReady(operand.addr, value);
+    } else {
+        grid_mock::MockMtsprFree(operand.addr, value);
+    }
+#endif
+}
+
+// Wait until a neighbor-produced counter mirror reaches threshold.
+//
+// Hardware contract:
+//   wfe_neighbor_counter(Ready, EAST, n) ~= wfe SPR_RDY_EAST, n
+//   wfe_neighbor_counter(Free,  EAST, n) ~= wfe SPR_FREE_EAST, n
+//
+// Memory ordering: acquire.  Operations after the wait must not be reordered
+// before the counter condition has been satisfied.
+AICORE inline bool wfe_neighbor_counter(NeighborCounterOperand operand, NeighborCounterKind kind, uint32_t dir,
+                                        uint32_t threshold, uint32_t maxSpins = 0)
+{
+#if defined(PTO_GRID_COUNTER_NATIVE_INTRINSIC)
+    (void)operand;
+    (void)maxSpins;
+    __builtin_pto_wfe_neighbor_counter(static_cast<uint32_t>(kind), dir, threshold);
+    return true;
+#else
+    (void)dir;
+    if (kind == NeighborCounterKind::Ready) {
+        return grid_mock::MockTryWfeReady(operand.addr, threshold, maxSpins);
+    }
+    return grid_mock::MockTryWfeFree(operand.addr, threshold, maxSpins);
+#endif
+}
+
+} // namespace pto
+
+#endif // PTO_GRID_COUNTER_INTRINSIC_HPP

--- a/include/pto/common/grid_counter_intrinsic.hpp
+++ b/include/pto/common/grid_counter_intrinsic.hpp
@@ -55,8 +55,8 @@ struct NeighborCounterOperand {
 //
 // Memory ordering: release.  Earlier payload writes must become visible before
 // the peer can observe this counter update.
-AICORE inline void mtspr_neighbor_counter(NeighborCounterOperand operand, NeighborCounterKind kind, uint32_t dir,
-                                          uint32_t value)
+AICORE inline void mtspr_neighbor_counter(NeighborCounterKind kind, uint32_t dir, uint32_t value,
+                                          NeighborCounterOperand operand = {})
 {
 #if defined(PTO_GRID_COUNTER_NATIVE_INTRINSIC)
     (void)operand;
@@ -79,8 +79,8 @@ AICORE inline void mtspr_neighbor_counter(NeighborCounterOperand operand, Neighb
 //
 // Memory ordering: acquire.  Operations after the wait must not be reordered
 // before the counter condition has been satisfied.
-AICORE inline bool wfe_neighbor_counter(NeighborCounterOperand operand, NeighborCounterKind kind, uint32_t dir,
-                                        uint32_t threshold, uint32_t maxSpins = 0)
+AICORE inline bool wfe_neighbor_counter(NeighborCounterKind kind, uint32_t dir, uint32_t threshold,
+                                        NeighborCounterOperand operand = {}, uint32_t maxSpins = 0)
 {
 #if defined(PTO_GRID_COUNTER_NATIVE_INTRINSIC)
     (void)operand;

--- a/include/pto/common/grid_pipe.hpp
+++ b/include/pto/common/grid_pipe.hpp
@@ -1,0 +1,223 @@
+/**
+Copyright (c) 2026 Huawei Technologies Co., Ltd.
+This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+CANN Open Software License Agreement Version 2.0 (the "License").
+Please refer to the License for details. You may not use this file except in compliance with the License.
+THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+See LICENSE in the root of the software repository for the full text of the License.
+*/
+
+// GridPipe: neighbor-core FIFO communication primitives.
+//
+// This is the proposal-level abstraction described in
+// distributed-ffn-grid-tpush-tpop_zh-SPR_WFE.md.  On LPU WSE silicon the
+// operations defined here are expected to lower to "SPR write + WFE wait +
+// existing TMOV" sequences (see design doc section 5.3).  On A2/A3 we provide
+// a mock backend that emulates the SPR+WFE semantics with HCCL shared windows
+// and GM atomic flags; see include/pto/npu/a2a3/GridTPush.hpp.
+//
+// Compiler-visible static constraints are enforced via static_assert inside
+// the intrinsic overloads in pto_instr.hpp.
+
+#ifndef PTO_GRID_PIPE_HPP
+#define PTO_GRID_PIPE_HPP
+
+#include <cstdint>
+#include <type_traits>
+
+#include <pto/common/arch_macro.hpp>
+#include <pto/common/type.hpp> // for AICORE (callable from both host and aicore contexts)
+
+// Forward declaration: provided by the target backend (cpu_stub.hpp on
+// CPU sim builds, CCE intrinsic / runtime header on A2/A3 NPU builds).
+// GetGridCoord below uses this; we declare it here so grid_pipe.hpp can be
+// included before any backend headers without triggering an undeclared name.
+uint32_t get_block_idx();
+
+namespace pto {
+
+// ---------------------------------------------------------------------------
+// 2D mesh coordinates and shape (design doc section 2).
+// ---------------------------------------------------------------------------
+struct GridShape {
+    int gridRows = 0; // N
+    int gridCols = 0; // M
+};
+
+struct GridCoord {
+    int row = 0; // 0 .. gridRows-1
+    int col = 0; // 0 .. gridCols-1
+};
+
+// ---------------------------------------------------------------------------
+// Direction enum (design doc section 3.1).  Strongly-typed to avoid clashing
+// with the cluster-local pto::Direction enum used by TPipe.
+// ---------------------------------------------------------------------------
+enum class GridDirection : uint8_t
+{
+    SOURCE = 0, // GM/Host/Runtime injection.  Only valid for TPOP.
+    NORTH = 1,  // row -> row-1
+    EAST = 2,   // col -> col+1
+    WEST = 3,   // col -> col-1
+};
+
+inline constexpr int kGridDirectionCount = 4;
+
+AICORE constexpr int GridDirectionIndex(GridDirection d)
+{
+    return static_cast<int>(d);
+}
+
+// ---------------------------------------------------------------------------
+// GridPipe<TileT, SlotBytes, SlotCount>
+//
+// One instance describes the FIFO state for a single logical channel that the
+// current core uses; each (core, direction) pair has its own ring buffer with
+// independent prod/cons indices, ready/free signals, and slot region.  Fields
+// are populated by the runtime during InitGridPipe and are read by the lower
+// half (compiler-generated intrinsic expansions).
+// ---------------------------------------------------------------------------
+template <typename TileT_, int SlotBytes_, int SlotCount_>
+struct GridPipe {
+    static_assert(SlotCount_ > 0, "GridPipe requires SlotCount > 0");
+    static_assert(SlotBytes_ > 0, "GridPipe requires SlotBytes > 0");
+
+    using TileType = TileT_;
+    static constexpr int SlotBytes = SlotBytes_;
+    static constexpr int SlotCount = SlotCount_;
+
+    // Shape + coord cached from runtime (design doc 2.1 / 2.2).
+    GridShape shape{};
+    GridCoord coord{};
+
+    // Per-direction state.  Index by GridDirectionIndex(dir).
+    __gm__ uint8_t *slotBase[kGridDirectionCount] = {nullptr};
+    __gm__ uint32_t *readyFlags[kGridDirectionCount] = {nullptr};
+    __gm__ uint32_t *freeFlags[kGridDirectionCount] = {nullptr};
+    uint32_t prodIndex[kGridDirectionCount] = {0};
+    uint32_t consIndex[kGridDirectionCount] = {0};
+
+    // Opaque runtime pointer used by the A2/A3 backend to resolve cross-rank
+    // addresses (HCCL device context).  Other targets may reinterpret.
+    __gm__ void *runtimeCtx = nullptr;
+
+    // Stable logical id used for runtime telemetry / mock SPR_PIPE_ID_<DIR>.
+    uint32_t pipeId = 0;
+};
+
+// ---------------------------------------------------------------------------
+// SFINAE marker: lets pto_instr.hpp's TPUSH/TPOP grid overloads disambiguate
+// against the existing TPipe overloads without ambiguity.
+// ---------------------------------------------------------------------------
+template <typename T>
+struct is_grid_pipe : std::false_type {};
+
+template <typename TileT, int SlotBytes, int SlotCount>
+struct is_grid_pipe<GridPipe<TileT, SlotBytes, SlotCount>> : std::true_type {};
+
+template <typename T>
+inline constexpr bool is_grid_pipe_v = is_grid_pipe<std::remove_reference_t<T>>::value;
+
+// ---------------------------------------------------------------------------
+// Coordinate bootstrap (design doc 2.1).  Row-major mapping from launcher's
+// block_idx to (row, col).  AICORE-qualified because it calls get_block_idx(),
+// which is a device intrinsic and has no host implementation.
+// ---------------------------------------------------------------------------
+AICORE inline GridCoord GetGridCoord(GridShape shape)
+{
+    int blockIdx = static_cast<int>(get_block_idx());
+    return GridCoord{blockIdx / shape.gridCols, blockIdx % shape.gridCols};
+}
+
+AICORE inline int RankFromCoord(GridCoord coord, GridShape shape)
+{
+    return coord.row * shape.gridCols + coord.col;
+}
+
+// ---------------------------------------------------------------------------
+// Compile-time / run-time direction validity (design doc 2.3).
+// ---------------------------------------------------------------------------
+AICORE constexpr bool CanPush(GridDirection dir, GridCoord c, GridShape s)
+{
+    switch (dir) {
+        case GridDirection::NORTH:
+            return c.row > 0;
+        case GridDirection::EAST:
+            return c.col + 1 < s.gridCols;
+        case GridDirection::WEST:
+            return c.col > 0;
+        case GridDirection::SOURCE:
+            return false; // Never legal to push to SOURCE.
+    }
+    return false;
+}
+
+AICORE constexpr bool CanPop(GridDirection dir, GridCoord c, GridShape s)
+{
+    switch (dir) {
+        case GridDirection::NORTH:
+            return c.row + 1 < s.gridRows;
+        case GridDirection::EAST:
+            return c.col > 0;
+        case GridDirection::WEST:
+            return c.col + 1 < s.gridCols;
+        case GridDirection::SOURCE:
+            return true;
+    }
+    return false;
+}
+
+AICORE constexpr GridCoord NeighborForPush(GridDirection dir, GridCoord c)
+{
+    switch (dir) {
+        case GridDirection::NORTH:
+            return {c.row - 1, c.col};
+        case GridDirection::EAST:
+            return {c.row, c.col + 1};
+        case GridDirection::WEST:
+            return {c.row, c.col - 1};
+        case GridDirection::SOURCE:
+            return c; // Unused; static_assert blocks TPUSH<SOURCE>.
+    }
+    return c;
+}
+
+AICORE constexpr GridCoord NeighborForPop(GridDirection dir, GridCoord c)
+{
+    switch (dir) {
+        case GridDirection::NORTH:
+            return {c.row + 1, c.col};
+        case GridDirection::EAST:
+            return {c.row, c.col - 1};
+        case GridDirection::WEST:
+            return {c.row, c.col + 1};
+        case GridDirection::SOURCE:
+            return c; // Bound by runtime to source queue.
+    }
+    return c;
+}
+
+inline constexpr int kInvalidRank = -1;
+
+AICORE constexpr int NeighborRankForPush(GridDirection dir, GridCoord c, GridShape s)
+{
+    if (!CanPush(dir, c, s)) {
+        return kInvalidRank;
+    }
+    GridCoord n = NeighborForPush(dir, c);
+    return n.row * s.gridCols + n.col;
+}
+
+AICORE constexpr int NeighborRankForPop(GridDirection dir, GridCoord c, GridShape s)
+{
+    if (!CanPop(dir, c, s)) {
+        return kInvalidRank;
+    }
+    GridCoord n = NeighborForPop(dir, c);
+    return n.row * s.gridCols + n.col;
+}
+
+} // namespace pto
+
+#endif // PTO_GRID_PIPE_HPP

--- a/include/pto/common/grid_pipe_mock_spr.hpp
+++ b/include/pto/common/grid_pipe_mock_spr.hpp
@@ -1,0 +1,235 @@
+/**
+Copyright (c) 2026 Huawei Technologies Co., Ltd.
+This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+CANN Open Software License Agreement Version 2.0 (the "License").
+Please refer to the License for details. You may not use this file except in compliance with the License.
+THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+See LICENSE in the root of the software repository for the full text of the License.
+*/
+
+// Mock layer that stands in for LPU WSE SPR + WFE primitives.
+//
+// Design doc section 5 defines the LPU WSE GridPipe lowering as:
+//   - mtspr SPR_RDY_<DIR>    -> cross-core SPR write, wakes neighbor WFE
+//   - mtspr SPR_FREE_<DIR>   -> cross-core SPR write, wakes producer WFE
+//   - mfspr SPR_RDY_<DIR>    -> read local mirror of ready flag
+//   - wfe   SPR_RDY_<DIR>, N -> block until ready >= N
+//   - wfe   SPR_FREE_<DIR>,N -> block until free  >= N
+//
+// On A2/A3 silicon there is no native cross-core mesh SPR + event line.  The
+// mocks below emulate the contract via GM atomic flags + spin-wait, so the
+// GridPipe semantics can be exercised on real A2/A3 boards while staying
+// trivially swappable for a real LPU WSE SPR backend later.
+//
+// Each MOCK_* function carries a comment naming the corresponding LPU WSE
+// pseudo-asm line from design doc section 5.3, so `grep -n "LPU WSE:"` returns
+// the substitution sites.
+
+#ifndef PTO_GRID_PIPE_MOCK_SPR_HPP
+#define PTO_GRID_PIPE_MOCK_SPR_HPP
+
+#include <cstdint>
+
+#include <pto/common/arch_macro.hpp>
+#include <pto/common/grid_pipe.hpp>
+
+namespace pto {
+namespace grid_mock {
+
+#ifndef PTO_GRID_MOCK_WFE_MAX_SPINS
+#define PTO_GRID_MOCK_WFE_MAX_SPINS 100000000U
+#endif
+
+inline constexpr uint32_t kDefaultWfeMaxSpins = PTO_GRID_MOCK_WFE_MAX_SPINS;
+inline constexpr uint32_t kFaultFlagWordOffset = 8;
+
+// MOCK: design doc 5.3 producer step (4), consumer step (4).
+//
+// LPU WSE: mtspr SPR_RDY_<DIR>, newValue      (cross-core, wakes neighbor WFE)
+// LPU WSE: mtspr SPR_FREE_<DIR>, newValue     (cross-core, wakes producer WFE)
+//
+// A2/A3 mock: producer / consumer holds a pointer into the *neighbor's* GM
+// window (resolved by HcclRemotePtr at runtime); we write the new monotonic
+// counter into that remote location.  Pairing read happens via MockWfe* below.
+//
+// volatile cast prevents the compiler from caching the write.  Cross-rank
+// visibility on A2/A3 requires an explicit dsb(DSB_DDR) + dcci pair around the
+// store: AICORE caches are not coherent between cores, so without the dcci the
+// pairing MockWfe spin on the remote rank may never observe the write.  This
+// matches the SetLocalSummaryReady pattern in ready_queue.hpp (allgather_gemm).
+inline AICORE void MockMtsprCounter(__gm__ uint32_t *remoteFlag, uint32_t newValue)
+{
+    if (remoteFlag != nullptr) {
+        volatile __gm__ uint32_t *ptr = reinterpret_cast<volatile __gm__ uint32_t *>(remoteFlag);
+        // Match the canonical TNotify Set pattern: pre-invalidate, store,
+        // post-invalidate, dsb(DSB_DDR).  Compiler barriers prevent reordering.
+        __asm__ __volatile__("" ::: "memory");
+        dcci(reinterpret_cast<__gm__ void *>(const_cast<__gm__ uint32_t *>(ptr)), SINGLE_CACHE_LINE);
+        __asm__ __volatile__("" ::: "memory");
+        *ptr = newValue;
+        __asm__ __volatile__("" ::: "memory");
+        dcci(reinterpret_cast<__gm__ void *>(const_cast<__gm__ uint32_t *>(ptr)), SINGLE_CACHE_LINE);
+        __asm__ __volatile__("" ::: "memory");
+        dsb(DSB_DDR);
+    }
+}
+
+inline AICORE void MockMtsprReady(__gm__ uint32_t *remoteFlag, uint32_t newValue)
+{
+    MockMtsprCounter(remoteFlag, newValue);
+}
+
+inline AICORE void MockMtsprFree(__gm__ uint32_t *remoteFlag, uint32_t newValue)
+{
+    MockMtsprCounter(remoteFlag, newValue);
+}
+
+// MOCK: design doc 5.3 producer step (1), consumer step (1).
+//
+// LPU WSE: mfspr r_ready, SPR_RDY_<DIR>
+// LPU WSE: mfspr r_free,  SPR_FREE_<DIR>
+//
+// A2/A3 mock: volatile read of the local mirror of the flag.
+inline AICORE uint32_t MockMfspr(__gm__ uint32_t *localFlag)
+{
+    if (localFlag == nullptr) {
+        return 0;
+    }
+    return *reinterpret_cast<volatile __gm__ uint32_t *>(localFlag);
+}
+
+// MOCK: design doc 5.3 producer step (1) wait, consumer step (1) wait.
+//
+// LPU WSE: wfe SPR_RDY_<DIR>,  threshold      (block until SPR >= threshold)
+// LPU WSE: wfe SPR_FREE_<DIR>, threshold
+//
+// A2/A3 mock: spin-poll the GM flag with `dcci` each iteration to invalidate
+// the local cache line so the next load fetches from DDR.  Without the dcci,
+// the AICORE may cache the original 0 indefinitely and never observe the
+// producer's write (cross-core caches are not auto-coherent on A2/A3).
+inline AICORE bool MockTryWfeCounter(__gm__ uint32_t *localFlag, uint32_t threshold,
+                                     uint32_t maxSpins = kDefaultWfeMaxSpins)
+{
+    if (localFlag == nullptr) {
+        return true;
+    }
+    volatile __gm__ uint32_t *p = reinterpret_cast<volatile __gm__ uint32_t *>(localFlag);
+    uint32_t spin = 0;
+    constexpr uint32_t kFenceInterval = 64;
+    while (true) {
+        __asm__ __volatile__("" ::: "memory");
+        dcci(reinterpret_cast<__gm__ void *>(const_cast<__gm__ uint32_t *>(p)), SINGLE_CACHE_LINE);
+        __asm__ __volatile__("" ::: "memory");
+        if (*p >= threshold) {
+            return true;
+        }
+        if (maxSpins != 0 && spin >= maxSpins) {
+            return false;
+        }
+        if ((++spin % kFenceInterval) == 0) {
+            pipe_barrier(PIPE_ALL);
+        }
+    }
+}
+
+inline AICORE bool MockTryWfeReady(__gm__ uint32_t *localFlag, uint32_t threshold,
+                                   uint32_t maxSpins = kDefaultWfeMaxSpins)
+{
+    return MockTryWfeCounter(localFlag, threshold, maxSpins);
+}
+
+inline AICORE bool MockTryWfeFree(__gm__ uint32_t *localFlag, uint32_t threshold,
+                                  uint32_t maxSpins = kDefaultWfeMaxSpins)
+{
+    return MockTryWfeCounter(localFlag, threshold, maxSpins);
+}
+
+inline AICORE void MockWfeReady(__gm__ uint32_t *localFlag, uint32_t threshold)
+{
+    (void)MockTryWfeReady(localFlag, threshold, 0);
+}
+
+inline AICORE void MockWfeFree(__gm__ uint32_t *localFlag, uint32_t threshold)
+{
+    (void)MockTryWfeFree(localFlag, threshold, 0);
+}
+
+inline AICORE void MockSetFault(__gm__ uint32_t *faultFlag, uint32_t faultCode)
+{
+    if (faultFlag != nullptr) {
+        volatile __gm__ uint32_t *ptr = reinterpret_cast<volatile __gm__ uint32_t *>(faultFlag);
+        __asm__ __volatile__("" ::: "memory");
+        *ptr = faultCode;
+        __asm__ __volatile__("" ::: "memory");
+        dcci(reinterpret_cast<__gm__ void *>(const_cast<__gm__ uint32_t *>(ptr)), SINGLE_CACHE_LINE);
+        dsb(DSB_DDR);
+    }
+}
+
+// MOCK: design doc 5.4 SPR_BOUNDARY_MASK fault.
+//
+// LPU WSE: writing SPR_RDY_<DIR> when SPR_BOUNDARY_MASK has that direction
+// disabled triggers a hardware fault / squash.
+//
+// A2/A3 mock: explicit early-exit + sentinel write so the host can detect the
+// out-of-bound attempt.  Real boards will raise a fault; here we trap softly
+// by writing a sentinel and aborting the kernel branch.  The host launcher
+// inspects a "fault sentinel" GM word after each kernel and fails the run.
+inline AICORE void MockBoundaryFault(__gm__ uint32_t *faultSentinel, uint32_t faultCode)
+{
+    if (faultSentinel != nullptr) {
+        *reinterpret_cast<volatile __gm__ uint32_t *>(faultSentinel) = faultCode;
+    }
+    // Best-effort halt of the current kernel branch.  Real silicon will fault
+    // here; on A2/A3 we just stop emitting further GridPipe ops in this branch.
+}
+
+// Fault codes mirror SPR_BOUNDARY_MASK fields (design doc section 5.2).
+inline constexpr uint32_t kFaultPushNorth = 0x101;
+inline constexpr uint32_t kFaultPushEast = 0x102;
+inline constexpr uint32_t kFaultPushWest = 0x103;
+inline constexpr uint32_t kFaultPushSource = 0x104; // Always illegal.
+inline constexpr uint32_t kFaultPopNorth = 0x201;
+inline constexpr uint32_t kFaultPopEast = 0x202;
+inline constexpr uint32_t kFaultPopWest = 0x203;
+inline constexpr uint32_t kFaultWaitReadyTimeout = 0x301;
+inline constexpr uint32_t kFaultWaitFreeTimeout = 0x302;
+
+// Direction-keyed fault code lookup.  Explicit switch avoids relying on the
+// numeric layout of GridDirection so renumbering the enum cannot silently
+// remap fault codes.
+AICORE constexpr uint32_t PushFaultCode(GridDirection dir)
+{
+    switch (dir) {
+        case GridDirection::NORTH:
+            return kFaultPushNorth;
+        case GridDirection::EAST:
+            return kFaultPushEast;
+        case GridDirection::WEST:
+            return kFaultPushWest;
+        case GridDirection::SOURCE:
+            return kFaultPushSource;
+    }
+    return kFaultPushSource;
+}
+
+AICORE constexpr uint32_t PopFaultCode(GridDirection dir)
+{
+    switch (dir) {
+        case GridDirection::NORTH:
+            return kFaultPopNorth;
+        case GridDirection::EAST:
+            return kFaultPopEast;
+        case GridDirection::WEST:
+            return kFaultPopWest;
+        case GridDirection::SOURCE:
+            return 0; // SOURCE pop is legal; never raises a boundary fault.
+    }
+    return 0;
+}
+
+} // namespace grid_mock
+} // namespace pto
+
+#endif // PTO_GRID_PIPE_MOCK_SPR_HPP

--- a/include/pto/common/grid_sram_intrinsic.hpp
+++ b/include/pto/common/grid_sram_intrinsic.hpp
@@ -1,0 +1,163 @@
+/**
+Copyright (c) 2026 Huawei Technologies Co., Ltd.
+This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+CANN Open Software License Agreement Version 2.0 (the "License").
+Please refer to the License for details. You may not use this file except in compliance with the License.
+THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+See LICENSE in the root of the software repository for the full text of the License.
+*/
+
+// CCE-intrinsic-style API for neighbor-core SRAM/UB/L1 addressing and transfer.
+// Grid TPUSH/TPOP calls this layer so the same protocol can use either native
+// __builtin_pto_* instructions or the current A2/A3 mock lowering.
+//
+// Grid TPUSH/TPOP payload movement targets neighbor-visible on-chip storage,
+// not a global-memory object in the hardware contract. Vector-core storage is
+// UB; Cube-core storage is L1/CBUF. Current A2/A3 demos emulate those neighbor
+// windows with local GM windows; the mock address operand is therefore kept as
+// backend context while the public API exposes address-register style values.
+
+#ifndef PTO_GRID_SRAM_INTRINSIC_HPP
+#define PTO_GRID_SRAM_INTRINSIC_HPP
+
+#include <cstdint>
+
+#include <pto/common/type.hpp>
+
+namespace pto {
+
+// Address-register model for a neighbor-visible SRAM location.
+// Native hardware: value is the encoded SRAM address register payload.
+// Current mock: value is the integer form of the backing fake-window pointer.
+struct neighbor_sram_addr {
+    uint64_t value = 0;
+};
+
+struct neighbor_ubuf_addr {
+    uint64_t value = 0;
+};
+
+struct neighbor_cbuf_addr {
+    uint64_t value = 0;
+};
+
+// Backend operand used only by the mock lowering. Native hardware ignores it
+// and derives the neighbor SRAM mapping from dir/peer configuration registers.
+struct NeighborSramOperand {
+    __gm__ void *runtimeCtx = nullptr;
+};
+
+namespace grid_sram_mock {
+
+AICORE uint64_t MockGetNeighborSramAddr(__gm__ void *runtimeCtx, uint64_t localSramAddr, int32_t peerRank);
+AICORE void MockCopyUbufToNeighborUbuf(neighbor_ubuf_addr dst, __ubuf__ void *src, uint32_t bytes, uint64_t config);
+AICORE void MockCopyUbufToNeighborCbuf(neighbor_cbuf_addr dst, __ubuf__ void *src, uint32_t bytes, uint64_t config);
+AICORE void MockCopyCbufToNeighborUbuf(neighbor_ubuf_addr dst, __cbuf__ void *src, uint32_t bytes, uint64_t config);
+AICORE void MockCopyCbufToNeighborCbuf(neighbor_cbuf_addr dst, __cbuf__ void *src, uint32_t bytes, uint64_t config);
+AICORE void MockCopyNeighborUbufToUbuf(__ubuf__ void *dst, neighbor_ubuf_addr src, uint32_t bytes, uint64_t config);
+
+} // namespace grid_sram_mock
+
+// Resolve a local SRAM slot address to the same slot in a neighbor core.
+//
+// Parameter order follows CCE data/address instructions: output register first,
+// source address register next, then topology/control operands.
+AICORE inline void get_neighbor_sram_addr(neighbor_sram_addr &dst, neighbor_sram_addr src, uint32_t dir,
+                                          int32_t peerRank, NeighborSramOperand operand = {})
+{
+#if defined(PTO_GRID_SRAM_NATIVE_INTRINSIC)
+    (void)operand;
+    dst.value = __builtin_pto_get_neighbor_sram_addr(src.value, dir, peerRank);
+#else
+    (void)dir;
+    dst.value = grid_sram_mock::MockGetNeighborSramAddr(operand.runtimeCtx, src.value, peerRank);
+#endif
+}
+
+AICORE inline void get_neighbor_ubuf_addr(neighbor_ubuf_addr &dst, neighbor_sram_addr src, uint32_t dir,
+                                          int32_t peerRank, NeighborSramOperand operand = {})
+{
+#if defined(PTO_GRID_SRAM_NATIVE_INTRINSIC)
+    (void)operand;
+    dst.value = __builtin_pto_get_neighbor_ubuf_addr(src.value, dir, peerRank);
+#else
+    neighbor_sram_addr remote{};
+    get_neighbor_sram_addr(remote, src, dir, peerRank, operand);
+    dst.value = remote.value;
+#endif
+}
+
+AICORE inline void get_neighbor_cbuf_addr(neighbor_cbuf_addr &dst, neighbor_sram_addr src, uint32_t dir,
+                                          int32_t peerRank, NeighborSramOperand operand = {})
+{
+#if defined(PTO_GRID_SRAM_NATIVE_INTRINSIC)
+    (void)operand;
+    dst.value = __builtin_pto_get_neighbor_cbuf_addr(src.value, dir, peerRank);
+#else
+    neighbor_sram_addr remote{};
+    get_neighbor_sram_addr(remote, src, dir, peerRank, operand);
+    dst.value = remote.value;
+#endif
+}
+
+// Cross-core payload writes. Source address space names the producer core's
+// local storage; destination address register names the neighbor core storage.
+AICORE inline void copy_ubuf_to_neighbor_ubuf(neighbor_ubuf_addr dst, __ubuf__ void *src, uint32_t bytes,
+                                              uint64_t config)
+{
+#if defined(PTO_GRID_SRAM_NATIVE_INTRINSIC)
+    __builtin_pto_copy_ubuf_to_neighbor_ubuf(dst.value, src, bytes, config);
+#else
+    // A2/A3 validation keeps the intrinsic call shape and only changes the
+    // final lowering to a GM-backed fake window.
+    grid_sram_mock::MockCopyUbufToNeighborUbuf(dst, src, bytes, config);
+#endif
+}
+
+AICORE inline void copy_ubuf_to_neighbor_cbuf(neighbor_cbuf_addr dst, __ubuf__ void *src, uint32_t bytes,
+                                              uint64_t config)
+{
+#if defined(PTO_GRID_SRAM_NATIVE_INTRINSIC)
+    __builtin_pto_copy_ubuf_to_neighbor_cbuf(dst.value, src, bytes, config);
+#else
+    grid_sram_mock::MockCopyUbufToNeighborCbuf(dst, src, bytes, config);
+#endif
+}
+
+AICORE inline void copy_cbuf_to_neighbor_ubuf(neighbor_ubuf_addr dst, __cbuf__ void *src, uint32_t bytes,
+                                              uint64_t config)
+{
+#if defined(PTO_GRID_SRAM_NATIVE_INTRINSIC)
+    __builtin_pto_copy_cbuf_to_neighbor_ubuf(dst.value, src, bytes, config);
+#else
+    grid_sram_mock::MockCopyCbufToNeighborUbuf(dst, src, bytes, config);
+#endif
+}
+
+AICORE inline void copy_cbuf_to_neighbor_cbuf(neighbor_cbuf_addr dst, __cbuf__ void *src, uint32_t bytes,
+                                              uint64_t config)
+{
+#if defined(PTO_GRID_SRAM_NATIVE_INTRINSIC)
+    __builtin_pto_copy_cbuf_to_neighbor_cbuf(dst.value, src, bytes, config);
+#else
+    grid_sram_mock::MockCopyCbufToNeighborCbuf(dst, src, bytes, config);
+#endif
+}
+
+// A2/A3 mock helper for TPOP validation. Native Grid TPOP should bind the
+// local UB/L1 slot through TASSIGN instead of issuing a remote load.
+AICORE inline void copy_neighbor_ubuf_to_ubuf(__ubuf__ void *dst, neighbor_ubuf_addr src, uint32_t bytes,
+                                              uint64_t config)
+{
+#if defined(PTO_GRID_SRAM_NATIVE_INTRINSIC)
+    __builtin_pto_copy_neighbor_ubuf_to_ubuf(dst, src.value, bytes, config);
+#else
+    // Keep TPOP visible as intrinsic-style UB transfer in the A2/A3 mock.
+    grid_sram_mock::MockCopyNeighborUbufToUbuf(dst, src, bytes, config);
+#endif
+}
+
+} // namespace pto
+
+#endif // PTO_GRID_SRAM_INTRINSIC_HPP

--- a/include/pto/common/pto_instr.hpp
+++ b/include/pto/common/pto_instr.hpp
@@ -2011,7 +2011,7 @@ PTO_INST RecordEvent TPUSH(Pipe &pipe, TileProd &tile, WaitEvents &...events)
     static_assert(Direction != pto::GridDirection::SOURCE,
                   "GridPipe TPUSH<SOURCE> is illegal (design doc section 4.3): "
                   "SOURCE is only valid for TPOP.");
-#if defined(PTO_NPU_ARCH_A2A3) || defined(__CPU_SIM)
+#if defined(PTO_NPU_ARCH_A2A3)
     TSYNC(events...);
     GRID_TPUSH_IMPL<Direction, Pipe, TileProd>(pipe, tile);
 #else
@@ -2026,7 +2026,7 @@ template <pto::GridDirection Direction, typename Pipe, typename TileCons,
           std::enable_if_t<is_grid_pipe_v<Pipe>, int> = 0, typename... WaitEvents>
 PTO_INST RecordEvent TPOP(Pipe &pipe, TileCons &tile, WaitEvents &...events)
 {
-#if defined(PTO_NPU_ARCH_A2A3) || defined(__CPU_SIM)
+#if defined(PTO_NPU_ARCH_A2A3)
     TSYNC(events...);
     GRID_TPOP_IMPL<Direction, Pipe, TileCons>(pipe, tile);
 #else

--- a/include/pto/common/pto_instr.hpp
+++ b/include/pto/common/pto_instr.hpp
@@ -14,6 +14,7 @@ See LICENSE in the root of the software repository for the full text of the Lice
 #include "pto/common/debug.h"
 #include "pto/common/event.hpp"
 #include "pto/common/fifo.hpp"
+#include "pto/common/grid_pipe.hpp"
 #include "pto/common/tassign_check.hpp"
 #include "pto/common/pto_instr_impl.hpp"
 #if !defined(__COSTMODEL) && !defined(PTO_COMM_NOT_SUPPORTED)
@@ -1991,6 +1992,48 @@ PTO_INST RecordEvent TGET_SCALE_ADDR(TileDataOut &dst, TileDataIn &src, WaitEven
 {
     TSYNC(events...);
     MAP_INSTR_IMPL(TGET_SCALE_ADDR, dst, src);
+    return {};
+}
+
+// ---------------------------------------------------------------------------
+// GridPipe TPUSH / TPOP overloads (design doc section 4.1, "neighbor-core
+// FIFO" form).  These coexist with the cluster-local TPipe overloads above:
+// SFINAE on is_grid_pipe_v keeps overload resolution unambiguous.  The
+// `Direction` non-type template parameter is constant-folded by the compiler,
+// matching design doc section 4.2's requirement that direction be a constant
+// at lowering time.
+// ---------------------------------------------------------------------------
+
+template <pto::GridDirection Direction, typename Pipe, typename TileProd,
+          std::enable_if_t<is_grid_pipe_v<Pipe>, int> = 0, typename... WaitEvents>
+PTO_INST RecordEvent TPUSH(Pipe &pipe, TileProd &tile, WaitEvents &...events)
+{
+    static_assert(Direction != pto::GridDirection::SOURCE,
+                  "GridPipe TPUSH<SOURCE> is illegal (design doc section 4.3): "
+                  "SOURCE is only valid for TPOP.");
+#if defined(PTO_NPU_ARCH_A2A3) || defined(__CPU_SIM)
+    TSYNC(events...);
+    GRID_TPUSH_IMPL<Direction, Pipe, TileProd>(pipe, tile);
+#else
+    static_assert(sizeof(Pipe) == 0,
+                  "GridPipe TPUSH not supported on this target profile "
+                  "(design doc section 5.4 forbids silent GM fallback).");
+#endif
+    return {};
+}
+
+template <pto::GridDirection Direction, typename Pipe, typename TileCons,
+          std::enable_if_t<is_grid_pipe_v<Pipe>, int> = 0, typename... WaitEvents>
+PTO_INST RecordEvent TPOP(Pipe &pipe, TileCons &tile, WaitEvents &...events)
+{
+#if defined(PTO_NPU_ARCH_A2A3) || defined(__CPU_SIM)
+    TSYNC(events...);
+    GRID_TPOP_IMPL<Direction, Pipe, TileCons>(pipe, tile);
+#else
+    static_assert(sizeof(Pipe) == 0,
+                  "GridPipe TPOP not supported on this target profile "
+                  "(design doc section 5.4 forbids silent GM fallback).");
+#endif
     return {};
 }
 

--- a/include/pto/common/pto_instr_impl.hpp
+++ b/include/pto/common/pto_instr_impl.hpp
@@ -158,6 +158,9 @@ See LICENSE in the root of the software repository for the full text of the Lice
 #include "pto/npu/a2a3/TAlloc.hpp"
 #include "pto/npu/a2a3/TFree.hpp"
 #include "pto/npu/a2a3/TColReduceIdx.hpp"
+#include "pto/npu/a2a3/grid_pipe_runtime.hpp"
+#include "pto/npu/a2a3/GridTPush.hpp"
+#include "pto/npu/a2a3/GridTPop.hpp"
 #endif
 #endif
 

--- a/include/pto/npu/a2a3/GridTPop.hpp
+++ b/include/pto/npu/a2a3/GridTPop.hpp
@@ -8,8 +8,7 @@ INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A
 See LICENSE in the root of the software repository for the full text of the License.
 */
 
-// A2/A3 backend for GridPipe TPOP<Direction>.  Mirrors GridTPush.hpp.
-// See design doc section 5.3 consumer expansion template.
+// A2/A3 backend for GridPipe TPOP<Direction>. Mirrors GridTPush.hpp.
 
 #ifndef PTO_A2A3_GRID_TPOP_HPP
 #define PTO_A2A3_GRID_TPOP_HPP
@@ -44,20 +43,22 @@ AICORE bool GRID_TRY_TPOP_IMPL(Pipe &pipe, TileCons &tile, uint32_t maxSpins = g
 #else
     NeighborCounterOperand readyCounter{pipe.readyFlags[dirIdx]};
 #endif
-    if (!wfe_neighbor_counter(readyCounter, NeighborCounterKind::Ready, dirIdx, expectedReady, maxSpins)) {
+    if (!wfe_neighbor_counter(NeighborCounterKind::Ready, dirIdx, expectedReady, readyCounter, maxSpins)) {
         grid_mock::MockSetFault(pipe.readyFlags[dirIdx] + grid_mock::kFaultFlagWordOffset,
                                 grid_mock::kFaultWaitReadyTimeout);
         return false;
     }
 
-    // Step 2: compute slot address (local; producer wrote it here).
+    // Step 2: compute local SRAM slot address; producer wrote it here.
     const uint32_t idx = pipe.consIndex[dirIdx];
     const uint32_t slotOff = (idx % Pipe::SlotCount) * Pipe::SlotBytes;
     __gm__ uint8_t *localSlot = pipe.slotBase[dirIdx] + slotOff;
+    neighbor_ubuf_addr localUbufSlot = a2a3_grid_payload::LocalUbufAddr(localSlot);
 
     // Step 3: payload transfer from local slot to consumer tile buffer.
     //   LPU WSE: tmov tile_buf, [r_slot]
-    a2a3_grid_payload::CopyGmSlotToTile<TileCons>(tile, localSlot, Pipe::SlotBytes);
+    // Adapter bridges Tile storage to copy_neighbor_ubuf_to_ubuf(...).
+    a2a3_grid_payload::CopyNeighborUbufSlotToTile<TileCons>(tile, localUbufSlot, Pipe::SlotBytes);
 
     // Step 4: notify upstream producer that slot is free.
     //   LPU WSE: mtspr SPR_FREE_<DIR>, r_idx + 1
@@ -70,10 +71,10 @@ AICORE bool GRID_TRY_TPOP_IMPL(Pipe &pipe, TileCons &tile, uint32_t maxSpins = g
 #else
         const int peerRank = NeighborRankForPop(Dir, pipe.coord, pipe.shape);
         __gm__ uint32_t *peerFree =
-            a2a3_grid_payload::RemotePtr<__gm__ uint32_t>(pipe.runtimeCtx, pipe.freeFlags[dirIdx], peerRank);
+            a2a3_grid_payload::RemoteCounterPtr(pipe.runtimeCtx, pipe.freeFlags[dirIdx], peerRank);
         NeighborCounterOperand freeCounter{peerFree};
 #endif
-        mtspr_neighbor_counter(freeCounter, NeighborCounterKind::Free, dirIdx, idx + 1);
+        mtspr_neighbor_counter(NeighborCounterKind::Free, dirIdx, idx + 1, freeCounter);
     }
 
     // Step 5: bump local consumer index.

--- a/include/pto/npu/a2a3/GridTPop.hpp
+++ b/include/pto/npu/a2a3/GridTPop.hpp
@@ -1,0 +1,92 @@
+/**
+Copyright (c) 2026 Huawei Technologies Co., Ltd.
+This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+CANN Open Software License Agreement Version 2.0 (the "License").
+Please refer to the License for details. You may not use this file except in compliance with the License.
+THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+See LICENSE in the root of the software repository for the full text of the License.
+*/
+
+// A2/A3 backend for GridPipe TPOP<Direction>.  Mirrors GridTPush.hpp.
+// See design doc section 5.3 consumer expansion template.
+
+#ifndef PTO_A2A3_GRID_TPOP_HPP
+#define PTO_A2A3_GRID_TPOP_HPP
+
+#include <cstdint>
+
+#include <pto/common/grid_counter_intrinsic.hpp>
+#include <pto/common/grid_pipe.hpp>
+#include <pto/common/grid_pipe_mock_spr.hpp>
+#include <pto/npu/a2a3/GridTPush.hpp> // for a2a3_grid_payload hooks
+#include <pto/npu/a2a3/grid_pipe_runtime.hpp>
+
+namespace pto {
+
+template <pto::GridDirection Dir, typename Pipe, typename TileCons>
+AICORE bool GRID_TRY_TPOP_IMPL(Pipe &pipe, TileCons &tile, uint32_t maxSpins = grid_mock::kDefaultWfeMaxSpins)
+{
+    constexpr int dirIdx = GridDirectionIndex(Dir);
+
+    // SOURCE TPOP is always legal (CanPop returns true); other directions
+    // require the appropriate neighbor to exist.
+    if (!CanPop(Dir, pipe.coord, pipe.shape)) {
+        grid_mock::MockBoundaryFault(pipe.freeFlags[dirIdx], grid_mock::PopFaultCode(Dir));
+        return false;
+    }
+
+    // Step 1: wait for ready signal from upstream.
+    //   LPU WSE: wfe SPR_RDY_<DIR>, r_idx + 1
+    const uint32_t expectedReady = pipe.consIndex[dirIdx] + 1;
+#if defined(PTO_GRID_COUNTER_NATIVE_INTRINSIC)
+    NeighborCounterOperand readyCounter{};
+#else
+    NeighborCounterOperand readyCounter{pipe.readyFlags[dirIdx]};
+#endif
+    if (!wfe_neighbor_counter(readyCounter, NeighborCounterKind::Ready, dirIdx, expectedReady, maxSpins)) {
+        grid_mock::MockSetFault(pipe.readyFlags[dirIdx] + grid_mock::kFaultFlagWordOffset,
+                                grid_mock::kFaultWaitReadyTimeout);
+        return false;
+    }
+
+    // Step 2: compute slot address (local; producer wrote it here).
+    const uint32_t idx = pipe.consIndex[dirIdx];
+    const uint32_t slotOff = (idx % Pipe::SlotCount) * Pipe::SlotBytes;
+    __gm__ uint8_t *localSlot = pipe.slotBase[dirIdx] + slotOff;
+
+    // Step 3: payload transfer from local slot to consumer tile buffer.
+    //   LPU WSE: tmov tile_buf, [r_slot]
+    a2a3_grid_payload::CopyGmSlotToTile<TileCons>(tile, localSlot, Pipe::SlotBytes);
+
+    // Step 4: notify upstream producer that slot is free.
+    //   LPU WSE: mtspr SPR_FREE_<DIR>, r_idx + 1
+    //
+    // SOURCE has no upstream rank (it's the launcher); host runtime handles
+    // free counters out-of-band.  Skip the cross-rank write for SOURCE.
+    if constexpr (Dir != GridDirection::SOURCE) {
+#if defined(PTO_GRID_COUNTER_NATIVE_INTRINSIC)
+        NeighborCounterOperand freeCounter{};
+#else
+        const int peerRank = NeighborRankForPop(Dir, pipe.coord, pipe.shape);
+        __gm__ uint32_t *peerFree =
+            a2a3_grid_payload::RemotePtr<__gm__ uint32_t>(pipe.runtimeCtx, pipe.freeFlags[dirIdx], peerRank);
+        NeighborCounterOperand freeCounter{peerFree};
+#endif
+        mtspr_neighbor_counter(freeCounter, NeighborCounterKind::Free, dirIdx, idx + 1);
+    }
+
+    // Step 5: bump local consumer index.
+    pipe.consIndex[dirIdx] = idx + 1;
+    return true;
+}
+
+template <pto::GridDirection Dir, typename Pipe, typename TileCons>
+AICORE void GRID_TPOP_IMPL(Pipe &pipe, TileCons &tile)
+{
+    (void)GRID_TRY_TPOP_IMPL<Dir, Pipe, TileCons>(pipe, tile, 0);
+}
+
+} // namespace pto
+
+#endif // PTO_A2A3_GRID_TPOP_HPP

--- a/include/pto/npu/a2a3/GridTPush.hpp
+++ b/include/pto/npu/a2a3/GridTPush.hpp
@@ -1,0 +1,146 @@
+/**
+Copyright (c) 2026 Huawei Technologies Co., Ltd.
+This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+CANN Open Software License Agreement Version 2.0 (the "License").
+Please refer to the License for details. You may not use this file except in compliance with the License.
+THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+See LICENSE in the root of the software repository for the full text of the License.
+*/
+
+// A2/A3 backend for GridPipe TPUSH<Direction>.
+//
+// Implements design doc section 5.3 producer expansion template using:
+//   - wfe_neighbor_counter / mtspr_neighbor_counter for free/ready counters
+//   - HcclRemotePtr                  (resolve neighbor rank's GM window)
+//   - TSTORE / TLOAD                 (existing A2/A3 tile <-> GM movers)
+//
+// payload transfer (GRID_PAYLOAD_STORE_IMPL) is intentionally pluggable: the
+// general type-erased copy is provided here for byte-aligned tiles, and
+// specialised tile copies live alongside the demo kernel.
+
+#ifndef PTO_A2A3_GRID_TPUSH_HPP
+#define PTO_A2A3_GRID_TPUSH_HPP
+
+#include <cstdint>
+
+#include <pto/common/grid_counter_intrinsic.hpp>
+#include <pto/common/grid_pipe.hpp>
+#include <pto/common/grid_pipe_mock_spr.hpp>
+#include <pto/npu/a2a3/grid_pipe_runtime.hpp>
+
+// Forward declaration: provided by demo's gridpipe_runtime adaptor.
+// At the demo level we inject a concrete implementation that knows how to
+// move a specific tile type to/from a GM slot via TSTORE/TLOAD.  Keeping the
+// hook out-of-line avoids tying GridPipe to a specific tile shape.
+namespace pto {
+namespace a2a3_grid_payload {
+
+template <typename TileT>
+AICORE void CopyTileToGmSlot(__gm__ uint8_t *remoteSlot, TileT &tile, int slotBytes);
+
+template <typename TileT>
+AICORE void CopyGmSlotToTile(TileT &tile, __gm__ uint8_t *localSlot, int slotBytes);
+
+// Resolve a pointer in our local GM window to the same field in `peerRank`'s
+// window.  Implemented in the demo's gridpipe_runtime adaptor on top of
+// HcclRemotePtr.
+template <typename PtrT>
+AICORE PtrT *RemotePtr(__gm__ void *runtimeCtx, PtrT *localPtr, int peerRank);
+
+} // namespace a2a3_grid_payload
+} // namespace pto
+
+namespace pto {
+
+// SOURCE direction is illegal as a TPUSH target (design doc 4.3).  Provide an
+// undefined primary template so attempts to instantiate it fail at link time
+// with a clear symbol name; the static_assert in pto_instr.hpp catches this
+// earlier at compile time.
+template <pto::GridDirection Dir, typename Pipe, typename TileProd>
+AICORE bool GRID_TRY_TPUSH_IMPL(Pipe &pipe, TileProd &tile, uint32_t maxSpins = grid_mock::kDefaultWfeMaxSpins)
+{
+    static_assert(Dir != GridDirection::SOURCE, "GridPipe TPUSH<SOURCE> is illegal (design doc 4.3)");
+
+    constexpr int dirIdx = GridDirectionIndex(Dir);
+
+    // Boundary check (design doc 2.3 + 5.4).  In production builds the
+    // compiler folds CanPush() against constexpr coord; here we keep the
+    // runtime check so dynamic coordinates still trap.
+    if (!CanPush(Dir, pipe.coord, pipe.shape)) {
+        grid_mock::MockBoundaryFault(pipe.readyFlags[dirIdx], grid_mock::PushFaultCode(Dir));
+        return false;
+    }
+
+    // Step 1: wait for a free slot.
+    //   LPU WSE: wfe SPR_FREE_<DIR>, r_idx + 1
+    const uint32_t expectedFree = pipe.prodIndex[dirIdx] + 1;
+    if (pipe.prodIndex[dirIdx] >= static_cast<uint32_t>(Pipe::SlotCount)) {
+#if defined(PTO_GRID_COUNTER_NATIVE_INTRINSIC)
+        NeighborCounterOperand freeCounter{};
+#else
+        NeighborCounterOperand freeCounter{pipe.freeFlags[dirIdx]};
+#endif
+        if (!wfe_neighbor_counter(freeCounter, NeighborCounterKind::Free, dirIdx, expectedFree - Pipe::SlotCount,
+                                  maxSpins)) {
+            grid_mock::MockSetFault(pipe.freeFlags[dirIdx] + grid_mock::kFaultFlagWordOffset,
+                                    grid_mock::kFaultWaitFreeTimeout);
+            return false;
+        }
+    }
+
+    // Step 2: compute slot address.
+    //   LPU WSE: mfspr r_idx, SPR_PROD_IDX_<DIR>
+    //            mfspr r_base, SPR_SLOT_BASE_<DIR>
+    //            and / mla -> r_slot
+    const uint32_t idx = pipe.prodIndex[dirIdx];
+    const uint32_t slotOff = (idx % Pipe::SlotCount) * Pipe::SlotBytes;
+    __gm__ uint8_t *localSlot = pipe.slotBase[dirIdx] + slotOff;
+
+    // Step 3: payload transfer to *neighbor's* slot region.
+    //   LPU WSE: tmov [r_slot], tile_buf   (slot is neighbor-mapped)
+    const int peerRank = NeighborRankForPush(Dir, pipe.coord, pipe.shape);
+    __gm__ uint8_t *remoteSlot = a2a3_grid_payload::RemotePtr<__gm__ uint8_t>(pipe.runtimeCtx, localSlot, peerRank);
+    a2a3_grid_payload::CopyTileToGmSlot<TileProd>(remoteSlot, tile, Pipe::SlotBytes);
+
+    // Publish fence (D-5).  Required between the slot TSTORE (MTE3, into peer
+    // window via HcclRemotePtr) and the cross-rank ready flag write below.
+    // Mirrors allgather_gemm's TPUT-loop -> `pipe_barrier(PIPE_ALL); dsb(DSB_DDR);`
+    // -> SetRemoteChunkFlagReady ordering (see
+    // kernels/manual/a2a3/allgather_gemm/allgather_gemm_comm_kernel.cpp:146).
+    // Without this the scalar-pipe flag store can become visible on the peer
+    // before the MTE3 slot bytes commit to DDR, causing the consumer's TLOAD to
+    // pick up pre-publish (zero) data.  Earlier attempts to place the fence
+    // inside the payload hook were inconclusive; doing it here keeps it on the
+    // canonical GridPipe expansion path and out of demo-specific code.
+#ifndef __PTO_AUTO__
+    pipe_barrier(PIPE_ALL);
+#endif
+    dsb(DSB_DDR);
+
+    // Step 4: trigger neighbor's ready flag.
+    //   LPU WSE: mtspr SPR_RDY_<DIR>, r_idx + 1   (cross-core SPR write)
+#if defined(PTO_GRID_COUNTER_NATIVE_INTRINSIC)
+    NeighborCounterOperand readyCounter{};
+#else
+    __gm__ uint32_t *neighborReady =
+        a2a3_grid_payload::RemotePtr<__gm__ uint32_t>(pipe.runtimeCtx, pipe.readyFlags[dirIdx], peerRank);
+    NeighborCounterOperand readyCounter{neighborReady};
+#endif
+    mtspr_neighbor_counter(readyCounter, NeighborCounterKind::Ready, dirIdx, idx + 1);
+
+    // Step 5: bump local producer index.
+    //   LPU WSE: mtspr SPR_PROD_IDX_<DIR>, r_idx + 1
+    pipe.prodIndex[dirIdx] = idx + 1;
+    return true;
+}
+
+template <pto::GridDirection Dir, typename Pipe, typename TileProd>
+AICORE void GRID_TPUSH_IMPL(Pipe &pipe, TileProd &tile)
+{
+    (void)GRID_TRY_TPUSH_IMPL<Dir, Pipe, TileProd>(pipe, tile, 0);
+}
+
+} // namespace pto
+
+#endif // PTO_A2A3_GRID_TPUSH_HPP

--- a/include/pto/npu/a2a3/GridTPush.hpp
+++ b/include/pto/npu/a2a3/GridTPush.hpp
@@ -10,10 +10,10 @@ See LICENSE in the root of the software repository for the full text of the Lice
 
 // A2/A3 backend for GridPipe TPUSH<Direction>.
 //
-// Implements design doc section 5.3 producer expansion template using:
+// Producer-side expansion uses:
 //   - wfe_neighbor_counter / mtspr_neighbor_counter for free/ready counters
-//   - HcclRemotePtr                  (resolve neighbor rank's GM window)
-//   - TSTORE / TLOAD                 (existing A2/A3 tile <-> GM movers)
+//   - get_neighbor_ubuf_addr         (resolve neighbor rank's Vector UB slot)
+//   - TSTORE / TLOAD                 (mock tile <-> fake-window movers)
 //
 // payload transfer (GRID_PAYLOAD_STORE_IMPL) is intentionally pluggable: the
 // general type-erased copy is provided here for byte-aligned tiles, and
@@ -27,33 +27,33 @@ See LICENSE in the root of the software repository for the full text of the Lice
 #include <pto/common/grid_counter_intrinsic.hpp>
 #include <pto/common/grid_pipe.hpp>
 #include <pto/common/grid_pipe_mock_spr.hpp>
+#include <pto/common/grid_sram_intrinsic.hpp>
 #include <pto/npu/a2a3/grid_pipe_runtime.hpp>
 
 // Forward declaration: provided by demo's gridpipe_runtime adaptor.
 // At the demo level we inject a concrete implementation that knows how to
-// move a specific tile type to/from a GM slot via TSTORE/TLOAD.  Keeping the
-// hook out-of-line avoids tying GridPipe to a specific tile shape.
+// move a specific tile type to/from a mock SRAM slot via TSTORE/TLOAD. Keeping
+// the hook out-of-line avoids tying GridPipe to a specific tile shape.
 namespace pto {
 namespace a2a3_grid_payload {
 
 template <typename TileT>
-AICORE void CopyTileToGmSlot(__gm__ uint8_t *remoteSlot, TileT &tile, int slotBytes);
+__tf__ AICORE void CopyTileToNeighborUbufSlot(neighbor_ubuf_addr remoteSlot, TileT &tile, int slotBytes);
 
 template <typename TileT>
-AICORE void CopyGmSlotToTile(TileT &tile, __gm__ uint8_t *localSlot, int slotBytes);
+__tf__ AICORE void CopyNeighborUbufSlotToTile(TileT &tile, neighbor_ubuf_addr localSlot, int slotBytes);
 
-// Resolve a pointer in our local GM window to the same field in `peerRank`'s
-// window.  Implemented in the demo's gridpipe_runtime adaptor on top of
-// HcclRemotePtr.
-template <typename PtrT>
-AICORE PtrT *RemotePtr(__gm__ void *runtimeCtx, PtrT *localPtr, int peerRank);
+AICORE neighbor_sram_addr LocalSramAddr(__gm__ uint8_t *localSlot);
+AICORE neighbor_ubuf_addr LocalUbufAddr(__gm__ uint8_t *localSlot);
+
+AICORE __gm__ uint32_t *RemoteCounterPtr(__gm__ void *runtimeCtx, __gm__ uint32_t *localCounter, int peerRank);
 
 } // namespace a2a3_grid_payload
 } // namespace pto
 
 namespace pto {
 
-// SOURCE direction is illegal as a TPUSH target (design doc 4.3).  Provide an
+// SOURCE direction is illegal as a TPUSH target.  Provide an
 // undefined primary template so attempts to instantiate it fail at link time
 // with a clear symbol name; the static_assert in pto_instr.hpp catches this
 // earlier at compile time.
@@ -64,9 +64,9 @@ AICORE bool GRID_TRY_TPUSH_IMPL(Pipe &pipe, TileProd &tile, uint32_t maxSpins = 
 
     constexpr int dirIdx = GridDirectionIndex(Dir);
 
-    // Boundary check (design doc 2.3 + 5.4).  In production builds the
-    // compiler folds CanPush() against constexpr coord; here we keep the
-    // runtime check so dynamic coordinates still trap.
+    // Boundary check. In production builds the compiler folds CanPush() against
+    // constexpr coord; here we keep the runtime check so dynamic coordinates
+    // still trap.
     if (!CanPush(Dir, pipe.coord, pipe.shape)) {
         grid_mock::MockBoundaryFault(pipe.readyFlags[dirIdx], grid_mock::PushFaultCode(Dir));
         return false;
@@ -81,7 +81,7 @@ AICORE bool GRID_TRY_TPUSH_IMPL(Pipe &pipe, TileProd &tile, uint32_t maxSpins = 
 #else
         NeighborCounterOperand freeCounter{pipe.freeFlags[dirIdx]};
 #endif
-        if (!wfe_neighbor_counter(freeCounter, NeighborCounterKind::Free, dirIdx, expectedFree - Pipe::SlotCount,
+        if (!wfe_neighbor_counter(NeighborCounterKind::Free, dirIdx, expectedFree - Pipe::SlotCount, freeCounter,
                                   maxSpins)) {
             grid_mock::MockSetFault(pipe.freeFlags[dirIdx] + grid_mock::kFaultFlagWordOffset,
                                     grid_mock::kFaultWaitFreeTimeout);
@@ -89,22 +89,28 @@ AICORE bool GRID_TRY_TPUSH_IMPL(Pipe &pipe, TileProd &tile, uint32_t maxSpins = 
         }
     }
 
-    // Step 2: compute slot address.
+    // Step 2: compute local SRAM slot address.
     //   LPU WSE: mfspr r_idx, SPR_PROD_IDX_<DIR>
     //            mfspr r_base, SPR_SLOT_BASE_<DIR>
     //            and / mla -> r_slot
     const uint32_t idx = pipe.prodIndex[dirIdx];
     const uint32_t slotOff = (idx % Pipe::SlotCount) * Pipe::SlotBytes;
     __gm__ uint8_t *localSlot = pipe.slotBase[dirIdx] + slotOff;
+    neighbor_sram_addr localSramSlot = a2a3_grid_payload::LocalSramAddr(localSlot);
 
-    // Step 3: payload transfer to *neighbor's* slot region.
+    // Step 3: payload transfer to *neighbor's* SRAM slot region.
     //   LPU WSE: tmov [r_slot], tile_buf   (slot is neighbor-mapped)
     const int peerRank = NeighborRankForPush(Dir, pipe.coord, pipe.shape);
-    __gm__ uint8_t *remoteSlot = a2a3_grid_payload::RemotePtr<__gm__ uint8_t>(pipe.runtimeCtx, localSlot, peerRank);
-    a2a3_grid_payload::CopyTileToGmSlot<TileProd>(remoteSlot, tile, Pipe::SlotBytes);
+    neighbor_ubuf_addr remoteUbufSlot{};
+    NeighborSramOperand sramOperand{pipe.runtimeCtx};
+    get_neighbor_ubuf_addr(remoteUbufSlot, localSramSlot, dirIdx, peerRank, sramOperand);
+    // Adapter keeps TPUSH independent of Tile internals; it immediately calls
+    // copy_ubuf_to_neighbor_ubuf(...) after extracting the tile's UB pointer.
+    a2a3_grid_payload::CopyTileToNeighborUbufSlot<TileProd>(remoteUbufSlot, tile, Pipe::SlotBytes);
 
-    // Publish fence (D-5).  Required between the slot TSTORE (MTE3, into peer
-    // window via HcclRemotePtr) and the cross-rank ready flag write below.
+    // Publish fence (D-5). Required between the slot TSTORE (MTE3, into peer
+    // SRAM window via the mock address adapter) and the cross-rank ready flag
+    // write below.
     // Mirrors allgather_gemm's TPUT-loop -> `pipe_barrier(PIPE_ALL); dsb(DSB_DDR);`
     // -> SetRemoteChunkFlagReady ordering (see
     // kernels/manual/a2a3/allgather_gemm/allgather_gemm_comm_kernel.cpp:146).
@@ -124,10 +130,10 @@ AICORE bool GRID_TRY_TPUSH_IMPL(Pipe &pipe, TileProd &tile, uint32_t maxSpins = 
     NeighborCounterOperand readyCounter{};
 #else
     __gm__ uint32_t *neighborReady =
-        a2a3_grid_payload::RemotePtr<__gm__ uint32_t>(pipe.runtimeCtx, pipe.readyFlags[dirIdx], peerRank);
+        a2a3_grid_payload::RemoteCounterPtr(pipe.runtimeCtx, pipe.readyFlags[dirIdx], peerRank);
     NeighborCounterOperand readyCounter{neighborReady};
 #endif
-    mtspr_neighbor_counter(readyCounter, NeighborCounterKind::Ready, dirIdx, idx + 1);
+    mtspr_neighbor_counter(NeighborCounterKind::Ready, dirIdx, idx + 1, readyCounter);
 
     // Step 5: bump local producer index.
     //   LPU WSE: mtspr SPR_PROD_IDX_<DIR>, r_idx + 1

--- a/include/pto/npu/a2a3/grid_pipe_runtime.hpp
+++ b/include/pto/npu/a2a3/grid_pipe_runtime.hpp
@@ -1,0 +1,101 @@
+/**
+Copyright (c) 2026 Huawei Technologies Co., Ltd.
+This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+CANN Open Software License Agreement Version 2.0 (the "License").
+Please refer to the License for details. You may not use this file except in compliance with the License.
+THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+See LICENSE in the root of the software repository for the full text of the License.
+*/
+
+// A2/A3 GridPipe runtime helpers: shmem window layout, init helpers, neighbor
+// rank resolution.  See design doc section 5 and the mock SPR lowering in
+// include/pto/common/grid_pipe_mock_spr.hpp.
+
+#ifndef PTO_A2A3_GRID_PIPE_RUNTIME_HPP
+#define PTO_A2A3_GRID_PIPE_RUNTIME_HPP
+
+#include <cstdint>
+
+#include <pto/common/grid_pipe.hpp>
+
+namespace pto {
+namespace a2a3_grid {
+
+// shmem window layout (per rank), in bytes:
+//
+//   offset                                         contents
+//   ----------------------------------------------------------------------
+//   0                                              ready flags [4 dirs] u32
+//   16                                             free  flags [4 dirs] u32
+//   32                                             reserved (alignment, telemetry)
+//   kSlotRegionOffset                              slot region for all 4 dirs
+//     + dir * SlotCount * SlotBytes                slot ring for that direction
+//
+// The slot region is sized to (kGridDirectionCount * SlotCount * SlotBytes).
+// Aligned to 512 bytes for A2/A3 GM access requirements.
+inline constexpr uint32_t kFlagsBytes = 64; // 4 ready + 4 free + reserved
+inline constexpr uint32_t kSlotRegionOffset = kFlagsBytes;
+
+inline constexpr uint32_t kReadyFlagOffset(GridDirection d)
+{
+    return static_cast<uint32_t>(d) * sizeof(uint32_t);
+}
+
+inline constexpr uint32_t kFreeFlagOffset(GridDirection d)
+{
+    return 4 * sizeof(uint32_t) + static_cast<uint32_t>(d) * sizeof(uint32_t);
+}
+
+template <int SlotBytes, int SlotCount>
+inline constexpr uint32_t kSlotRegionBytes()
+{
+    return kGridDirectionCount * SlotCount * SlotBytes;
+}
+
+template <int SlotBytes, int SlotCount>
+inline constexpr uint32_t kWindowBytes()
+{
+    return kSlotRegionOffset + kSlotRegionBytes<SlotBytes, SlotCount>();
+}
+
+template <int SlotBytes, int SlotCount>
+inline constexpr uint32_t kDirSlotRegionOffset(GridDirection d)
+{
+    return kSlotRegionOffset + static_cast<uint32_t>(d) * SlotCount * SlotBytes;
+}
+
+// Wire up a GridPipe instance from a flat GM window owned by this rank.
+// The host launcher allocates kWindowBytes() bytes per rank, then calls this
+// in the kernel prologue.  `runtimeCtx` is the HCCL device context handle used
+// later by GridTPush/GridTPop to resolve cross-rank addresses.
+template <typename Pipe>
+AICORE inline void InitGridPipeFromWindow(Pipe &pipe, GridShape shape, GridCoord coord, __gm__ uint8_t *window,
+                                          __gm__ void *runtimeCtx, uint32_t pipeId)
+{
+    pipe.shape = shape;
+    pipe.coord = coord;
+    pipe.runtimeCtx = runtimeCtx;
+    pipe.pipeId = pipeId;
+
+    __gm__ uint32_t *flags = reinterpret_cast<__gm__ uint32_t *>(window);
+    for (int i = 0; i < kGridDirectionCount; ++i) {
+        pipe.readyFlags[i] = flags + i;
+        pipe.freeFlags[i] = flags + 4 + i;
+        pipe.slotBase[i] = window + kSlotRegionOffset + i * Pipe::SlotCount * Pipe::SlotBytes;
+        pipe.prodIndex[i] = 0;
+        pipe.consIndex[i] = 0;
+    }
+}
+
+// Host-side helper: total bytes per rank for a single GridPipe.
+template <typename Pipe>
+inline constexpr uint32_t WindowBytes()
+{
+    return kWindowBytes<Pipe::SlotBytes, Pipe::SlotCount>();
+}
+
+} // namespace a2a3_grid
+} // namespace pto
+
+#endif // PTO_A2A3_GRID_PIPE_RUNTIME_HPP

--- a/kernels/manual/a2a3/distributed_ffn_grid/CMakeLists.txt
+++ b/kernels/manual/a2a3/distributed_ffn_grid/CMakeLists.txt
@@ -1,0 +1,152 @@
+# --------------------------------------------------------------------------------
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# --------------------------------------------------------------------------------
+
+cmake_minimum_required(VERSION 3.16)
+
+set(CMAKE_COMPILER bisheng)
+set(CMAKE_C_COMPILER ${CMAKE_COMPILER})
+set(CMAKE_CXX_COMPILER ${CMAKE_COMPILER})
+
+project(distributed_ffn_grid_demo)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+
+if(NOT DEFINED ENV{ASCEND_HOME_PATH})
+    message(FATAL_ERROR "Cannot find ASCEND_HOME_PATH, please run set_env.sh.")
+else()
+    set(ASCEND_HOME_PATH $ENV{ASCEND_HOME_PATH})
+endif()
+
+if(DEFINED ENV{ASCEND_DRIVER_PATH})
+    set(ASCEND_DRIVER_PATH $ENV{ASCEND_DRIVER_PATH})
+else()
+    set(ASCEND_DRIVER_PATH /usr/local/Ascend/driver)
+endif()
+
+# =============================================================================
+# Grid + tile dimensions (override via -DGRID_ROWS=... etc).
+# =============================================================================
+if(NOT DEFINED GRID_ROWS)
+    set(GRID_ROWS 2)
+endif()
+if(NOT DEFINED GRID_COLS)
+    set(GRID_COLS 2)
+endif()
+if(NOT DEFINED TOKEN_TILE)
+    set(TOKEN_TILE 16)
+endif()
+if(NOT DEFINED MODEL_TILE)
+    set(MODEL_TILE 64)
+endif()
+if(NOT DEFINED FFN_TILE)
+    set(FFN_TILE 64)
+endif()
+
+message(STATUS "Grid: ${GRID_ROWS}x${GRID_COLS}  Tile: ${TOKEN_TILE}x${MODEL_TILE}  FfnTile: ${FFN_TILE}")
+
+add_compile_options(
+    -D_FORTIFY_SOURCE=2
+    -O2 -std=c++17
+    -Wno-macro-redefined -Wno-ignored-attributes
+    -fstack-protector-strong
+)
+
+add_link_options(-s -Wl,-z,relro -Wl,-z,now)
+
+set(CMAKE_CCE_COMPILE_OPTIONS
+    -xcce
+    -Xhost-start -Xhost-end
+    "SHELL:-mllvm -cce-aicore-stack-size=0x8000"
+    "SHELL:-mllvm -cce-aicore-function-stack-size=0x8000"
+    "SHELL:-mllvm -cce-aicore-record-overflow=true"
+    "SHELL:-mllvm -cce-aicore-addr-transform"
+    "SHELL:-mllvm -cce-aicore-dcci-insert-for-scalar=false"
+)
+
+set(CMAKE_CPP_COMPILE_OPTIONS
+    -xc++
+    "SHELL:-include stdint.h"
+    "SHELL:-include stddef.h"
+)
+
+include_directories(
+    ${PROJECT_SOURCE_DIR}/../../../../include
+    ${ASCEND_HOME_PATH}/include
+    ${ASCEND_DRIVER_PATH}/kernel/inc
+)
+
+# =============================================================================
+# 1. Mixed Cube/Vec Kernel.  Cube and Vec branches run concurrently and use
+#    regular A2/A3 TPipe synchronization for intermediate FFN tiles.
+# =============================================================================
+add_library(distributed_ffn_grid_mixed_kernel SHARED distributed_ffn_grid_compute_kernel.cpp)
+target_compile_options(distributed_ffn_grid_mixed_kernel PRIVATE
+    ${CMAKE_CCE_COMPILE_OPTIONS}
+    --cce-aicore-arch=dav-c220
+    -DMEMORY_BASE -std=c++17
+    -DCONFIG_GRID_ROWS=${GRID_ROWS} -DCONFIG_GRID_COLS=${GRID_COLS}
+    -DCONFIG_TOKEN_TILE=${TOKEN_TILE} -DCONFIG_MODEL_TILE=${MODEL_TILE}
+    -DCONFIG_FFN_TILE=${FFN_TILE}
+)
+target_include_directories(distributed_ffn_grid_mixed_kernel PRIVATE
+    ${PROJECT_SOURCE_DIR}/../../../../include/
+    ${PROJECT_SOURCE_DIR}/../../../../tests/npu/a2a3/comm/st/testcase/
+    $ENV{ASCEND_HOME_PATH}/aarch64-linux/asc
+    $ENV{ASCEND_HOME_PATH}/aarch64-linux/asc/include
+    $ENV{ASCEND_HOME_PATH}/aarch64-linux/ascendc/include/basic_api
+    $ENV{ASCEND_HOME_PATH}/aarch64-linux/include/ascendc/basic_api
+    $ENV{ASCEND_HOME_PATH}/aarch64-linux/asc/impl/basic_api
+    $ENV{ASCEND_HOME_PATH}/aarch64-linux/ascendc/include/basic_api/impl
+    $ENV{ASCEND_HOME_PATH}/aarch64-linux/asc/include/interface
+    $ENV{ASCEND_HOME_PATH}/aarch64-linux/asc/include/utils
+)
+target_link_directories(distributed_ffn_grid_mixed_kernel PRIVATE ${ASCEND_HOME_PATH}/lib64)
+target_link_libraries(distributed_ffn_grid_mixed_kernel PRIVATE hcomm runtime nnopbase)
+target_link_options(distributed_ffn_grid_mixed_kernel PRIVATE --cce-fatobj-link)
+
+# =============================================================================
+# 2. Host driver executable
+# =============================================================================
+add_executable(distributed_ffn_grid main.cpp)
+target_compile_options(distributed_ffn_grid PRIVATE ${CMAKE_CPP_COMPILE_OPTIONS})
+target_include_directories(distributed_ffn_grid PRIVATE
+    ${PROJECT_SOURCE_DIR}/../../../../include/
+    ${PROJECT_SOURCE_DIR}/../../../../tests/common
+    ${PROJECT_SOURCE_DIR}/../../../../tests/npu/a2a3/comm/st/testcase/
+    ${ASCEND_HOME_PATH}/pkg_inc/runtime
+    ${ASCEND_HOME_PATH}/pkg_inc/toolchain
+    ${ASCEND_HOME_PATH}/pkg_inc/profiling
+    ${ASCEND_HOME_PATH}/aarch64-linux/pkg_inc/runtime
+    ${ASCEND_HOME_PATH}/aarch64-linux/pkg_inc
+    ${ASCEND_HOME_PATH}/aarch64-linux/pkg_inc/profiling
+)
+target_compile_definitions(distributed_ffn_grid PRIVATE
+    CONFIG_GRID_ROWS=${GRID_ROWS} CONFIG_GRID_COLS=${GRID_COLS}
+    CONFIG_TOKEN_TILE=${TOKEN_TILE} CONFIG_MODEL_TILE=${MODEL_TILE}
+    CONFIG_FFN_TILE=${FFN_TILE}
+)
+
+target_link_directories(distributed_ffn_grid PUBLIC
+    ${ASCEND_HOME_PATH}/lib64
+    ${ASCEND_HOME_PATH}/simulator/${SOC_VERSION}/lib
+    ${ASCEND_HOME_PATH}/tools/simulator/${SOC_VERSION}/lib
+)
+
+target_link_libraries(distributed_ffn_grid PRIVATE
+    distributed_ffn_grid_mixed_kernel
+    $<BUILD_INTERFACE:$<$<STREQUAL:${RUN_MODE},sim>:runtime_camodel>>
+    $<BUILD_INTERFACE:$<$<STREQUAL:${RUN_MODE},npu>:runtime>>
+    stdc++ ascendcl hcomm m tiling_api platform c_sec dl nnopbase pthread
+)

--- a/kernels/manual/a2a3/distributed_ffn_grid/README.md
+++ b/kernels/manual/a2a3/distributed_ffn_grid/README.md
@@ -1,0 +1,135 @@
+# Single-device Multi-block FFN GridPipe Demo
+
+## Goal
+
+`distributed_ffn_grid` validates a single-device logical FFN grid on A2/A3. The host runs one process on device 0 and launches `gridRows * gridCols` blocks. Each block owns one logical cell:
+
+- Rows are data-parallel token slices.
+- Columns are model-parallel FFN intermediate shards.
+- The mixed Cube/Vec kernel computes gate/up, activation, down projection, and row-local `EAST` reduce in one launch.
+- The last column in each row writes the final fp32 `[T, H]` output tile, which the host compares with `golden.bin` using `1e-3` tolerance.
+
+The `EAST` reduce uses the A2/A3 GridPipe mock backend: local GM windows, fake `HcclDeviceContext` window pointers, ready/free counters, `dcci/dsb` fences, and spin waits. This validates the programming model and same-device mock path; it is not multi-card communication validation.
+
+## Files
+
+| File | Purpose |
+| --- | --- |
+| `README.md` / `README_zh.md` | English / Chinese documentation. |
+| `CMakeLists.txt` | Builds the host executable and the mixed Cube/Vec device kernel shared library. |
+| `run.sh` | Sets up CANN, generates data, configures CMake, builds, and runs the single-process demo. |
+| `ffn_config.hpp` | Compile-time grid shape, tile shape, GridPipe window sizes, buffer sizes, and PReLU alpha. |
+| `kernel_launch.hpp` | Host-side mixed kernel launch declaration. |
+| `main.cpp` | Host driver: ACL setup, fake HCCL context/local GridPipe windows, device buffers, data loading, kernel launch, golden comparison, and cleanup. |
+| `distributed_ffn_grid_compute_kernel.cpp` | Mixed Cube/Vec kernel. Cube computes GEMMs; Vec computes activation/cast and GridPipe `EAST` reduce. |
+| `gridpipe_payload_inl.hpp` | Local GridPipe payload hooks and fake-window remote pointer adapter. |
+| `../../../../include/pto/common/grid_counter_intrinsic.hpp` | CCE-intrinsic-style neighbor counter API used by GridPipe ready/free waits and notifications. |
+| `scripts/gen_data.py` | Generates per-cell fp16 X/weight shards and an fp32 golden reference. |
+| `build/` | Ignored generated build directory. |
+| `out/` | Ignored generated data directory. |
+
+## Execution Flow
+
+1. `run.sh` parses arguments. Defaults are `gridRows=2`, `gridCols=2`, `T=16`, `H=64`, `Fi=64`, and `n-ranks=1`.
+2. Unless `--build-only` is set, `scripts/gen_data.py` generates per-cell input and weight files plus `golden.bin`.
+3. CMake builds two targets:
+   - `distributed_ffn_grid_mixed_kernel`: `dav-c220` mixed Cube/Vec.
+   - `distributed_ffn_grid`: host executable.
+4. The host initializes ACL on device 0 and allocates all per-cell device buffers.
+5. The host allocates one local GridPipe GM window per cell and builds a fake `HcclDeviceContext` where `windowsIn[cell]` points into that contiguous allocation.
+6. The host loads X and weights into row-major per-cell buffers.
+7. The host obtains the FFTS base address with `rtGetC2cCtrlAddr()` and launches `DistributedFfnGridMixedKernel` once with `gridRows * gridCols` blocks.
+8. Inside each block, Cube and Vec branches exchange intermediate tiles through A2/A3 `TPipe` FIFOs:
+
+```text
+Cube:
+  X[row] @ W_gate[col] -> gatePartial[row,col] --TPipe C2V-->
+  X[row] @ W_up[col]   -> upPartial[row,col]   --TPipe C2V-->
+
+Vec:
+  hidden[row,col] = fp16(PReLU(gatePartial) * upPartial)
+  hidden[row,col] --TPipe V2C-->
+
+Cube:
+  hidden[row,col] @ W_down[col] -> downPartial[row,col] --TPipe C2V-->
+
+Vec:
+  downPartial --GridPipe EAST reduce across cols--> yOutput[row] on final col
+```
+
+9. The host synchronizes the stream, checks GridPipe fault flags, copies `yOutput` back, and compares it with `golden.bin`.
+
+## Key Designs
+
+### Mixed Cube/Vec launch
+
+The device kernel is compiled for `dav-c220`. Cube and Vec code paths are guarded by `__DAV_CUBE__` and `__DAV_VEC__`, so both sides live in one kernel source and synchronize through regular A2/A3 `TPipe` ready/free handshakes.
+
+### Single-device logical grid
+
+`get_block_idx()` is the row-major cell id:
+
+```text
+cell = get_block_idx()
+row  = cell / gridCols
+col  = cell % gridCols
+```
+
+All cells run on one device. `gridRows` controls data-parallel token tiles, and `gridCols` controls model-parallel FFN shards.
+
+### Local GridPipe mock
+
+The host allocates `gridRows * gridCols` local GM windows. `TPUSH<EAST>` writes the east neighbor's slot and ready counter through the fake HCCL window table; `TPOP<EAST>` waits on the local ready counter, loads the slot, and returns free credit to the west neighbor.
+
+The mock uses GM flag polling and cache maintenance to emulate the intended LPU WSE `SPR` / `WFE` behavior on A2/A3.
+
+### Neighbor counter intrinsic API
+
+GridPipe ready/free synchronization goes through two CCE-intrinsic-style APIs in `include/pto/common/grid_counter_intrinsic.hpp`:
+
+- `mtspr_neighbor_counter(operand, kind, dir, value)` publishes a monotonic `Ready` or `Free` counter to the neighbor-visible counter for `dir`.
+- `wfe_neighbor_counter(operand, kind, dir, threshold)` waits until the local mirror of that counter reaches `threshold`.
+
+`TPUSH<EAST>` waits on `Free` with `wfe_neighbor_counter`, writes the payload slot, then publishes `Ready` with `mtspr_neighbor_counter`. `TPOP<EAST>` waits on `Ready`, reads the payload slot, then publishes `Free` back upstream.
+
+On current A2/A3 boards, `NeighborCounterOperand::addr` points to a GM counter in the local/fake peer GridPipe window, and the APIs lower to the mock `dcci/dsb` plus spin-wait implementation. When real hardware supports neighbor SPR/WFE counters, this demo should be adapted by compiling GridPipe with `PTO_GRID_COUNTER_NATIVE_INTRINSIC` and providing the compiler builtins `__builtin_pto_mtspr_neighbor_counter` and `__builtin_pto_wfe_neighbor_counter`. In that mode the counter operand address is ignored by the API, and the host/device setup should move from fake GM ready/free counters to the hardware-provided per-neighbor counter/event registers while keeping the GridPipe `TPUSH/TPOP` call sites unchanged. Payload slot mapping may still use the backend-specific GridPipe window or native slot address mechanism, but counter publication and waiting should no longer use GM polling.
+
+### fp32 EAST reduction
+
+The reduce slot carries fp32 `[T, H]`, so `FFN_SLOT_BYTES = T * H * 4`. This keeps `downPartial`, `yOutput`, and `golden.bin` in fp32 for direct tolerance-based comparison.
+
+## How to Run
+
+### Build only
+
+```bash
+bash run.sh --build-only -v Ascend910B1 --grid-rows 2 --grid-cols 2
+```
+
+### Run on NPU
+
+```bash
+task-submit --device auto --run "cd $(pwd)/kernels/manual/a2a3/distributed_ffn_grid && bash run.sh -r npu -v Ascend910B1 --grid-rows 3 --grid-cols 3"
+```
+
+### Common arguments
+
+```text
+-r, --run-mode      sim or npu, default npu
+-v, --soc-version   default Ascend910B1
+-n, --n-ranks       fixed to 1
+--grid-rows         logical grid row count, default 2
+--grid-cols         logical grid column count, default 2
+--token-tile        token tile T per cell, default 16
+--model-tile        hidden dim H, default 64
+--ffn-tile          intermediate dim Fi per column, default 64
+--build-only        build only; skip data generation and execution
+```
+
+## Expected Result
+
+On success, the executable prints:
+
+```text
+[SUCCESS] Single-device multi-block FFN GridPipe PASS.
+```

--- a/kernels/manual/a2a3/distributed_ffn_grid/README.md
+++ b/kernels/manual/a2a3/distributed_ffn_grid/README.md
@@ -2,14 +2,14 @@
 
 ## Goal
 
-`distributed_ffn_grid` validates a single-device logical FFN grid on A2/A3. The host runs one process on device 0 and launches `gridRows * gridCols` blocks. Each block owns one logical cell:
+`distributed_ffn_grid` validates a single-device logical FFN grid on A2/A3. The host runs one process on the selected device and launches `gridRows * gridCols` blocks. Each block owns one logical cell:
 
 - Rows are data-parallel token slices.
 - Columns are model-parallel FFN intermediate shards.
 - The mixed Cube/Vec kernel computes gate/up, activation, down projection, and row-local `EAST` reduce in one launch.
 - The last column in each row writes the final fp32 `[T, H]` output tile, which the host compares with `golden.bin` using `1e-3` tolerance.
 
-The `EAST` reduce uses the A2/A3 GridPipe mock backend: local GM windows, fake `HcclDeviceContext` window pointers, ready/free counters, `dcci/dsb` fences, and spin waits. This validates the programming model and same-device mock path; it is not multi-card communication validation.
+The `EAST` reduce uses the A2/A3 GridPipe mock backend: local SRAM windows backed by GM in the mock, fake `HcclDeviceContext` window pointers, ready/free counters, `dcci/dsb` fences, and spin waits. This validates the programming model and same-device mock path; it is not multi-card communication validation.
 
 ## Files
 
@@ -24,6 +24,7 @@ The `EAST` reduce uses the A2/A3 GridPipe mock backend: local GM windows, fake `
 | `distributed_ffn_grid_compute_kernel.cpp` | Mixed Cube/Vec kernel. Cube computes GEMMs; Vec computes activation/cast and GridPipe `EAST` reduce. |
 | `gridpipe_payload_inl.hpp` | Local GridPipe payload hooks and fake-window remote pointer adapter. |
 | `../../../../include/pto/common/grid_counter_intrinsic.hpp` | CCE-intrinsic-style neighbor counter API used by GridPipe ready/free waits and notifications. |
+| `../../../../include/pto/common/grid_sram_intrinsic.hpp` | CCE-intrinsic-style neighbor SRAM address and payload transfer API used by GridPipe payload movement. |
 | `scripts/gen_data.py` | Generates per-cell fp16 X/weight shards and an fp32 golden reference. |
 | `build/` | Ignored generated build directory. |
 | `out/` | Ignored generated data directory. |
@@ -35,8 +36,8 @@ The `EAST` reduce uses the A2/A3 GridPipe mock backend: local GM windows, fake `
 3. CMake builds two targets:
    - `distributed_ffn_grid_mixed_kernel`: `dav-c220` mixed Cube/Vec.
    - `distributed_ffn_grid`: host executable.
-4. The host initializes ACL on device 0 and allocates all per-cell device buffers.
-5. The host allocates one local GridPipe GM window per cell and builds a fake `HcclDeviceContext` where `windowsIn[cell]` points into that contiguous allocation.
+4. The host initializes ACL on the selected device and allocates all per-cell device buffers.
+5. The host allocates one local GridPipe SRAM window per cell, backed by GM in the mock, and builds a fake `HcclDeviceContext` where `windowsIn[cell]` points into that contiguous allocation.
 6. The host loads X and weights into row-major per-cell buffers.
 7. The host obtains the FFTS base address with `rtGetC2cCtrlAddr()` and launches `DistributedFfnGridMixedKernel` once with `gridRows * gridCols` blocks.
 8. Inside each block, Cube and Vec branches exchange intermediate tiles through A2/A3 `TPipe` FIFOs:
@@ -79,20 +80,29 @@ All cells run on one device. `gridRows` controls data-parallel token tiles, and 
 
 ### Local GridPipe mock
 
-The host allocates `gridRows * gridCols` local GM windows. `TPUSH<EAST>` writes the east neighbor's slot and ready counter through the fake HCCL window table; `TPOP<EAST>` waits on the local ready counter, loads the slot, and returns free credit to the west neighbor.
+The host allocates `gridRows * gridCols` local SRAM windows, backed by GM in the mock. `TPUSH<EAST>` resolves the east neighbor's Vector UB slot with `get_neighbor_ubuf_addr`, writes the payload, then publishes the ready counter; `TPOP<EAST>` waits on the local ready counter, loads the local UB slot, and returns free credit to the west neighbor.
 
 The mock uses GM flag polling and cache maintenance to emulate the intended LPU WSE `SPR` / `WFE` behavior on A2/A3.
 
 ### Neighbor counter intrinsic API
 
-GridPipe ready/free synchronization goes through two CCE-intrinsic-style APIs in `include/pto/common/grid_counter_intrinsic.hpp`:
+GridPipe ready/free synchronization goes through two CCE-intrinsic-style APIs in `include/pto/common/grid_counter_intrinsic.hpp`. The canonical call form keeps hardware semantic operands first and the mock backend operand last:
 
-- `mtspr_neighbor_counter(operand, kind, dir, value)` publishes a monotonic `Ready` or `Free` counter to the neighbor-visible counter for `dir`.
-- `wfe_neighbor_counter(operand, kind, dir, threshold)` waits until the local mirror of that counter reaches `threshold`.
+- `mtspr_neighbor_counter(kind, dir, value, operand)` publishes a monotonic `Ready` or `Free` counter to the neighbor-visible counter for `dir`.
+- `wfe_neighbor_counter(kind, dir, threshold, operand, maxSpins)` waits until the local mirror of that counter reaches `threshold`.
+
+GridPipe payload address resolution goes through `include/pto/common/grid_sram_intrinsic.hpp`:
+
+- `get_neighbor_ubuf_addr(dst, src, dir, peerRank, operand)` / `get_neighbor_cbuf_addr(dst, src, dir, peerRank, operand)` resolve a local slot offset to a neighbor Vector UB or Cube L1/CBUF address register.
+- `copy_ubuf_to_neighbor_ubuf(dst, src, bytes, config)` / `copy_ubuf_to_neighbor_cbuf(dst, src, bytes, config)` write Vector UB payloads to a neighbor Vector UB or Cube L1 slot.
+- `copy_cbuf_to_neighbor_ubuf(dst, src, bytes, config)` / `copy_cbuf_to_neighbor_cbuf(dst, src, bytes, config)` write Cube L1 payloads to a neighbor Vector UB or Cube L1 slot.
+- `copy_neighbor_ubuf_to_ubuf(dst, src, bytes, config)` is the A2/A3 mock TPOP-side load from the local GM-backed slot into the consumer Vector UB tile; native Grid TPOP is expected to bind the local slot through hardware SRAM addressing instead.
+
+The current A2/A3 mock implements UB-source paths with MTE copies through the GM-backed fake window. CBUF-source paths use existing `copy_cbuf_to_gm` to write into the GM-backed fake window. Once native hardware provides the corresponding builtins, GridPipe call sites do not need to change.
 
 `TPUSH<EAST>` waits on `Free` with `wfe_neighbor_counter`, writes the payload slot, then publishes `Ready` with `mtspr_neighbor_counter`. `TPOP<EAST>` waits on `Ready`, reads the payload slot, then publishes `Free` back upstream.
 
-On current A2/A3 boards, `NeighborCounterOperand::addr` points to a GM counter in the local/fake peer GridPipe window, and the APIs lower to the mock `dcci/dsb` plus spin-wait implementation. When real hardware supports neighbor SPR/WFE counters, this demo should be adapted by compiling GridPipe with `PTO_GRID_COUNTER_NATIVE_INTRINSIC` and providing the compiler builtins `__builtin_pto_mtspr_neighbor_counter` and `__builtin_pto_wfe_neighbor_counter`. In that mode the counter operand address is ignored by the API, and the host/device setup should move from fake GM ready/free counters to the hardware-provided per-neighbor counter/event registers while keeping the GridPipe `TPUSH/TPOP` call sites unchanged. Payload slot mapping may still use the backend-specific GridPipe window or native slot address mechanism, but counter publication and waiting should no longer use GM polling.
+On current A2/A3 boards, `NeighborCounterOperand::addr` points to a GM-backed counter in the local/fake peer GridPipe window, and `NeighborSramOperand::runtimeCtx` points to the fake HCCL context. When real hardware supports neighbor SPR/WFE counters and neighbor SRAM address registers, this demo should be adapted by compiling GridPipe with `PTO_GRID_COUNTER_NATIVE_INTRINSIC` and `PTO_GRID_SRAM_NATIVE_INTRINSIC` and providing the compiler builtins. In that mode the mock operands are ignored, and the host/device setup should move from fake GM windows to hardware-provided per-neighbor counter/event registers and SRAM slot bases while keeping the GridPipe `TPUSH/TPOP` call sites unchanged.
 
 ### fp32 EAST reduction
 
@@ -109,7 +119,7 @@ bash run.sh --build-only -v Ascend910B1 --grid-rows 2 --grid-cols 2
 ### Run on NPU
 
 ```bash
-task-submit --device auto --run "cd $(pwd)/kernels/manual/a2a3/distributed_ffn_grid && bash run.sh -r npu -v Ascend910B1 --grid-rows 3 --grid-cols 3"
+bash run.sh -r npu -v Ascend910B1 --device-id 0 --grid-rows 3 --grid-cols 3
 ```
 
 ### Common arguments
@@ -118,6 +128,7 @@ task-submit --device auto --run "cd $(pwd)/kernels/manual/a2a3/distributed_ffn_g
 -r, --run-mode      sim or npu, default npu
 -v, --soc-version   default Ascend910B1
 -n, --n-ranks       fixed to 1
+-d, --device-id     selected ACL device id, default 0
 --grid-rows         logical grid row count, default 2
 --grid-cols         logical grid column count, default 2
 --token-tile        token tile T per cell, default 16

--- a/kernels/manual/a2a3/distributed_ffn_grid/README_zh.md
+++ b/kernels/manual/a2a3/distributed_ffn_grid/README_zh.md
@@ -1,0 +1,143 @@
+# Single-device Multi-block FFN GridPipe Demo
+
+## 整体目标
+
+`distributed_ffn_grid` 当前用于验证 A2/A3 上的单卡逻辑 FFN 网格。host 在 device 0 上启动单进程，并 launch `gridRows * gridCols` 个 block。每个 block 对应一个逻辑 cell：
+
+- `gridRows` 是 data-parallel token 分片。
+- `gridCols` 是 model-parallel FFN intermediate 分片。
+- mixed Cube/Vec kernel 在单次 launch 中完成 gate/up、activation、down projection 和行内 `EAST` reduce。
+- 每行最右列写出 fp32 `[T, H]` 输出 tile，host 使用 `1e-3` 容差与 `golden.bin` 比对。
+
+`EAST` reduce 使用 A2/A3 GridPipe mock backend：本地 GM windows、fake `HcclDeviceContext` window 指针、ready/free counter、`dcci/dsb` fence 和 spin wait。该 demo 验证的是单设备 mock 路径和 GridPipe 编程模型，不是多卡通信验证。
+
+## 文件作用
+
+| 文件 | 作用 |
+| --- | --- |
+| `README_zh.md` / `README.md` | 中文 / 英文说明文档。 |
+| `CMakeLists.txt` | 构建 host 可执行文件和 mixed Cube/Vec device kernel shared library。 |
+| `run.sh` | 一键设置 CANN 环境、生成输入数据、配置 CMake、编译并在单进程中启动 demo。 |
+| `ffn_config.hpp` | 编译期配置：逻辑网格尺寸、tile 尺寸、GridPipe window 字节数、buffer 字节数、PReLU alpha。 |
+| `kernel_launch.hpp` | host 侧 mixed kernel launch 接口声明。 |
+| `main.cpp` | host driver：ACL 初始化、fake HCCL context/local GridPipe windows、device buffer 分配、数据加载、kernel launch、golden 校验和资源清理。 |
+| `distributed_ffn_grid_compute_kernel.cpp` | mixed Cube/Vec kernel。Cube 负责 GEMM，Vec 负责 activation/cast 和 GridPipe `EAST` reduce。 |
+| `gridpipe_payload_inl.hpp` | 本地 GridPipe payload/remote pointer adaptor。 |
+| `../../../../include/pto/common/grid_counter_intrinsic.hpp` | CCE intrinsic 风格的 neighbor counter API，GridPipe ready/free wait 与 notify 会经过这里。 |
+| `scripts/gen_data.py` | 生成每个 cell 的 fp16 X/weight shard，以及 fp32 golden reference。 |
+| `build/` | 被忽略的生成 build 目录。 |
+| `out/` | 被忽略的生成数据目录。 |
+
+## 运行流程
+
+1. `run.sh` 解析参数。默认 `gridRows=2`、`gridCols=2`、`T=16`、`H=64`、`Fi=64`、`n-ranks=1`。
+2. 如果没有指定 `--build-only`，`scripts/gen_data.py` 生成 per-cell 输入、权重文件和 `golden.bin`。
+3. CMake 构建两个 target：
+   - `distributed_ffn_grid_mixed_kernel`：`dav-c220` mixed Cube/Vec kernel。
+   - `distributed_ffn_grid`：host 可执行文件。
+4. host 初始化 ACL 并固定使用 device 0。
+5. host 按 `gridRows * gridCols` 个 cell 分配连续 device buffers。
+6. host 分配每个 cell 一个本地 GridPipe GM window，并构造 fake `HcclDeviceContext`：
+
+```text
+windowsIn[cell] = reduce_pipe_windows_dev + cell * FFN_GRID_WINDOW_BYTES
+rankNum = gridRows * gridCols
+winSize = FFN_GRID_WINDOW_BYTES
+```
+
+7. host 加载每个 cell 的 X 和 weight shard。
+8. host 通过 `rtGetC2cCtrlAddr()` 获取 FFTS base address，并单次 launch `DistributedFfnGridMixedKernel`。
+9. kernel 内 Cube 和 Vec 分支通过 A2/A3 `TPipe` FIFO 交换中间 tile：
+
+```text
+Cube:
+  X[row] @ W_gate[col] -> gatePartial[row,col] --TPipe C2V-->
+  X[row] @ W_up[col]   -> upPartial[row,col]   --TPipe C2V-->
+
+Vec:
+  hidden[row,col] = fp16(PReLU(gatePartial) * upPartial)
+  hidden[row,col] --TPipe V2C-->
+
+Cube:
+  hidden[row,col] @ W_down[col] -> downPartial[row,col] --TPipe C2V-->
+
+Vec:
+  downPartial --GridPipe EAST reduce across cols--> yOutput[row] on final col
+```
+
+10. host 同步 stream，检查 GridPipe fault flags，拷回 `yOutput` 并与 `golden.bin` 比对。
+
+## 关键设计
+
+### 1. Mixed Cube/Vec 单次 launch
+
+device kernel 编译为 `dav-c220`。Cube 和 Vec 分支分别由 `__DAV_CUBE__`、`__DAV_VEC__` 保护，两个分支位于同一个 kernel source 中，通过 A2/A3 `TPipe` ready/free handshake 同步。
+
+### 2. 单卡逻辑网格
+
+`get_block_idx()` 是 row-major cell id：
+
+```text
+cell = get_block_idx()
+row  = cell / gridCols
+col  = cell % gridCols
+```
+
+所有 cell 都在同一个 device 上运行。`gridRows` 控制 data-parallel token tile 数，`gridCols` 控制 model-parallel FFN shard 数。
+
+### 3. 本地 GridPipe mock
+
+host 分配 `gridRows * gridCols` 个本地 GM windows。`TPUSH<EAST>` 通过 fake HCCL window table 写入 east neighbor 的 slot 和 ready counter；`TPOP<EAST>` 等待本地 ready counter、读取 slot，并向 west neighbor 归还 free credit。
+
+mock 使用 GM flag polling 和 cache maintenance 在 A2/A3 上模拟 LPU WSE 预期的 `SPR` / `WFE` 行为。
+
+### 4. Neighbor counter intrinsic API
+
+GridPipe 的 ready/free 同步统一经过 `include/pto/common/grid_counter_intrinsic.hpp` 中两个 CCE intrinsic 风格 API：
+
+- `mtspr_neighbor_counter(operand, kind, dir, value)`：向 `dir` 对应的 neighbor-visible counter 发布单调递增的 `Ready` 或 `Free` 值。
+- `wfe_neighbor_counter(operand, kind, dir, threshold)`：等待本地 counter mirror 达到 `threshold`。
+
+`TPUSH<EAST>` 先用 `wfe_neighbor_counter` 等待 `Free` credit，写 payload slot，然后用 `mtspr_neighbor_counter` 发布 `Ready`。`TPOP<EAST>` 先等待 `Ready`，读取 payload slot，再向上游发布 `Free`。
+
+当前 A2/A3 上，`NeighborCounterOperand::addr` 指向本地/fake peer GridPipe window 中的 GM counter，API 会落到 mock 的 `dcci/dsb` 与 spin-wait 实现。真实硬件支持 neighbor SPR/WFE counter 后，本示例应通过 `PTO_GRID_COUNTER_NATIVE_INTRINSIC` 编译 GridPipe，并由编译器提供 `__builtin_pto_mtspr_neighbor_counter` 和 `__builtin_pto_wfe_neighbor_counter`。此时 counter operand 地址由 API 忽略，host/device 侧应从 fake GM ready/free counter 切到硬件提供的 neighbor counter/event register；GridPipe `TPUSH/TPOP` 调用点不需要变化。payload slot 映射仍可由后端选择 GridPipe window 或真实硬件 slot 地址机制，但 counter 发布和等待不应再走 GM polling。
+
+### 5. fp32 EAST reduce
+
+reduce slot 携带 fp32 `[T, H]`，所以 `FFN_SLOT_BYTES = T * H * 4`。`downPartial`、`yOutput` 和 `golden.bin` 都保持 fp32，host 可直接做容差比较。
+
+## 运行方法
+
+### 仅编译
+
+```bash
+bash run.sh --build-only -v Ascend910B1 --grid-rows 2 --grid-cols 2
+```
+
+### NPU 运行
+
+```bash
+task-submit --device auto --run "cd $(pwd)/kernels/manual/a2a3/distributed_ffn_grid && bash run.sh -r npu -v Ascend910B1 --grid-rows 3 --grid-cols 3"
+```
+
+### 常用参数
+
+```text
+-r, --run-mode      sim 或 npu，默认 npu
+-v, --soc-version   默认 Ascend910B1
+-n, --n-ranks       固定为 1
+--grid-rows         单卡逻辑网格行数，默认 2
+--grid-cols         单卡逻辑网格列数，默认 2
+--token-tile        每个 cell 的 token tile T，默认 16
+--model-tile        hidden dim H，默认 64
+--ffn-tile          每列 intermediate dim Fi，默认 64
+--build-only        只编译，不生成数据和运行
+```
+
+## 期望输出
+
+成功时最终打印：
+
+```text
+[SUCCESS] Single-device multi-block FFN GridPipe PASS.
+```

--- a/kernels/manual/a2a3/distributed_ffn_grid/README_zh.md
+++ b/kernels/manual/a2a3/distributed_ffn_grid/README_zh.md
@@ -2,14 +2,14 @@
 
 ## 整体目标
 
-`distributed_ffn_grid` 当前用于验证 A2/A3 上的单卡逻辑 FFN 网格。host 在 device 0 上启动单进程，并 launch `gridRows * gridCols` 个 block。每个 block 对应一个逻辑 cell：
+`distributed_ffn_grid` 当前用于验证 A2/A3 上的单卡逻辑 FFN 网格。host 在选定 device 上启动单进程，并 launch `gridRows * gridCols` 个 block。每个 block 对应一个逻辑 cell：
 
 - `gridRows` 是 data-parallel token 分片。
 - `gridCols` 是 model-parallel FFN intermediate 分片。
 - mixed Cube/Vec kernel 在单次 launch 中完成 gate/up、activation、down projection 和行内 `EAST` reduce。
 - 每行最右列写出 fp32 `[T, H]` 输出 tile，host 使用 `1e-3` 容差与 `golden.bin` 比对。
 
-`EAST` reduce 使用 A2/A3 GridPipe mock backend：本地 GM windows、fake `HcclDeviceContext` window 指针、ready/free counter、`dcci/dsb` fence 和 spin wait。该 demo 验证的是单设备 mock 路径和 GridPipe 编程模型，不是多卡通信验证。
+`EAST` reduce 使用 A2/A3 GridPipe mock backend：本地 SRAM windows（当前由 GM 分配模拟）、fake `HcclDeviceContext` window 指针、ready/free counter、`dcci/dsb` fence 和 spin wait。该 demo 验证的是单设备 mock 路径和 GridPipe 编程模型，不是多卡通信验证。
 
 ## 文件作用
 
@@ -24,6 +24,7 @@
 | `distributed_ffn_grid_compute_kernel.cpp` | mixed Cube/Vec kernel。Cube 负责 GEMM，Vec 负责 activation/cast 和 GridPipe `EAST` reduce。 |
 | `gridpipe_payload_inl.hpp` | 本地 GridPipe payload/remote pointer adaptor。 |
 | `../../../../include/pto/common/grid_counter_intrinsic.hpp` | CCE intrinsic 风格的 neighbor counter API，GridPipe ready/free wait 与 notify 会经过这里。 |
+| `../../../../include/pto/common/grid_sram_intrinsic.hpp` | CCE intrinsic 风格的 neighbor SRAM 地址解析和 payload 搬运 API，GridPipe payload movement 会经过这里。 |
 | `scripts/gen_data.py` | 生成每个 cell 的 fp16 X/weight shard，以及 fp32 golden reference。 |
 | `build/` | 被忽略的生成 build 目录。 |
 | `out/` | 被忽略的生成数据目录。 |
@@ -35,9 +36,9 @@
 3. CMake 构建两个 target：
    - `distributed_ffn_grid_mixed_kernel`：`dav-c220` mixed Cube/Vec kernel。
    - `distributed_ffn_grid`：host 可执行文件。
-4. host 初始化 ACL 并固定使用 device 0。
+4. host 在选定 device 上初始化 ACL。
 5. host 按 `gridRows * gridCols` 个 cell 分配连续 device buffers。
-6. host 分配每个 cell 一个本地 GridPipe GM window，并构造 fake `HcclDeviceContext`：
+6. host 分配每个 cell 一个本地 GridPipe SRAM window（当前用 GM backing），并构造 fake `HcclDeviceContext`：
 
 ```text
 windowsIn[cell] = reduce_pipe_windows_dev + cell * FFN_GRID_WINDOW_BYTES
@@ -87,20 +88,29 @@ col  = cell % gridCols
 
 ### 3. 本地 GridPipe mock
 
-host 分配 `gridRows * gridCols` 个本地 GM windows。`TPUSH<EAST>` 通过 fake HCCL window table 写入 east neighbor 的 slot 和 ready counter；`TPOP<EAST>` 等待本地 ready counter、读取 slot，并向 west neighbor 归还 free credit。
+host 分配 `gridRows * gridCols` 个本地 SRAM windows（当前由 GM backing）。`TPUSH<EAST>` 通过 `get_neighbor_ubuf_addr` 解析 east neighbor 的 Vector UB slot 后写入 payload，再发布 ready counter；`TPOP<EAST>` 等待本地 ready counter、读取本地 UB slot，并向 west neighbor 归还 free credit。
 
 mock 使用 GM flag polling 和 cache maintenance 在 A2/A3 上模拟 LPU WSE 预期的 `SPR` / `WFE` 行为。
 
 ### 4. Neighbor counter intrinsic API
 
-GridPipe 的 ready/free 同步统一经过 `include/pto/common/grid_counter_intrinsic.hpp` 中两个 CCE intrinsic 风格 API：
+GridPipe 的 ready/free 同步统一经过 `include/pto/common/grid_counter_intrinsic.hpp` 中两个 CCE intrinsic 风格 API。规范调用形态把硬件语义参数放在前面，mock backend operand 放在末尾：
 
-- `mtspr_neighbor_counter(operand, kind, dir, value)`：向 `dir` 对应的 neighbor-visible counter 发布单调递增的 `Ready` 或 `Free` 值。
-- `wfe_neighbor_counter(operand, kind, dir, threshold)`：等待本地 counter mirror 达到 `threshold`。
+- `mtspr_neighbor_counter(kind, dir, value, operand)`：向 `dir` 对应的 neighbor-visible counter 发布单调递增的 `Ready` 或 `Free` 值。
+- `wfe_neighbor_counter(kind, dir, threshold, operand, maxSpins)`：等待本地 counter mirror 达到 `threshold`。
+
+GridPipe payload 的远端 SRAM 地址解析统一经过 `include/pto/common/grid_sram_intrinsic.hpp`：
+
+- `get_neighbor_ubuf_addr(dst, src, dir, peerRank, operand)` / `get_neighbor_cbuf_addr(dst, src, dir, peerRank, operand)`：将本地 slot offset 解析为邻居 Vector UB 或 Cube L1/CBUF slot 地址寄存器。
+- `copy_ubuf_to_neighbor_ubuf(dst, src, bytes, config)` / `copy_ubuf_to_neighbor_cbuf(dst, src, bytes, config)`：Vector UB 到邻居 Vector UB 或 Cube L1 的写入接口。
+- `copy_cbuf_to_neighbor_ubuf(dst, src, bytes, config)` / `copy_cbuf_to_neighbor_cbuf(dst, src, bytes, config)`：Cube L1 到邻居 Vector UB 或 Cube L1 的写入接口。
+- `copy_neighbor_ubuf_to_ubuf(dst, src, bytes, config)`：A2/A3 mock 中 TPOP 侧从本地 GM-backed slot 加载到 consumer Vector UB tile 的接口；native Grid TPOP 预期通过硬件 SRAM 地址机制绑定本地 slot。
+
+当前 A2/A3 mock 中，UB 源路径通过 GM-backed fake window 上的 MTE 搬运实现；`__cbuf__` 源路径通过现有 `copy_cbuf_to_gm` 写入 GM-backed fake window。native 硬件提供对应 builtin 后，上层 GridPipe 调用点不需要修改。
 
 `TPUSH<EAST>` 先用 `wfe_neighbor_counter` 等待 `Free` credit，写 payload slot，然后用 `mtspr_neighbor_counter` 发布 `Ready`。`TPOP<EAST>` 先等待 `Ready`，读取 payload slot，再向上游发布 `Free`。
 
-当前 A2/A3 上，`NeighborCounterOperand::addr` 指向本地/fake peer GridPipe window 中的 GM counter，API 会落到 mock 的 `dcci/dsb` 与 spin-wait 实现。真实硬件支持 neighbor SPR/WFE counter 后，本示例应通过 `PTO_GRID_COUNTER_NATIVE_INTRINSIC` 编译 GridPipe，并由编译器提供 `__builtin_pto_mtspr_neighbor_counter` 和 `__builtin_pto_wfe_neighbor_counter`。此时 counter operand 地址由 API 忽略，host/device 侧应从 fake GM ready/free counter 切到硬件提供的 neighbor counter/event register；GridPipe `TPUSH/TPOP` 调用点不需要变化。payload slot 映射仍可由后端选择 GridPipe window 或真实硬件 slot 地址机制，但 counter 发布和等待不应再走 GM polling。
+当前 A2/A3 上，`NeighborCounterOperand::addr` 指向本地/fake peer GridPipe window 中的 GM-backed counter，`NeighborSramOperand::runtimeCtx` 指向 fake HCCL context。真实硬件支持 neighbor SPR/WFE counter 和 neighbor SRAM address register 后，应分别通过 `PTO_GRID_COUNTER_NATIVE_INTRINSIC`、`PTO_GRID_SRAM_NATIVE_INTRINSIC` 编译 GridPipe，并由编译器提供对应 `__builtin_pto_*`。此时 mock operand 被忽略，host/device 侧应从 fake GM window 切到硬件提供的 per-neighbor counter/event register 与 SRAM slot base；GridPipe `TPUSH/TPOP` 调用点不需要变化。
 
 ### 5. fp32 EAST reduce
 
@@ -117,7 +127,7 @@ bash run.sh --build-only -v Ascend910B1 --grid-rows 2 --grid-cols 2
 ### NPU 运行
 
 ```bash
-task-submit --device auto --run "cd $(pwd)/kernels/manual/a2a3/distributed_ffn_grid && bash run.sh -r npu -v Ascend910B1 --grid-rows 3 --grid-cols 3"
+bash run.sh -r npu -v Ascend910B1 --device-id 0 --grid-rows 3 --grid-cols 3
 ```
 
 ### 常用参数
@@ -126,6 +136,7 @@ task-submit --device auto --run "cd $(pwd)/kernels/manual/a2a3/distributed_ffn_g
 -r, --run-mode      sim 或 npu，默认 npu
 -v, --soc-version   默认 Ascend910B1
 -n, --n-ranks       固定为 1
+-d, --device-id     ACL device id，默认 0
 --grid-rows         单卡逻辑网格行数，默认 2
 --grid-cols         单卡逻辑网格列数，默认 2
 --token-tile        每个 cell 的 token tile T，默认 16

--- a/kernels/manual/a2a3/distributed_ffn_grid/distributed_ffn_grid_compute_kernel.cpp
+++ b/kernels/manual/a2a3/distributed_ffn_grid/distributed_ffn_grid_compute_kernel.cpp
@@ -305,6 +305,8 @@ __global__ AICORE void DistributedFfnGridMixedKernel(__gm__ uint8_t *fftsAddr, _
         if (col > 0) {
             TPOP<GridDirection::EAST>(reducePipe, addF32);
 #ifndef __PTO_AUTO__
+            set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+            wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
             pipe_barrier(PIPE_ALL);
 #endif
             dsb(DSB_DDR);
@@ -316,6 +318,13 @@ __global__ AICORE void DistributedFfnGridMixedKernel(__gm__ uint8_t *fftsAddr, _
 
         if (col + 1 < gridCols) {
 #ifndef __PTO_AUTO__
+            if (col > 0) {
+                set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+                wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+            } else {
+                set_flag(PIPE_MTE2, PIPE_MTE3, EVENT_ID0);
+                wait_flag(PIPE_MTE2, PIPE_MTE3, EVENT_ID0);
+            }
             pipe_barrier(PIPE_ALL);
 #endif
             dsb(DSB_DDR);

--- a/kernels/manual/a2a3/distributed_ffn_grid/distributed_ffn_grid_compute_kernel.cpp
+++ b/kernels/manual/a2a3/distributed_ffn_grid/distributed_ffn_grid_compute_kernel.cpp
@@ -1,0 +1,367 @@
+/**
+Copyright (c) 2026 Huawei Technologies Co., Ltd.
+This program is free software, you can redistribute it and/or modify it under
+the terms and conditions of CANN Open Software License Agreement Version 2.0
+(the "License"). Please refer to the License for details. You may not use this
+file except in compliance with the License. THIS SOFTWARE IS PROVIDED ON AN "AS
+IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING
+BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A
+PARTICULAR PURPOSE. See LICENSE in the root of the software repository for the
+full text of the License.
+*/
+
+// Single-device multi-block FFN mixed Cube/Vec kernel.
+//
+// Each block owns one logical grid cell (row, col).  Cube computes the three
+// GEMMs, Vec computes the activation and row-local EAST reduce.  Cube/Vec
+// exchange intermediate tiles through regular A2/A3 TPipe FIFO handshakes.
+
+#include <cstddef>
+#include <cstdint>
+#include <pto/pto-inst.hpp>
+
+#include <pto/common/fifo.hpp>
+#include <pto/common/grid_pipe.hpp>
+#include <pto/npu/a2a3/grid_pipe_runtime.hpp>
+
+#include "common.hpp"
+#include "ffn_config.hpp"
+#include "gridpipe_payload_inl.hpp"
+
+#ifdef __CCE_AICORE__
+using namespace pto;
+
+#ifdef __DAV_CUBE__
+constexpr bool DAV_CUBE = true;
+#else
+constexpr bool DAV_CUBE = false;
+#endif
+
+#ifdef __DAV_VEC__
+constexpr bool DAV_VEC = true;
+#else
+constexpr bool DAV_VEC = false;
+#endif
+
+using GateF32Tile = Tile<TileType::Vec, float, FFN_TOKEN_TILE, FFN_FFN_TILE, BLayout::RowMajor>;
+using UpF32Tile = GateF32Tile;
+using HiddenF32Tile = GateF32Tile;
+using HiddenF16Tile = Tile<TileType::Vec, half, FFN_TOKEN_TILE, FFN_FFN_TILE, BLayout::RowMajor>;
+using DownF32Tile = Tile<TileType::Vec, float, FFN_TOKEN_TILE, FFN_MODEL_TILE, BLayout::RowMajor>;
+using FfnGridPipe = GridPipe<DownF32Tile, FFN_SLOT_BYTES, FFN_SLOT_COUNT>;
+
+using ShapeTH = Shape<1, 1, 1, FFN_TOKEN_TILE, FFN_MODEL_TILE>;
+using StrideTH = Stride<FFN_TOKEN_TILE * FFN_MODEL_TILE, FFN_TOKEN_TILE * FFN_MODEL_TILE,
+                        FFN_TOKEN_TILE * FFN_MODEL_TILE, FFN_MODEL_TILE, 1>;
+using GTHF32 = GlobalTensor<float, ShapeTH, StrideTH, Layout::ND>;
+
+constexpr int kUbGateF32 = 0x0000;
+constexpr int kUbUpF32 = 0x1000;
+constexpr int kUbHiddenF32 = 0x2000;
+constexpr int kUbHiddenF16 = 0x3000;
+constexpr int kUbDownF32 = 0x4000;
+constexpr int kUbAddF32 = 0x5000;
+
+constexpr int kL1X = 0x00000;
+constexpr int kL1Hidden = 0x10000;
+constexpr int kL1WGate = 0x20000;
+constexpr int kL1WUp = 0x24000;
+constexpr int kL1WDown = 0x28000;
+
+#endif
+
+__global__ AICORE void DistributedFfnGridMixedKernel(__gm__ uint8_t *fftsAddr, __gm__ uint8_t *reducePipeWindow,
+                                                     __gm__ uint8_t *x, __gm__ uint8_t *wGate, __gm__ uint8_t *wUp,
+                                                     __gm__ uint8_t *wDown, __gm__ uint8_t *gatePartial,
+                                                     __gm__ uint8_t *upPartial, __gm__ uint8_t *hiddenIn,
+                                                     __gm__ uint8_t *downPartial, __gm__ uint8_t *yOutput,
+                                                     __gm__ uint8_t *hcclCtxRaw, int gridRows, int gridCols)
+{
+#ifdef __CCE_AICORE__
+    set_ffts_base_addr(reinterpret_cast<uint64_t>(fftsAddr));
+
+    int blockIdx = get_block_idx();
+    int totalBlocks = gridRows * gridCols;
+    if (blockIdx < 0 || blockIdx >= totalBlocks) {
+        return;
+    }
+
+    constexpr int validM = FFN_TOKEN_TILE; // 16
+    constexpr int validK = FFN_MODEL_TILE; // 64
+    constexpr int validN = FFN_FFN_TILE;   // 64
+    constexpr int blockAlign = C0_SIZE_BYTE / static_cast<int>(sizeof(half));
+    constexpr int M = ((validM + 15) / 16) * 16;
+    constexpr int K = ((validK + blockAlign - 1) / blockAlign) * blockAlign;
+    constexpr int N = ((validN + blockAlign - 1) / blockAlign) * blockAlign;
+
+    using GX = GlobalTensor<half, Shape<1, 1, 1, validM, validK>,
+                            Stride<validM * validK, validM * validK, validM * validK, validK, 1>>;
+    using GW = GlobalTensor<half, Shape<1, 1, 1, validK, validN>,
+                            Stride<validK * validN, validK * validN, validK * validN, validN, 1>>;
+    using TileA = Tile<TileType::Mat, half, M, K, BLayout::ColMajor, validM, validK, SLayout::RowMajor, 512>;
+    using TileB = Tile<TileType::Mat, half, K, N, BLayout::ColMajor, validK, validN, SLayout::RowMajor, 512>;
+    using TL = TileLeft<half, M, K, validM, validK>;
+    using TR = TileRight<half, K, N, validK, validN>;
+    using TC = TileAcc<float, M, N, validM, validN>;
+
+    using GatePipe = TPipe<0, Direction::DIR_C2V, FFN_GATE_PARTIAL_BYTES, 1>;
+    using UpPipe = TPipe<2, Direction::DIR_C2V, FFN_UP_PARTIAL_BYTES, 1>;
+    using HiddenPipe = TPipe<4, Direction::DIR_V2C, FFN_HIDDEN_BYTES, 1>;
+    using DownPipe = TPipe<6, Direction::DIR_C2V, FFN_DOWN_PARTIAL_BYTES, 1>;
+
+    TileA xMat;
+    TileA hiddenMat;
+    TileB wGateMat;
+    TileB wUpMat;
+    TileB wDownMat;
+    TASSIGN(xMat, kL1X);
+    TASSIGN(hiddenMat, kL1Hidden);
+    TASSIGN(wGateMat, kL1WGate);
+    TASSIGN(wUpMat, kL1WUp);
+    TASSIGN(wDownMat, kL1WDown);
+
+    TL aT;
+    TR bT;
+    TC cT;
+    TASSIGN(aT, 0x0);
+    TASSIGN(bT, 0x0);
+    TASSIGN(cT, 0x0);
+
+    constexpr int xTileBytes = FFN_X_BYTES;
+    constexpr int wGateTileBytes = FFN_W_GATE_BYTES;
+    constexpr int wUpTileBytes = FFN_W_UP_BYTES;
+    constexpr int wDownTileBytes = FFN_W_DOWN_BYTES;
+    constexpr int partialTileBytes = FFN_GATE_PARTIAL_BYTES;
+    constexpr int hiddenTileBytes = FFN_HIDDEN_BYTES;
+    constexpr int downTileBytes = FFN_DOWN_PARTIAL_BYTES;
+    __gm__ uint8_t *xBlock = x + blockIdx * xTileBytes;
+    __gm__ uint8_t *wGateBlock = wGate + blockIdx * wGateTileBytes;
+    __gm__ uint8_t *wUpBlock = wUp + blockIdx * wUpTileBytes;
+    __gm__ uint8_t *wDownBlock = wDown + blockIdx * wDownTileBytes;
+    __gm__ uint8_t *gateBlock = gatePartial + blockIdx * partialTileBytes;
+    __gm__ uint8_t *upBlock = upPartial + blockIdx * partialTileBytes;
+    __gm__ uint8_t *hiddenBlock = hiddenIn + blockIdx * hiddenTileBytes;
+    __gm__ uint8_t *downBlock = downPartial + blockIdx * downTileBytes;
+    __gm__ uint8_t *yBlock = yOutput + (blockIdx / gridCols) * FFN_Y_OUTPUT_BYTES;
+
+    GatePipe gatePipe(reinterpret_cast<__gm__ void *>(gateBlock), kUbGateF32, 0);
+    UpPipe upPipe(reinterpret_cast<__gm__ void *>(upBlock), kUbUpF32, 0);
+    HiddenPipe hiddenPipe(reinterpret_cast<__gm__ void *>(hiddenBlock), 0, kL1Hidden);
+    DownPipe downPipe(reinterpret_cast<__gm__ void *>(downBlock), kUbDownF32, 0);
+
+    if constexpr (DAV_CUBE) {
+        GX xG(reinterpret_cast<__gm__ half *>(xBlock));
+        GW wGateG(reinterpret_cast<__gm__ half *>(wGateBlock));
+        GW wUpG(reinterpret_cast<__gm__ half *>(wUpBlock));
+        GW wDownG(reinterpret_cast<__gm__ half *>(wDownBlock));
+
+        TLOAD(xMat, xG);
+        TLOAD(wGateMat, wGateG);
+        TLOAD(wUpMat, wUpG);
+        TLOAD(wDownMat, wDownG);
+
+#ifndef __PTO_AUTO__
+        set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);
+        wait_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);
+#endif
+
+        // -------- gate: gatePartial = x @ W_gate --------
+        TMOV(aT, xMat);
+        TMOV(bT, wGateMat);
+
+#ifndef __PTO_AUTO__
+        set_flag(PIPE_MTE1, PIPE_M, EVENT_ID0);
+        wait_flag(PIPE_MTE1, PIPE_M, EVENT_ID0);
+#endif
+
+        TMATMUL(cT, aT, bT);
+
+#ifndef __PTO_AUTO__
+        set_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
+        wait_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
+#endif
+
+        TPUSH<GatePipe, TC, TileSplitAxis::TILE_NO_SPLIT>(gatePipe, cT);
+
+#ifndef __PTO_AUTO__
+        pipe_barrier(PIPE_ALL);
+#endif
+        dsb(DSB_DDR);
+
+        // -------- up: upPartial = x @ W_up --------
+        TMOV(aT, xMat);
+        TMOV(bT, wUpMat);
+
+#ifndef __PTO_AUTO__
+        set_flag(PIPE_MTE1, PIPE_M, EVENT_ID0);
+        wait_flag(PIPE_MTE1, PIPE_M, EVENT_ID0);
+#endif
+
+        TMATMUL(cT, aT, bT);
+
+#ifndef __PTO_AUTO__
+        set_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
+        wait_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
+#endif
+
+        TPUSH<UpPipe, TC, TileSplitAxis::TILE_NO_SPLIT>(upPipe, cT);
+
+#ifndef __PTO_AUTO__
+        pipe_barrier(PIPE_ALL);
+#endif
+        dsb(DSB_DDR);
+
+        TPOP<HiddenPipe, TileA, TileSplitAxis::TILE_NO_SPLIT>(hiddenPipe, hiddenMat);
+#ifndef __PTO_AUTO__
+        set_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);
+        wait_flag(PIPE_MTE2, PIPE_MTE1, EVENT_ID0);
+        pipe_barrier(PIPE_ALL);
+#endif
+        dsb(DSB_DDR);
+
+        // -------- down: downPartial = hidden @ W_down --------
+        TMOV(aT, hiddenMat);
+        TMOV(bT, wDownMat);
+
+#ifndef __PTO_AUTO__
+        set_flag(PIPE_MTE1, PIPE_M, EVENT_ID0);
+        wait_flag(PIPE_MTE1, PIPE_M, EVENT_ID0);
+#endif
+
+        TMATMUL(cT, aT, bT);
+
+#ifndef __PTO_AUTO__
+        set_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
+        wait_flag(PIPE_M, PIPE_FIX, EVENT_ID0);
+#endif
+
+        TPUSH<DownPipe, TC, TileSplitAxis::TILE_NO_SPLIT>(downPipe, cT);
+
+#ifndef __PTO_AUTO__
+        pipe_barrier(PIPE_ALL);
+#endif
+        dsb(DSB_DDR);
+    }
+
+    if constexpr (DAV_VEC) {
+        GateF32Tile gateF32;
+        UpF32Tile upF32;
+        HiddenF32Tile hiddenF32;
+        HiddenF16Tile hiddenF16;
+        DownF32Tile downF32;
+        DownF32Tile addF32;
+        TASSIGN(gateF32, kUbGateF32);
+        TASSIGN(upF32, kUbUpF32);
+        TASSIGN(hiddenF32, kUbHiddenF32);
+        TASSIGN(hiddenF16, kUbHiddenF16);
+        TASSIGN(downF32, kUbDownF32);
+        TASSIGN(addF32, kUbAddF32);
+
+        TPOP<GatePipe, GateF32Tile, TileSplitAxis::TILE_NO_SPLIT>(gatePipe, gateF32);
+        TPOP<UpPipe, UpF32Tile, TileSplitAxis::TILE_NO_SPLIT>(upPipe, upF32);
+
+#ifndef __PTO_AUTO__
+        set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+        wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+#endif
+
+        TLRELU(gateF32, gateF32, FFN_PRELU_ALPHA);
+
+#ifndef __PTO_AUTO__
+        pipe_barrier(PIPE_V);
+#endif
+
+        TMUL(hiddenF32, gateF32, upF32);
+
+#ifndef __PTO_AUTO__
+        pipe_barrier(PIPE_V);
+#endif
+
+        TCVT(hiddenF16, hiddenF32, RoundMode::CAST_RINT);
+
+#ifndef __PTO_AUTO__
+        set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+        wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+#endif
+
+        TPUSH<HiddenPipe, HiddenF16Tile, TileSplitAxis::TILE_NO_SPLIT>(hiddenPipe, hiddenF16);
+
+        TPOP<DownPipe, DownF32Tile, TileSplitAxis::TILE_NO_SPLIT>(downPipe, downF32);
+
+#ifndef __PTO_AUTO__
+        set_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+        wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+#endif
+
+        FfnGridPipe reducePipe;
+        GridShape shape{gridRows, gridCols};
+        GridCoord coord{blockIdx / gridCols, blockIdx - (blockIdx / gridCols) * gridCols};
+        __gm__ uint8_t *window = reducePipeWindow + blockIdx * FFN_GRID_WINDOW_BYTES;
+        a2a3_grid::InitGridPipeFromWindow(reducePipe, shape, coord, window, reinterpret_cast<__gm__ void *>(hcclCtxRaw),
+                                          /*pipeId=*/0);
+
+        using pto::GridDirection;
+        int col = coord.col;
+        if (col > 0) {
+            TPOP<GridDirection::EAST>(reducePipe, addF32);
+#ifndef __PTO_AUTO__
+            pipe_barrier(PIPE_ALL);
+#endif
+            dsb(DSB_DDR);
+            TADD(downF32, downF32, addF32);
+#ifndef __PTO_AUTO__
+            pipe_barrier(PIPE_V);
+#endif
+        }
+
+        if (col + 1 < gridCols) {
+#ifndef __PTO_AUTO__
+            pipe_barrier(PIPE_ALL);
+#endif
+            dsb(DSB_DDR);
+            TPUSH<GridDirection::EAST>(reducePipe, downF32);
+        } else {
+#ifndef __PTO_AUTO__
+            set_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+            wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+#endif
+            GTHF32 yG(reinterpret_cast<__gm__ float *>(yBlock));
+            TSTORE(yG, downF32);
+        }
+
+#ifndef __PTO_AUTO__
+        pipe_barrier(PIPE_ALL);
+#endif
+        dsb(DSB_DDR);
+    }
+#else
+    (void)fftsAddr;
+    (void)reducePipeWindow;
+    (void)x;
+    (void)wGate;
+    (void)wUp;
+    (void)wDown;
+    (void)gatePartial;
+    (void)upPartial;
+    (void)hiddenIn;
+    (void)downPartial;
+    (void)yOutput;
+    (void)hcclCtxRaw;
+    (void)gridRows;
+    (void)gridCols;
+#endif
+}
+
+void launchDistributedFfnGridMixedKernel(uint8_t *ffts, uint8_t *reducePipeWindow, uint8_t *x, uint8_t *wGate,
+                                         uint8_t *wUp, uint8_t *wDown, uint8_t *gatePartial, uint8_t *upPartial,
+                                         uint8_t *hiddenIn, uint8_t *downPartial, uint8_t *yOutput, uint8_t *hcclCtx,
+                                         int gridRows, int gridCols, void *stream)
+{
+    int totalBlocks = gridRows * gridCols;
+    if (totalBlocks <= 0) {
+        return;
+    }
+    DistributedFfnGridMixedKernel<<<totalBlocks, nullptr, stream>>>(ffts, reducePipeWindow, x, wGate, wUp, wDown,
+                                                                    gatePartial, upPartial, hiddenIn, downPartial,
+                                                                    yOutput, hcclCtx, gridRows, gridCols);
+}

--- a/kernels/manual/a2a3/distributed_ffn_grid/ffn_config.hpp
+++ b/kernels/manual/a2a3/distributed_ffn_grid/ffn_config.hpp
@@ -1,0 +1,102 @@
+/**
+Copyright (c) 2026 Huawei Technologies Co., Ltd.
+This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+CANN Open Software License Agreement Version 2.0 (the "License").
+Please refer to the License for details. You may not use this file except in compliance with the License.
+THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+See LICENSE in the root of the software repository for the full text of the License.
+*/
+
+// Compile-time shape constants for the single-device multi-block FFN demo.
+
+#ifndef DISTRIBUTED_FFN_GRID_CONFIG_HPP
+#define DISTRIBUTED_FFN_GRID_CONFIG_HPP
+
+#ifndef CONFIG_GRID_ROWS
+#define CONFIG_GRID_ROWS 2
+#endif
+
+#ifndef CONFIG_GRID_COLS
+#define CONFIG_GRID_COLS 2
+#endif
+
+#ifndef CONFIG_TOKEN_TILE
+#define CONFIG_TOKEN_TILE 16
+#endif
+
+#ifndef CONFIG_MODEL_TILE
+#define CONFIG_MODEL_TILE 64
+#endif
+
+#ifndef CONFIG_FFN_TILE
+#define CONFIG_FFN_TILE 64
+#endif
+
+constexpr int FFN_GRID_ROWS = CONFIG_GRID_ROWS;
+constexpr int FFN_GRID_COLS = CONFIG_GRID_COLS;
+constexpr int FFN_TOKEN_TILE = CONFIG_TOKEN_TILE;
+constexpr int FFN_MODEL_TILE = CONFIG_MODEL_TILE;
+constexpr int FFN_FFN_TILE = CONFIG_FFN_TILE;
+
+constexpr int FFN_TILE_ELEMS = FFN_TOKEN_TILE * FFN_MODEL_TILE;
+constexpr int FFN_TILE_BYTES = FFN_TILE_ELEMS * 2; // half
+
+// GridPipe EAST reduce carries fp32 [T, H] down partial tiles.
+constexpr int FFN_SLOT_BYTES = FFN_TOKEN_TILE * FFN_MODEL_TILE * 4;
+constexpr int FFN_SLOT_COUNT = 4;
+
+// Host-visible mirror of pto::a2a3_grid::kWindowBytes<FFN_SLOT_BYTES, FFN_SLOT_COUNT>().
+// Keep in sync with include/pto/npu/a2a3/grid_pipe_runtime.hpp:
+//   layout = kFlagsBytes (64) + 4 dirs * SlotCount * SlotBytes.
+constexpr int FFN_GRID_FLAGS_BYTES = 64;
+constexpr int FFN_GRID_WINDOW_BYTES = FFN_GRID_FLAGS_BYTES + 4 * FFN_SLOT_COUNT * FFN_SLOT_BYTES;
+
+// ---------------------------------------------------------------------------
+// Per-cell weight + golden byte sizes.
+//   - W_gate [H, Fi]   fp16   = FFN_MODEL_TILE * FFN_FFN_TILE * 2
+//   - W_up   [H, Fi]   fp16   = FFN_MODEL_TILE * FFN_FFN_TILE * 2
+//   - W_down [Fi, H]   fp16   = FFN_FFN_TILE  * FFN_MODEL_TILE * 2
+//   - golden_per_row [T, H]   fp32   = FFN_TOKEN_TILE * FFN_MODEL_TILE * 4
+//     (each row owns one [T, H] slice of yOutput; the block with col == cols-1
+//      writes its row's slice)
+//   - golden_total   [T_total, H]    fp32   = FFN_GRID_ROWS * FFN_GOLDEN_BYTES
+//     (full file on disk; data-parallel rows split T across rows)
+// Source of truth for both scripts/gen_data.py and main.cpp aclrtMalloc.
+// If dtype or T_total layout changes, update gen_data.py AND main.cpp LoadWeights
+// / VerifyOutput together.
+// ---------------------------------------------------------------------------
+constexpr int FFN_W_GATE_BYTES = FFN_MODEL_TILE * FFN_FFN_TILE * 2;
+constexpr int FFN_W_UP_BYTES = FFN_MODEL_TILE * FFN_FFN_TILE * 2;
+constexpr int FFN_W_DOWN_BYTES = FFN_FFN_TILE * FFN_MODEL_TILE * 2;
+constexpr int FFN_GOLDEN_BYTES = FFN_TOKEN_TILE * FFN_MODEL_TILE * 4;
+constexpr int FFN_GOLDEN_TOTAL_BYTES = FFN_GRID_ROWS * FFN_GOLDEN_BYTES;
+
+// ---------------------------------------------------------------------------
+// Device buffer byte sizes for the mixed Cube/Vec FFN pipeline.
+//   - x          [T, H]   fp16  (per-rank shard, loaded by main from
+//                                pe_<r>_x.bin into an independent device
+//                                buffer; cube TMATMUL input for gate/up)
+//   - gatePartial[T, Fi]  fp32  (cube output: X @ W_gate)
+//   - upPartial  [T, Fi]  fp32  (cube output: X @ W_up)
+//   - hidden     [T, Fi]  fp16  (Vec output: TCVT(TMUL(prelu(gate), up));
+//                                Cube TMATMUL input for down projection)
+//   - downPartial[T, H]   fp32  (Cube output: hidden @ W_down; Vec input for
+//                                EAST reduce.  EAST reduce writes the final
+//                                row output from the last column block.)
+// ---------------------------------------------------------------------------
+constexpr int FFN_X_BYTES = FFN_TOKEN_TILE * FFN_MODEL_TILE * 2;
+constexpr int FFN_GATE_PARTIAL_BYTES = FFN_TOKEN_TILE * FFN_FFN_TILE * 4;
+constexpr int FFN_UP_PARTIAL_BYTES = FFN_TOKEN_TILE * FFN_FFN_TILE * 4;
+constexpr int FFN_HIDDEN_BYTES = FFN_TOKEN_TILE * FFN_FFN_TILE * 2;
+constexpr int FFN_DOWN_PARTIAL_BYTES = FFN_TOKEN_TILE * FFN_MODEL_TILE * 4;
+
+// Matches FFN_GOLDEN_BYTES / golden.bin for direct fp32 comparison.
+constexpr int FFN_Y_OUTPUT_BYTES = FFN_TOKEN_TILE * FFN_MODEL_TILE * 4;
+
+// PReLU negative-slope coefficient.  Source of truth is gen_data.py top-level
+// alpha; if you change one you MUST change the other or D-3 ResultCmp fails.
+// Used by the Vec branch as a TLRELU scalar (no separate alpha tile needed).
+constexpr float FFN_PRELU_ALPHA = 0.1f;
+
+#endif // DISTRIBUTED_FFN_GRID_CONFIG_HPP

--- a/kernels/manual/a2a3/distributed_ffn_grid/gridpipe_payload_inl.hpp
+++ b/kernels/manual/a2a3/distributed_ffn_grid/gridpipe_payload_inl.hpp
@@ -1,0 +1,107 @@
+/**
+Copyright (c) 2026 Huawei Technologies Co., Ltd.
+This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+CANN Open Software License Agreement Version 2.0 (the "License").
+Please refer to the License for details. You may not use this file except in compliance with the License.
+THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+See LICENSE in the root of the software repository for the full text of the License.
+*/
+
+// Per-demo payload + remote-ptr adaptor for the GridPipe A2/A3 backend.
+//
+// GridTPush.hpp / GridTPop.hpp declare three forward functions in
+// `pto::a2a3_grid_payload` that intentionally have no header-level definition,
+// because they need a concrete tile type and the HCCL device context layout
+// that lives in this demo (not in the public header tree).  We provide those
+// definitions here once per kernel translation unit.
+//
+//   RemotePtr<T>(ctx, localPtr, peerRank)
+//     -> resolves a pointer into our own GM window to the same byte offset in
+//        peerRank's window via HcclRemotePtr.  Reused by both push and pop for
+//        the cross-rank ready/free flag writes.
+//
+//   CopyTileToGmSlot<TileT>(remoteSlot, tile, slotBytes)
+//     -> moves a UB-resident tile into a GM slot in the *neighbor's* window.
+//        Implements design doc 5.3 step 3 producer side: `tmov [r_slot], tile`.
+//
+//   CopyGmSlotToTile<TileT>(tile, localSlot, slotBytes)
+//     -> moves bytes from a GM slot in our own window into a UB-resident tile.
+//        Implements design doc 5.3 step 3 consumer side.
+//
+// The skeleton implementation uses AscendC byte-level DataCopy through
+// GlobalTensor/LocalTensor in/out of the tile's underlying address.  Real
+// silicon LPU WSE would issue a single TMOV against the slot region.
+
+#ifndef DISTRIBUTED_FFN_GRID_PAYLOAD_INL_HPP
+#define DISTRIBUTED_FFN_GRID_PAYLOAD_INL_HPP
+
+#include <cstdint>
+
+#include "common.hpp" // HcclRemotePtr, HcclDeviceContext
+
+namespace pto {
+namespace a2a3_grid_payload {
+
+// ---------------------------------------------------------------------------
+// RemotePtr: trivial wrapper around HcclRemotePtr, but keeps the GridTPush /
+// GridTPop callsites isolated from the HCCL header (they only see the void*
+// runtimeCtx).
+// ---------------------------------------------------------------------------
+template <typename PtrT>
+AICORE inline PtrT *RemotePtr(__gm__ void *runtimeCtx, PtrT *localPtr, int peerRank)
+{
+    auto *ctx = reinterpret_cast<__gm__ HcclDeviceContext *>(runtimeCtx);
+    uint64_t localAddr = reinterpret_cast<uint64_t>(localPtr);
+    for (uint32_t i = 0; i < ctx->rankNum && i < HCCL_MAX_RANK_NUM; ++i) {
+        uint64_t base = ctx->windowsIn[i];
+        if (localAddr >= base && localAddr < base + ctx->winSize) {
+            return reinterpret_cast<__gm__ PtrT *>(ctx->windowsIn[peerRank] + (localAddr - base));
+        }
+    }
+    return HcclRemotePtr(ctx, localPtr, peerRank);
+}
+
+// ---------------------------------------------------------------------------
+// Payload hooks.
+//
+// M3-T1: wire to TSTORE / TLOAD against a 5D ND GlobalTensor view of the
+// remote / local slot.  Tile must be UB-resident (caller TASSIGNs it before
+// the hook fires).  The Shape/Stride convention matches topk_kernel.cpp and
+// allgather_gemm_compute_kernel.cpp: dim0..2 = whole-tile element count,
+// dim3 = Cols, dim4 = 1.
+// ---------------------------------------------------------------------------
+template <typename TileT>
+AICORE inline void CopyTileToGmSlot(__gm__ uint8_t *remoteSlot, TileT &tile, int slotBytes)
+{
+    using Elem = typename TileT::DType;
+    static constexpr int kRows = TileT::Rows;
+    static constexpr int kCols = TileT::Cols;
+    static constexpr int kNumel = kRows * kCols;
+    using ShapeT = pto::Shape<1, 1, 1, kRows, kCols>;
+    using StrideT = pto::Stride<kNumel, kNumel, kNumel, kCols, 1>;
+    using GT = pto::GlobalTensor<Elem, ShapeT, StrideT, pto::Layout::ND>;
+    GT dstG(reinterpret_cast<__gm__ Elem *>(remoteSlot));
+    TSTORE(dstG, tile);
+    (void)slotBytes;
+}
+
+template <typename TileT>
+AICORE inline void CopyGmSlotToTile(TileT &tile, __gm__ uint8_t *localSlot, int slotBytes)
+{
+    using Elem = typename TileT::DType;
+    static constexpr int kRows = TileT::Rows;
+    static constexpr int kCols = TileT::Cols;
+    static constexpr int kNumel = kRows * kCols;
+    using ShapeT = pto::Shape<1, 1, 1, kRows, kCols>;
+    using StrideT = pto::Stride<kNumel, kNumel, kNumel, kCols, 1>;
+    using GT = pto::GlobalTensor<Elem, ShapeT, StrideT, pto::Layout::ND>;
+    GT srcG(reinterpret_cast<__gm__ Elem *>(localSlot));
+    TLOAD(tile, srcG);
+    (void)slotBytes;
+}
+
+} // namespace a2a3_grid_payload
+} // namespace pto
+
+#endif // DISTRIBUTED_FFN_GRID_PAYLOAD_INL_HPP

--- a/kernels/manual/a2a3/distributed_ffn_grid/gridpipe_payload_inl.hpp
+++ b/kernels/manual/a2a3/distributed_ffn_grid/gridpipe_payload_inl.hpp
@@ -8,7 +8,7 @@ INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A
 See LICENSE in the root of the software repository for the full text of the License.
 */
 
-// Per-demo payload + remote-ptr adaptor for the GridPipe A2/A3 backend.
+// Per-demo payload + neighbor-SRAM adaptor for the GridPipe A2/A3 backend.
 //
 // GridTPush.hpp / GridTPop.hpp declare three forward functions in
 // `pto::a2a3_grid_payload` that intentionally have no header-level definition,
@@ -16,92 +16,155 @@ See LICENSE in the root of the software repository for the full text of the Lice
 // that lives in this demo (not in the public header tree).  We provide those
 // definitions here once per kernel translation unit.
 //
-//   RemotePtr<T>(ctx, localPtr, peerRank)
-//     -> resolves a pointer into our own GM window to the same byte offset in
-//        peerRank's window via HcclRemotePtr.  Reused by both push and pop for
-//        the cross-rank ready/free flag writes.
+//   get_neighbor_sram_addr(...)
+//     -> resolves an address in our own SRAM window to the same byte offset in
+//        peerRank's window.  On A2/A3 this SRAM window is mocked by local GM
+//        windows and HcclRemotePtr.
 //
-//   CopyTileToGmSlot<TileT>(remoteSlot, tile, slotBytes)
-//     -> moves a UB-resident tile into a GM slot in the *neighbor's* window.
-//        Implements design doc 5.3 step 3 producer side: `tmov [r_slot], tile`.
+//   CopyTileToNeighborUbufSlot<TileT>(remoteSlot, tile, slotBytes)
+//     -> Tile-to-intrinsic adapter: extract the Tile UB pointer, then call
+//        copy_ubuf_to_neighbor_ubuf(...).
 //
-//   CopyGmSlotToTile<TileT>(tile, localSlot, slotBytes)
-//     -> moves bytes from a GM slot in our own window into a UB-resident tile.
-//        Implements design doc 5.3 step 3 consumer side.
+//   CopyNeighborUbufSlotToTile<TileT>(tile, localSlot, slotBytes)
+//     -> Tile-to-intrinsic adapter: extract the Tile UB pointer, then call
+//        copy_neighbor_ubuf_to_ubuf(...).
 //
-// The skeleton implementation uses AscendC byte-level DataCopy through
-// GlobalTensor/LocalTensor in/out of the tile's underlying address.  Real
-// silicon LPU WSE would issue a single TMOV against the slot region.
+// The skeleton implementation converts Tile descriptors to UB pointers, then
+// lets grid_sram_intrinsic.hpp choose native builtin vs A2/A3 mock lowering.
+// Keeping this adapter outside GridTPush/GridTPop preserves the generic payload
+// protocol while this demo owns the concrete PTO Tile representation.
 
 #ifndef DISTRIBUTED_FFN_GRID_PAYLOAD_INL_HPP
 #define DISTRIBUTED_FFN_GRID_PAYLOAD_INL_HPP
 
 #include <cstdint>
 
+#include <pto/common/grid_sram_intrinsic.hpp>
+
 #include "common.hpp" // HcclRemotePtr, HcclDeviceContext
 
 namespace pto {
 namespace a2a3_grid_payload {
 
-// ---------------------------------------------------------------------------
-// RemotePtr: trivial wrapper around HcclRemotePtr, but keeps the GridTPush /
-// GridTPop callsites isolated from the HCCL header (they only see the void*
-// runtimeCtx).
-// ---------------------------------------------------------------------------
-template <typename PtrT>
-AICORE inline PtrT *RemotePtr(__gm__ void *runtimeCtx, PtrT *localPtr, int peerRank)
+AICORE inline uint64_t ResolvePeerWindowAddress(__gm__ void *runtimeCtx, uint64_t localAddr, int peerRank)
 {
     auto *ctx = reinterpret_cast<__gm__ HcclDeviceContext *>(runtimeCtx);
-    uint64_t localAddr = reinterpret_cast<uint64_t>(localPtr);
     for (uint32_t i = 0; i < ctx->rankNum && i < HCCL_MAX_RANK_NUM; ++i) {
         uint64_t base = ctx->windowsIn[i];
         if (localAddr >= base && localAddr < base + ctx->winSize) {
-            return reinterpret_cast<__gm__ PtrT *>(ctx->windowsIn[peerRank] + (localAddr - base));
+            return ctx->windowsIn[peerRank] + (localAddr - base);
         }
     }
-    return HcclRemotePtr(ctx, localPtr, peerRank);
+    return reinterpret_cast<uint64_t>(HcclRemotePtr(ctx, reinterpret_cast<__gm__ void *>(localAddr), peerRank));
 }
 
-// ---------------------------------------------------------------------------
-// Payload hooks.
-//
-// M3-T1: wire to TSTORE / TLOAD against a 5D ND GlobalTensor view of the
-// remote / local slot.  Tile must be UB-resident (caller TASSIGNs it before
-// the hook fires).  The Shape/Stride convention matches topk_kernel.cpp and
-// allgather_gemm_compute_kernel.cpp: dim0..2 = whole-tile element count,
-// dim3 = Cols, dim4 = 1.
-// ---------------------------------------------------------------------------
-template <typename TileT>
-AICORE inline void CopyTileToGmSlot(__gm__ uint8_t *remoteSlot, TileT &tile, int slotBytes)
+AICORE inline neighbor_sram_addr LocalSramAddr(__gm__ uint8_t *localSlot)
 {
-    using Elem = typename TileT::DType;
-    static constexpr int kRows = TileT::Rows;
-    static constexpr int kCols = TileT::Cols;
-    static constexpr int kNumel = kRows * kCols;
-    using ShapeT = pto::Shape<1, 1, 1, kRows, kCols>;
-    using StrideT = pto::Stride<kNumel, kNumel, kNumel, kCols, 1>;
-    using GT = pto::GlobalTensor<Elem, ShapeT, StrideT, pto::Layout::ND>;
-    GT dstG(reinterpret_cast<__gm__ Elem *>(remoteSlot));
-    TSTORE(dstG, tile);
-    (void)slotBytes;
+    return neighbor_sram_addr{reinterpret_cast<uint64_t>(localSlot)};
+}
+
+AICORE inline neighbor_ubuf_addr LocalUbufAddr(__gm__ uint8_t *localSlot)
+{
+    return neighbor_ubuf_addr{reinterpret_cast<uint64_t>(localSlot)};
+}
+
+AICORE inline __gm__ uint32_t *RemoteCounterPtr(__gm__ void *runtimeCtx, __gm__ uint32_t *localCounter, int peerRank)
+{
+    uint64_t remoteAddr = ResolvePeerWindowAddress(runtimeCtx, reinterpret_cast<uint64_t>(localCounter), peerRank);
+    return reinterpret_cast<__gm__ uint32_t *>(remoteAddr);
 }
 
 template <typename TileT>
-AICORE inline void CopyGmSlotToTile(TileT &tile, __gm__ uint8_t *localSlot, int slotBytes)
+__tf__ AICORE inline void CopyTileToNeighborUbufSlot(neighbor_ubuf_addr remoteSlot, TileT &tile, int slotBytes)
 {
-    using Elem = typename TileT::DType;
-    static constexpr int kRows = TileT::Rows;
-    static constexpr int kCols = TileT::Cols;
-    static constexpr int kNumel = kRows * kCols;
-    using ShapeT = pto::Shape<1, 1, 1, kRows, kCols>;
-    using StrideT = pto::Stride<kNumel, kNumel, kNumel, kCols, 1>;
-    using GT = pto::GlobalTensor<Elem, ShapeT, StrideT, pto::Layout::ND>;
-    GT srcG(reinterpret_cast<__gm__ Elem *>(localSlot));
-    TLOAD(tile, srcG);
-    (void)slotBytes;
+    __ubuf__ void *src = reinterpret_cast<__ubuf__ void *>(__cce_get_tile_ptr(tile.data()));
+    // Producer-side cross-core payload transfer in CCE-intrinsic form.
+    copy_ubuf_to_neighbor_ubuf(remoteSlot, src, static_cast<uint32_t>(slotBytes), 0);
+}
+
+template <typename TileT>
+__tf__ AICORE inline void CopyNeighborUbufSlotToTile(TileT &tile, neighbor_ubuf_addr localSlot, int slotBytes)
+{
+    __ubuf__ void *dst = reinterpret_cast<__ubuf__ void *>(__cce_get_tile_ptr(tile.data()));
+    // Consumer-side counterpart of the same intrinsic-style payload transfer.
+    copy_neighbor_ubuf_to_ubuf(dst, localSlot, static_cast<uint32_t>(slotBytes), 0);
 }
 
 } // namespace a2a3_grid_payload
+
+namespace grid_sram_mock {
+
+AICORE inline uint64_t MockGetNeighborSramAddr(__gm__ void *runtimeCtx, uint64_t localSramAddr, int32_t peerRank)
+{
+    return a2a3_grid_payload::ResolvePeerWindowAddress(runtimeCtx, localSramAddr, peerRank);
+}
+
+AICORE inline void MockCopyUbufToNeighborUbuf(neighbor_ubuf_addr dst, __ubuf__ void *src, uint32_t bytes,
+                                              uint64_t config)
+{
+    (void)config;
+    // A2/A3 mock lowering of copy_ubuf_to_neighbor_ubuf:
+    // UB(local core) -> GM-backed peer slot window.
+    constexpr uint32_t kChunkBytes = 256;
+    auto *dstBytes = reinterpret_cast<__gm__ uint8_t *>(dst.value);
+    auto *srcBytes = reinterpret_cast<__ubuf__ uint8_t *>(src);
+    uint32_t offset = 0;
+    while (offset < bytes) {
+        uint32_t chunk = (bytes - offset > kChunkBytes) ? kChunkBytes : (bytes - offset);
+        copy_ubuf_to_gm_align_b8(dstBytes + offset, srcBytes + offset, 0, 1, chunk, 0, 0, 0, 0);
+        offset += chunk;
+    }
+}
+
+AICORE inline void MockCopyUbufToNeighborCbuf(neighbor_cbuf_addr dst, __ubuf__ void *src, uint32_t bytes,
+                                              uint64_t config)
+{
+    (void)config;
+    constexpr uint32_t kChunkBytes = 256;
+    auto *dstBytes = reinterpret_cast<__gm__ uint8_t *>(dst.value);
+    auto *srcBytes = reinterpret_cast<__ubuf__ uint8_t *>(src);
+    uint32_t offset = 0;
+    while (offset < bytes) {
+        uint32_t chunk = (bytes - offset > kChunkBytes) ? kChunkBytes : (bytes - offset);
+        copy_ubuf_to_gm_align_b8(dstBytes + offset, srcBytes + offset, 0, 1, chunk, 0, 0, 0, 0);
+        offset += chunk;
+    }
+}
+
+AICORE inline void MockCopyCbufToNeighborUbuf(neighbor_ubuf_addr dst, __cbuf__ void *src, uint32_t bytes,
+                                              uint64_t config)
+{
+    (void)config;
+    copy_cbuf_to_gm(reinterpret_cast<__gm__ uint8_t *>(dst.value), reinterpret_cast<__cbuf__ uint8_t *>(src), 0, 1,
+                    static_cast<uint16_t>(bytes), 0, 0);
+}
+
+AICORE inline void MockCopyCbufToNeighborCbuf(neighbor_cbuf_addr dst, __cbuf__ void *src, uint32_t bytes,
+                                              uint64_t config)
+{
+    (void)config;
+    copy_cbuf_to_gm(reinterpret_cast<__gm__ uint8_t *>(dst.value), reinterpret_cast<__cbuf__ uint8_t *>(src), 0, 1,
+                    static_cast<uint16_t>(bytes), 0, 0);
+}
+
+AICORE inline void MockCopyNeighborUbufToUbuf(__ubuf__ void *dst, neighbor_ubuf_addr src, uint32_t bytes,
+                                              uint64_t config)
+{
+    (void)config;
+    // A2/A3 mock lowering of copy_neighbor_ubuf_to_ubuf:
+    // GM-backed local slot window -> UB(local core).
+    constexpr uint32_t kChunkBytes = 256;
+    auto *dstBytes = reinterpret_cast<__ubuf__ uint8_t *>(dst);
+    auto *srcBytes = reinterpret_cast<__gm__ uint8_t *>(src.value);
+    uint32_t offset = 0;
+    while (offset < bytes) {
+        uint32_t chunk = (bytes - offset > kChunkBytes) ? kChunkBytes : (bytes - offset);
+        copy_gm_to_ubuf_align_b8(dstBytes + offset, srcBytes + offset, 0, 1, chunk, 0, 0, 0, 0);
+        offset += chunk;
+    }
+}
+
+} // namespace grid_sram_mock
 } // namespace pto
 
 #endif // DISTRIBUTED_FFN_GRID_PAYLOAD_INL_HPP

--- a/kernels/manual/a2a3/distributed_ffn_grid/kernel_launch.hpp
+++ b/kernels/manual/a2a3/distributed_ffn_grid/kernel_launch.hpp
@@ -1,0 +1,30 @@
+/**
+Copyright (c) 2026 Huawei Technologies Co., Ltd.
+This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+CANN Open Software License Agreement Version 2.0 (the "License").
+Please refer to the License for details. You may not use this file except in compliance with the License.
+THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+See LICENSE in the root of the software repository for the full text of the License.
+*/
+
+#ifndef DISTRIBUTED_FFN_GRID_KERNEL_LAUNCH_HPP
+#define DISTRIBUTED_FFN_GRID_KERNEL_LAUNCH_HPP
+
+#include <cstdint>
+
+// Mixed Cube/Vec kernel for the single-device multi-block FFN path.
+//
+// gridRows*gridCols blocks form a single-device logical grid.  Each block uses
+// get_block_idx() as its row-major cell id.
+//
+// The kernel is compiled for dav-c220 mixed Cube/Vector.  Cube and Vec branches
+// run concurrently and exchange gate/up/hidden/down intermediates through
+// regular A2/A3 TPipe ready/free synchronization.  The final row-local EAST
+// reduce still uses GridPipe windows.
+void launchDistributedFfnGridMixedKernel(uint8_t *ffts, uint8_t *reducePipeWindow, uint8_t *x, uint8_t *wGate,
+                                         uint8_t *wUp, uint8_t *wDown, uint8_t *gatePartial, uint8_t *upPartial,
+                                         uint8_t *hiddenIn, uint8_t *downPartial, uint8_t *yOutput, uint8_t *hcclCtx,
+                                         int gridRows, int gridCols, void *stream);
+
+#endif // DISTRIBUTED_FFN_GRID_KERNEL_LAUNCH_HPP

--- a/kernels/manual/a2a3/distributed_ffn_grid/main.cpp
+++ b/kernels/manual/a2a3/distributed_ffn_grid/main.cpp
@@ -16,6 +16,7 @@ See LICENSE in the root of the software repository for the full text of the Lice
 // windows and a fake HcclDeviceContext.
 
 #include <chrono>
+#include <climits>
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
@@ -86,20 +87,89 @@ struct DeviceResources {
     std::string dataDir = "./out";
 };
 
+static bool ParseDeviceIdValue(const char *value, int &deviceId)
+{
+    if (value == nullptr || value[0] == '\0') {
+        return false;
+    }
+
+    char *end = nullptr;
+    long parsed = std::strtol(value, &end, 10);
+    if (end == value || *end != '\0' || parsed < 0 || parsed > INT_MAX) {
+        return false;
+    }
+    deviceId = static_cast<int>(parsed);
+    return true;
+}
+
+static bool ParseDeviceIdEnv(const char *name, int &deviceId)
+{
+    const char *value = std::getenv(name);
+    if (value == nullptr || value[0] == '\0') {
+        return false;
+    }
+    if (!ParseDeviceIdValue(value, deviceId)) {
+        std::cerr << "[WARN] ignoring invalid " << name << "=" << value << std::endl;
+        return false;
+    }
+    return true;
+}
+
+static int GetDeviceId(int argc, char **argv)
+{
+    int deviceId = 0;
+    for (int i = 1; i < argc; ++i) {
+        if (std::strcmp(argv[i], "--device-id") == 0 || std::strcmp(argv[i], "-d") == 0) {
+            if (i + 1 >= argc || !ParseDeviceIdValue(argv[i + 1], deviceId)) {
+                std::cerr << "[ERROR] invalid --device-id value" << std::endl;
+                std::exit(1);
+            }
+            return deviceId;
+        }
+        constexpr const char *kPrefix = "--device-id=";
+        constexpr size_t kPrefixLen = 12;
+        if (std::strncmp(argv[i], kPrefix, kPrefixLen) == 0) {
+            if (!ParseDeviceIdValue(argv[i] + kPrefixLen, deviceId)) {
+                std::cerr << "[ERROR] invalid --device-id value" << std::endl;
+                std::exit(1);
+            }
+            return deviceId;
+        }
+    }
+
+    if (ParseDeviceIdEnv("FFN_GRID_DEVICE_ID", deviceId) || ParseDeviceIdEnv("ASCEND_DEVICE_ID", deviceId) ||
+        ParseDeviceIdEnv("DEVICE_ID", deviceId)) {
+        return deviceId;
+    }
+    return 0;
+}
+
 static bool InitAcl(int device_id)
 {
     constexpr int kAclRepeatInit = 100002;
+    std::cout << "[INFO] aclInit begin" << std::endl;
     aclError aRet = aclInit(nullptr);
     if (aRet != ACL_SUCCESS && static_cast<int>(aRet) != kAclRepeatInit) {
         std::cerr << "[ERROR] aclInit failed: " << static_cast<int>(aRet) << std::endl;
         return false;
     }
-    rtSetDevice(device_id);
+    std::cout << "[INFO] aclInit done rc=" << static_cast<int>(aRet) << std::endl;
+
+    std::cout << "[INFO] rtSetDevice(" << device_id << ") begin" << std::endl;
+    rtError_t rtRet = rtSetDevice(device_id);
+    if (rtRet != RT_ERROR_NONE) {
+        std::cerr << "[ERROR] rtSetDevice(" << device_id << ") failed: " << static_cast<int>(rtRet) << std::endl;
+        return false;
+    }
+    std::cout << "[INFO] rtSetDevice(" << device_id << ") done" << std::endl;
+
+    std::cout << "[INFO] aclrtSetDevice(" << device_id << ") begin" << std::endl;
     aRet = aclrtSetDevice(device_id);
     if (aRet != ACL_SUCCESS) {
         std::cerr << "[ERROR] aclrtSetDevice(" << device_id << ") failed: " << static_cast<int>(aRet) << std::endl;
         return false;
     }
+    std::cout << "[INFO] aclrtSetDevice(" << device_id << ") done" << std::endl;
     return true;
 }
 
@@ -423,9 +493,9 @@ static bool RunSingleDevice()
 
 int main(int argc, char **argv)
 {
-    (void)argc;
-    (void)argv;
-    if (!InitAcl(/*device_id=*/0)) {
+    int deviceId = GetDeviceId(argc, argv);
+    std::cout << "[INFO] using device " << deviceId << std::endl;
+    if (!InitAcl(deviceId)) {
         return 1;
     }
 
@@ -441,7 +511,7 @@ int main(int argc, char **argv)
     std::cout << (ok ? "[SUCCESS] Single-device multi-block FFN GridPipe PASS." :
                        "[FAILED] Single-device multi-block FFN GridPipe FAILED.")
               << std::endl;
-    aclrtResetDevice(0);
+    aclrtResetDevice(deviceId);
     aclFinalize();
     return ok ? 0 : 1;
 }

--- a/kernels/manual/a2a3/distributed_ffn_grid/main.cpp
+++ b/kernels/manual/a2a3/distributed_ffn_grid/main.cpp
@@ -1,0 +1,447 @@
+/**
+Copyright (c) 2026 Huawei Technologies Co., Ltd.
+This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+CANN Open Software License Agreement Version 2.0 (the "License").
+Please refer to the License for details. You may not use this file except in compliance with the License.
+THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+See LICENSE in the root of the software repository for the full text of the License.
+*/
+
+// Single-device multi-block FFN GridPipe driver.
+//
+// gridRows*gridCols blocks form a logical grid on one NPU.  Each cell computes
+// one model-parallel FFN shard, then cells in the same row reduce their fp32
+// down partials through a same-device GridPipe EAST mock backed by local GM
+// windows and a fake HcclDeviceContext.
+
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include "runtime/rt.h"
+#ifdef RT_STREAM_PRIORITY_DEFAULT
+#undef RT_STREAM_PRIORITY_DEFAULT
+#endif
+
+#ifdef AICORE
+#undef AICORE
+#endif
+#define AICORE
+
+#ifndef __gm__
+#define __gm__
+#endif
+
+#include "common.hpp"
+
+#ifdef DT_UNDEFINED
+#define DT_UNDEFINED_SAVED DT_UNDEFINED
+#undef DT_UNDEFINED
+#endif
+#include "test_common.h"
+#ifdef DT_UNDEFINED_SAVED
+#define DT_UNDEFINED DT_UNDEFINED_SAVED
+#undef DT_UNDEFINED_SAVED
+#endif
+
+#include "ffn_config.hpp"
+#include "kernel_launch.hpp"
+
+struct DeviceResources {
+    aclrtStream stream = nullptr;
+    void *x_dev = nullptr;
+    void *w_gate_dev = nullptr;
+    void *w_up_dev = nullptr;
+    void *w_down_dev = nullptr;
+    void *gate_partial_dev = nullptr;
+    void *up_partial_dev = nullptr;
+    void *hidden_dev = nullptr;
+    void *down_partial_dev = nullptr;
+    void *y_output_dev = nullptr;
+    void *reduce_pipe_windows_dev = nullptr;
+    void *fake_hccl_ctx_dev = nullptr;
+    uint64_t ffts = 0;
+    uint32_t fftsLen = 0;
+
+    size_t rows = static_cast<size_t>(FFN_GRID_ROWS);
+    size_t cols = static_cast<size_t>(FFN_GRID_COLS);
+    size_t cells = static_cast<size_t>(FFN_GRID_ROWS) * static_cast<size_t>(FFN_GRID_COLS);
+    size_t xBytes = 0;
+    size_t wGateBytes = 0;
+    size_t wUpBytes = 0;
+    size_t wDownBytes = 0;
+    size_t gatePartialBytes = 0;
+    size_t upPartialBytes = 0;
+    size_t hiddenBytes = 0;
+    size_t downPartialBytes = 0;
+    size_t yOutputBytes = 0;
+    size_t reducePipeBytes = 0;
+
+    std::string dataDir = "./out";
+};
+
+static bool InitAcl(int device_id)
+{
+    constexpr int kAclRepeatInit = 100002;
+    aclError aRet = aclInit(nullptr);
+    if (aRet != ACL_SUCCESS && static_cast<int>(aRet) != kAclRepeatInit) {
+        std::cerr << "[ERROR] aclInit failed: " << static_cast<int>(aRet) << std::endl;
+        return false;
+    }
+    rtSetDevice(device_id);
+    aRet = aclrtSetDevice(device_id);
+    if (aRet != ACL_SUCCESS) {
+        std::cerr << "[ERROR] aclrtSetDevice(" << device_id << ") failed: " << static_cast<int>(aRet) << std::endl;
+        return false;
+    }
+    return true;
+}
+
+static bool InitLocalGridPipeContext(DeviceResources &r)
+{
+    r.reducePipeBytes = r.cells * static_cast<size_t>(FFN_GRID_WINDOW_BYTES);
+    if (aclrtMalloc(&r.reduce_pipe_windows_dev, r.reducePipeBytes, ACL_MEM_MALLOC_HUGE_FIRST) != ACL_SUCCESS) {
+        std::cerr << "[ERROR] aclrtMalloc(reduce_pipe_windows) failed" << std::endl;
+        return false;
+    }
+    aclrtMemset(r.reduce_pipe_windows_dev, r.reducePipeBytes, 0, r.reducePipeBytes);
+
+    HcclDeviceContext hostCtx{};
+    hostCtx.rankId = 0;
+    hostCtx.rankNum = static_cast<uint32_t>(r.cells);
+    hostCtx.winSize = static_cast<uint64_t>(FFN_GRID_WINDOW_BYTES);
+    uint64_t base = reinterpret_cast<uint64_t>(r.reduce_pipe_windows_dev);
+    for (size_t i = 0; i < r.cells && i < HCCL_MAX_RANK_NUM; ++i) {
+        hostCtx.windowsIn[i] = base + i * static_cast<size_t>(FFN_GRID_WINDOW_BYTES);
+        hostCtx.windowsOut[i] = hostCtx.windowsIn[i];
+    }
+
+    if (aclrtMalloc(&r.fake_hccl_ctx_dev, sizeof(HcclDeviceContext), ACL_MEM_MALLOC_HUGE_FIRST) != ACL_SUCCESS) {
+        std::cerr << "[ERROR] aclrtMalloc(fake_hccl_ctx) failed" << std::endl;
+        return false;
+    }
+    if (aclrtMemcpy(r.fake_hccl_ctx_dev, sizeof(HcclDeviceContext), &hostCtx, sizeof(HcclDeviceContext),
+                    ACL_MEMCPY_HOST_TO_DEVICE) != ACL_SUCCESS) {
+        std::cerr << "[ERROR] aclrtMemcpy(fake_hccl_ctx) failed" << std::endl;
+        return false;
+    }
+    return true;
+}
+
+static bool AllocateResources(DeviceResources &r)
+{
+    if (r.cells == 0 || r.cells > HCCL_MAX_RANK_NUM) {
+        std::cerr << "[ERROR] invalid cell count " << r.cells << "; supported range is 1.." << HCCL_MAX_RANK_NUM
+                  << std::endl;
+        return false;
+    }
+    if (const char *env = std::getenv("FFN_GRID_DATA_DIR")) {
+        r.dataDir = env;
+    }
+
+    if (aclrtCreateStream(&r.stream) != ACL_SUCCESS) {
+        std::cerr << "[ERROR] aclrtCreateStream failed" << std::endl;
+        return false;
+    }
+
+    r.xBytes = r.cells * static_cast<size_t>(FFN_X_BYTES);
+    r.wGateBytes = r.cells * static_cast<size_t>(FFN_W_GATE_BYTES);
+    r.wUpBytes = r.cells * static_cast<size_t>(FFN_W_UP_BYTES);
+    r.wDownBytes = r.cells * static_cast<size_t>(FFN_W_DOWN_BYTES);
+    r.gatePartialBytes = r.cells * static_cast<size_t>(FFN_GATE_PARTIAL_BYTES);
+    r.upPartialBytes = r.cells * static_cast<size_t>(FFN_UP_PARTIAL_BYTES);
+    r.hiddenBytes = r.cells * static_cast<size_t>(FFN_HIDDEN_BYTES);
+    r.downPartialBytes = r.cells * static_cast<size_t>(FFN_DOWN_PARTIAL_BYTES);
+    r.yOutputBytes = r.rows * static_cast<size_t>(FFN_Y_OUTPUT_BYTES);
+
+    aclrtMalloc(&r.x_dev, r.xBytes, ACL_MEM_MALLOC_HUGE_FIRST);
+    aclrtMalloc(&r.w_gate_dev, r.wGateBytes, ACL_MEM_MALLOC_HUGE_FIRST);
+    aclrtMalloc(&r.w_up_dev, r.wUpBytes, ACL_MEM_MALLOC_HUGE_FIRST);
+    aclrtMalloc(&r.w_down_dev, r.wDownBytes, ACL_MEM_MALLOC_HUGE_FIRST);
+    aclrtMalloc(&r.gate_partial_dev, r.gatePartialBytes, ACL_MEM_MALLOC_HUGE_FIRST);
+    aclrtMalloc(&r.up_partial_dev, r.upPartialBytes, ACL_MEM_MALLOC_HUGE_FIRST);
+    aclrtMalloc(&r.hidden_dev, r.hiddenBytes, ACL_MEM_MALLOC_HUGE_FIRST);
+    aclrtMalloc(&r.down_partial_dev, r.downPartialBytes, ACL_MEM_MALLOC_HUGE_FIRST);
+    aclrtMalloc(&r.y_output_dev, r.yOutputBytes, ACL_MEM_MALLOC_HUGE_FIRST);
+
+    if (!r.x_dev || !r.w_gate_dev || !r.w_up_dev || !r.w_down_dev || !r.gate_partial_dev || !r.up_partial_dev ||
+        !r.hidden_dev || !r.down_partial_dev || !r.y_output_dev) {
+        std::cerr << "[ERROR] aclrtMalloc failed" << std::endl;
+        return false;
+    }
+
+    aclrtMemset(r.x_dev, r.xBytes, 0, r.xBytes);
+    aclrtMemset(r.gate_partial_dev, r.gatePartialBytes, 0, r.gatePartialBytes);
+    aclrtMemset(r.up_partial_dev, r.upPartialBytes, 0, r.upPartialBytes);
+    aclrtMemset(r.hidden_dev, r.hiddenBytes, 0, r.hiddenBytes);
+    aclrtMemset(r.down_partial_dev, r.downPartialBytes, 0, r.downPartialBytes);
+    aclrtMemset(r.y_output_dev, r.yOutputBytes, 0, r.yOutputBytes);
+
+    if (!InitLocalGridPipeContext(r)) {
+        return false;
+    }
+
+    rtGetC2cCtrlAddr(&r.ffts, &r.fftsLen);
+    if (r.ffts == 0) {
+        std::cerr << "[ERROR] rtGetC2cCtrlAddr returned null FFTS address" << std::endl;
+        return false;
+    }
+
+    std::cout << "[INFO] grid=" << r.rows << "x" << r.cols << " cells=" << r.cells << " dataDir=" << r.dataDir
+              << " reducePipeBytes=" << r.reducePipeBytes << " yOutputBytes=" << r.yOutputBytes << std::endl;
+    return true;
+}
+
+static bool LoadInputs(DeviceResources &r)
+{
+    std::vector<uint8_t> hostX(r.xBytes);
+    for (size_t cell = 0; cell < r.cells; ++cell) {
+        std::string xPath = r.dataDir + "/pe_" + std::to_string(cell) + "_x.bin";
+        size_t fileSize = 0;
+        uint8_t *dst = hostX.data() + cell * static_cast<size_t>(FFN_X_BYTES);
+        if (!PtoTestCommon::ReadFile(xPath, fileSize, dst, static_cast<size_t>(FFN_X_BYTES)) ||
+            fileSize != static_cast<size_t>(FFN_X_BYTES)) {
+            std::cerr << "[ERROR] X file load mismatch: " << xPath << " (got " << fileSize << " bytes, expected "
+                      << FFN_X_BYTES << ")" << std::endl;
+            return false;
+        }
+    }
+    if (aclrtMemcpy(r.x_dev, r.xBytes, hostX.data(), r.xBytes, ACL_MEMCPY_HOST_TO_DEVICE) != ACL_SUCCESS) {
+        std::cerr << "[ERROR] aclrtMemcpy(x_dev) failed" << std::endl;
+        return false;
+    }
+    return true;
+}
+
+static bool LoadWeights(DeviceResources &r)
+{
+    struct WeightSpec {
+        const char *suffix;
+        void *dev;
+        size_t tileBytes;
+        size_t totalBytes;
+    };
+    WeightSpec specs[] = {
+        {"_w_gate.bin", r.w_gate_dev, static_cast<size_t>(FFN_W_GATE_BYTES), r.wGateBytes},
+        {"_w_up.bin", r.w_up_dev, static_cast<size_t>(FFN_W_UP_BYTES), r.wUpBytes},
+        {"_w_down.bin", r.w_down_dev, static_cast<size_t>(FFN_W_DOWN_BYTES), r.wDownBytes},
+    };
+
+    for (const auto &w : specs) {
+        std::vector<uint8_t> hostBuf(w.totalBytes);
+        for (size_t cell = 0; cell < r.cells; ++cell) {
+            std::string path = r.dataDir + "/pe_" + std::to_string(cell) + w.suffix;
+            size_t fileSize = 0;
+            uint8_t *dst = hostBuf.data() + cell * w.tileBytes;
+            if (!PtoTestCommon::ReadFile(path, fileSize, dst, w.tileBytes) || fileSize != w.tileBytes) {
+                std::cerr << "[ERROR] weight load mismatch: " << path << " (got " << fileSize << " bytes, expected "
+                          << w.tileBytes << ")" << std::endl;
+                return false;
+            }
+        }
+        if (aclrtMemcpy(w.dev, w.totalBytes, hostBuf.data(), w.totalBytes, ACL_MEMCPY_HOST_TO_DEVICE) != ACL_SUCCESS) {
+            std::cerr << "[ERROR] aclrtMemcpy(weight " << w.suffix << ") failed" << std::endl;
+            return false;
+        }
+    }
+    return true;
+}
+
+static bool VerifyOutput(DeviceResources &r)
+{
+    const size_t outputElems = r.rows * static_cast<size_t>(FFN_TILE_ELEMS);
+    const size_t outputBytes = r.rows * static_cast<size_t>(FFN_Y_OUTPUT_BYTES);
+
+    std::vector<float> outHost(outputElems);
+    if (aclrtMemcpy(outHost.data(), outputBytes, r.y_output_dev, outputBytes, ACL_MEMCPY_DEVICE_TO_HOST) !=
+        ACL_SUCCESS) {
+        std::cerr << "[ERROR] y_output D2H memcpy failed" << std::endl;
+        return false;
+    }
+
+    std::string goldenPath = r.dataDir + "/golden.bin";
+    std::vector<float> golden(outputElems);
+    size_t fileSize = 0;
+    if (!PtoTestCommon::ReadFile(goldenPath, fileSize, golden.data(), outputBytes) || fileSize != outputBytes) {
+        std::cerr << "[ERROR] golden.bin mismatch: " << goldenPath << " (got " << fileSize << " bytes, expected "
+                  << outputBytes << ")" << std::endl;
+        return false;
+    }
+
+    std::cout << "[INFO] ResultCmp single-device GridPipe EAST-reduced output vs golden:" << std::endl;
+    return PtoTestCommon::ResultCmp(golden, outHost.data(), 0.001f);
+}
+
+static const char *GridPipeFaultName(uint32_t code)
+{
+    switch (code) {
+        case 0x101:
+            return "push north boundary";
+        case 0x102:
+            return "push east boundary";
+        case 0x103:
+            return "push west boundary";
+        case 0x104:
+            return "push source boundary";
+        case 0x201:
+            return "pop north boundary";
+        case 0x202:
+            return "pop east boundary";
+        case 0x203:
+            return "pop west boundary";
+        case 0x301:
+            return "wait ready timeout";
+        case 0x302:
+            return "wait free timeout";
+        default:
+            return "unknown";
+    }
+}
+
+static bool CheckGridPipeFaults(DeviceResources &r)
+{
+    constexpr size_t kFlagWordsPerWindow = static_cast<size_t>(FFN_GRID_FLAGS_BYTES) / sizeof(uint32_t);
+    std::vector<uint32_t> flags(r.cells * kFlagWordsPerWindow, 0);
+    for (size_t cell = 0; cell < r.cells; ++cell) {
+        auto *src = reinterpret_cast<uint8_t *>(r.reduce_pipe_windows_dev) + cell * FFN_GRID_WINDOW_BYTES;
+        auto *dst = flags.data() + cell * kFlagWordsPerWindow;
+        if (aclrtMemcpy(dst, kFlagWordsPerWindow * sizeof(uint32_t), src, kFlagWordsPerWindow * sizeof(uint32_t),
+                        ACL_MEMCPY_DEVICE_TO_HOST) != ACL_SUCCESS) {
+            std::cerr << "[ERROR] GridPipe flag D2H memcpy failed for cell " << cell << std::endl;
+            return false;
+        }
+    }
+
+    bool ok = true;
+    for (size_t cell = 0; cell < r.cells; ++cell) {
+        size_t row = cell / r.cols;
+        size_t col = cell - row * r.cols;
+        const uint32_t *cellFlags = flags.data() + cell * kFlagWordsPerWindow;
+        for (size_t i = 0; i < kFlagWordsPerWindow; ++i) {
+            uint32_t value = cellFlags[i];
+            if (value >= 0x100U) {
+                std::cerr << "[ERROR] GridPipe fault cell=" << cell << " row=" << row << " col=" << col
+                          << " flagWord=" << i << " code=0x" << std::hex << value << std::dec << " ("
+                          << GridPipeFaultName(value) << ")" << std::endl;
+                ok = false;
+            }
+        }
+    }
+    return ok;
+}
+
+static void Cleanup(DeviceResources &r)
+{
+    if (r.fake_hccl_ctx_dev) {
+        aclrtFree(r.fake_hccl_ctx_dev);
+        r.fake_hccl_ctx_dev = nullptr;
+    }
+    if (r.reduce_pipe_windows_dev) {
+        aclrtFree(r.reduce_pipe_windows_dev);
+        r.reduce_pipe_windows_dev = nullptr;
+    }
+    if (r.w_gate_dev) {
+        aclrtFree(r.w_gate_dev);
+        r.w_gate_dev = nullptr;
+    }
+    if (r.w_up_dev) {
+        aclrtFree(r.w_up_dev);
+        r.w_up_dev = nullptr;
+    }
+    if (r.w_down_dev) {
+        aclrtFree(r.w_down_dev);
+        r.w_down_dev = nullptr;
+    }
+    if (r.x_dev) {
+        aclrtFree(r.x_dev);
+        r.x_dev = nullptr;
+    }
+    if (r.gate_partial_dev) {
+        aclrtFree(r.gate_partial_dev);
+        r.gate_partial_dev = nullptr;
+    }
+    if (r.up_partial_dev) {
+        aclrtFree(r.up_partial_dev);
+        r.up_partial_dev = nullptr;
+    }
+    if (r.hidden_dev) {
+        aclrtFree(r.hidden_dev);
+        r.hidden_dev = nullptr;
+    }
+    if (r.down_partial_dev) {
+        aclrtFree(r.down_partial_dev);
+        r.down_partial_dev = nullptr;
+    }
+    if (r.y_output_dev) {
+        aclrtFree(r.y_output_dev);
+        r.y_output_dev = nullptr;
+    }
+    if (r.stream) {
+        aclrtDestroyStream(r.stream);
+        r.stream = nullptr;
+    }
+}
+
+static bool RunSingleDevice()
+{
+    DeviceResources r;
+    if (!AllocateResources(r) || !LoadInputs(r) || !LoadWeights(r)) {
+        Cleanup(r);
+        return false;
+    }
+
+    auto t0 = std::chrono::high_resolution_clock::now();
+
+    launchDistributedFfnGridMixedKernel(
+        reinterpret_cast<uint8_t *>(r.ffts), reinterpret_cast<uint8_t *>(r.reduce_pipe_windows_dev),
+        reinterpret_cast<uint8_t *>(r.x_dev), reinterpret_cast<uint8_t *>(r.w_gate_dev),
+        reinterpret_cast<uint8_t *>(r.w_up_dev), reinterpret_cast<uint8_t *>(r.w_down_dev),
+        reinterpret_cast<uint8_t *>(r.gate_partial_dev), reinterpret_cast<uint8_t *>(r.up_partial_dev),
+        reinterpret_cast<uint8_t *>(r.hidden_dev), reinterpret_cast<uint8_t *>(r.down_partial_dev),
+        reinterpret_cast<uint8_t *>(r.y_output_dev), reinterpret_cast<uint8_t *>(r.fake_hccl_ctx_dev), FFN_GRID_ROWS,
+        FFN_GRID_COLS, r.stream);
+    aclError mixedRet = aclrtSynchronizeStream(r.stream);
+    bool gridPipeOk = (mixedRet == ACL_SUCCESS) && CheckGridPipeFaults(r);
+
+    auto t1 = std::chrono::high_resolution_clock::now();
+    double us = std::chrono::duration<double, std::micro>(t1 - t0).count();
+    std::cout << "[INFO] launch+sync " << us << " us  (mixed rc=" << static_cast<int>(mixedRet)
+              << " gridpipe_ok=" << (gridPipeOk ? 1 : 0);
+    std::cout << ")" << std::endl;
+
+    bool syncOk = (mixedRet == ACL_SUCCESS) && gridPipeOk;
+    bool verifyOk = syncOk && VerifyOutput(r);
+    Cleanup(r);
+    return syncOk && verifyOk;
+}
+
+int main(int argc, char **argv)
+{
+    (void)argc;
+    (void)argv;
+    if (!InitAcl(/*device_id=*/0)) {
+        return 1;
+    }
+
+    std::cout << "\n================================================================" << std::endl;
+    std::cout << "  Single-device multi-block FFN GridPipe demo" << std::endl;
+    std::cout << "  grid=" << FFN_GRID_ROWS << "x" << FFN_GRID_COLS << " cells=" << (FFN_GRID_ROWS * FFN_GRID_COLS)
+              << " tile=" << FFN_TOKEN_TILE << "x" << FFN_MODEL_TILE << " ffnTile=" << FFN_FFN_TILE << std::endl;
+    std::cout << "  Mode: row=data-parallel, col=model-parallel on one device; EAST reduce uses local GM windows"
+              << std::endl;
+    std::cout << "================================================================" << std::endl;
+
+    bool ok = RunSingleDevice();
+    std::cout << (ok ? "[SUCCESS] Single-device multi-block FFN GridPipe PASS." :
+                       "[FAILED] Single-device multi-block FFN GridPipe FAILED.")
+              << std::endl;
+    aclrtResetDevice(0);
+    aclFinalize();
+    return ok ? 0 : 1;
+}

--- a/kernels/manual/a2a3/distributed_ffn_grid/run.sh
+++ b/kernels/manual/a2a3/distributed_ffn_grid/run.sh
@@ -1,0 +1,111 @@
+#!/bin/bash
+# --------------------------------------------------------------------------------
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# --------------------------------------------------------------------------------
+
+# Single-device multi-block FFN GridPipe demo.  grid-rows x grid-cols is the
+# logical grid launched on one NPU.  Columns are model-parallel FFN shards and
+# reduce through the same-device GridPipe EAST mock.
+
+: "${ASCEND_CANN_PATH:=$(ls -1d /usr/local/Ascend/cann-*/set_env.sh 2>/dev/null | sort -V | tail -1)}"
+if [ -z "${ASCEND_CANN_PATH}" ]; then
+    echo "[ERROR] Cannot find CANN set_env.sh.  Set ASCEND_CANN_PATH explicitly."
+    exit 1
+fi
+source "${ASCEND_CANN_PATH}"
+
+SHORT=r:,v:,n:
+LONG=run-mode:,soc-version:,n-ranks:,grid-rows:,grid-cols:,token-tile:,model-tile:,ffn-tile:,build-only
+OPTS=$(getopt -a --options $SHORT --longoptions $LONG -- "$@")
+eval set -- "$OPTS"
+
+BUILD_ONLY=0
+while :; do
+    case "$1" in
+        (-r | --run-mode)    RUN_MODE="$2"; shift 2;;
+        (-v | --soc-version) SOC_VERSION="$2"; shift 2;;
+        (-n | --n-ranks)     N_RANKS="$2"; shift 2;;
+        (--grid-rows)        GRID_ROWS="$2"; shift 2;;
+        (--grid-cols)        GRID_COLS="$2"; shift 2;;
+        (--token-tile)       TOKEN_TILE="$2"; shift 2;;
+        (--model-tile)       MODEL_TILE="$2"; shift 2;;
+        (--ffn-tile)         FFN_TILE="$2"; shift 2;;
+        (--build-only)       BUILD_ONLY=1; shift;;
+        (--) shift; break;;
+        (*) echo "[ERROR] Unexpected option: $1"; exit 1;;
+    esac
+done
+
+: "${RUN_MODE:=npu}"
+: "${SOC_VERSION:=Ascend910B1}"
+: "${GRID_ROWS:=2}"
+: "${GRID_COLS:=2}"
+: "${TOKEN_TILE:=16}"
+: "${MODEL_TILE:=64}"
+: "${FFN_TILE:=64}"
+: "${N_RANKS:=1}"
+
+if [ "${N_RANKS}" -ne 1 ]; then
+    echo "[ERROR] Single-device multi-block mode requires -n/--n-ranks 1."
+    exit 1
+fi
+
+if [[ ! "${SOC_VERSION}" =~ ^Ascend ]]; then
+    echo "[ERROR] Unsupported SocVersion: ${SOC_VERSION}"
+    exit 1
+fi
+if [[ "${SOC_VERSION}" =~ ^Ascend910B4-1 ]] && [ "${RUN_MODE}" == "sim" ]; then
+    echo "[ERROR] SocVersion: ${SOC_VERSION} can not support sim mode, please use Ascend910B4."
+    exit 1
+fi
+
+rm -rf /dev/shm/sem.hccl* 2>/dev/null
+ipcrm -a 2>/dev/null
+
+echo "=== Single-device Multi-block FFN GridPipe Demo ==="
+echo "  RUN_MODE: ${RUN_MODE}  SOC_VERSION: ${SOC_VERSION}"
+echo "  Grid: ${GRID_ROWS}x${GRID_COLS}  N_RANKS: ${N_RANKS}"
+echo "  Tile: ${TOKEN_TILE}x${MODEL_TILE}  FfnTile: ${FFN_TILE}"
+echo "==================================================="
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+cd "${SCRIPT_DIR}"
+
+# Regenerate per-cell inputs + golden before running.  The host maps all
+# grid_rows * grid_cols cells to blocks on device 0.
+if [ "${BUILD_ONLY}" -eq 0 ]; then
+    python3 "${SCRIPT_DIR}/scripts/gen_data.py" \
+        --grid-rows "${GRID_ROWS}" --grid-cols "${GRID_COLS}" \
+        --t "${TOKEN_TILE}" --h "${MODEL_TILE}" --fi "${FFN_TILE}" \
+        --output-dir "${SCRIPT_DIR}/out"
+fi
+
+rm -rf build
+mkdir build
+cd build
+
+export LD_LIBRARY_PATH=${ASCEND_HOME_PATH}/tools/simulator/${SOC_VERSION}/lib:${LD_LIBRARY_PATH:-}
+set -euo pipefail
+
+cmake -DRUN_MODE=${RUN_MODE} -DSOC_VERSION=${SOC_VERSION} \
+      -DGRID_ROWS=${GRID_ROWS} -DGRID_COLS=${GRID_COLS} \
+      -DTOKEN_TILE=${TOKEN_TILE} -DMODEL_TILE=${MODEL_TILE} -DFFN_TILE=${FFN_TILE} \
+      ..
+make -j16
+
+if [ "${BUILD_ONLY}" -eq 1 ]; then
+    echo "[INFO] --build-only requested; skipping run."
+    exit 0
+fi
+
+echo ""
+echo "=== Running Single-device Multi-block FFN GridPipe ==="
+export N_RANKS=${N_RANKS}
+export FFN_GRID_DATA_DIR="${SCRIPT_DIR}/out"
+./distributed_ffn_grid

--- a/kernels/manual/a2a3/distributed_ffn_grid/run.sh
+++ b/kernels/manual/a2a3/distributed_ffn_grid/run.sh
@@ -20,8 +20,8 @@ if [ -z "${ASCEND_CANN_PATH}" ]; then
 fi
 source "${ASCEND_CANN_PATH}"
 
-SHORT=r:,v:,n:
-LONG=run-mode:,soc-version:,n-ranks:,grid-rows:,grid-cols:,token-tile:,model-tile:,ffn-tile:,build-only
+SHORT=r:,v:,n:,d:
+LONG=run-mode:,soc-version:,n-ranks:,device-id:,grid-rows:,grid-cols:,token-tile:,model-tile:,ffn-tile:,build-only
 OPTS=$(getopt -a --options $SHORT --longoptions $LONG -- "$@")
 eval set -- "$OPTS"
 
@@ -31,6 +31,7 @@ while :; do
         (-r | --run-mode)    RUN_MODE="$2"; shift 2;;
         (-v | --soc-version) SOC_VERSION="$2"; shift 2;;
         (-n | --n-ranks)     N_RANKS="$2"; shift 2;;
+        (-d | --device-id)   DEVICE_ID="$2"; shift 2;;
         (--grid-rows)        GRID_ROWS="$2"; shift 2;;
         (--grid-cols)        GRID_COLS="$2"; shift 2;;
         (--token-tile)       TOKEN_TILE="$2"; shift 2;;
@@ -50,6 +51,7 @@ done
 : "${MODEL_TILE:=64}"
 : "${FFN_TILE:=64}"
 : "${N_RANKS:=1}"
+: "${DEVICE_ID:=${FFN_GRID_DEVICE_ID:-${ASCEND_DEVICE_ID:-${DEVICE_ID:-0}}}}"
 
 if [ "${N_RANKS}" -ne 1 ]; then
     echo "[ERROR] Single-device multi-block mode requires -n/--n-ranks 1."
@@ -70,7 +72,7 @@ ipcrm -a 2>/dev/null
 
 echo "=== Single-device Multi-block FFN GridPipe Demo ==="
 echo "  RUN_MODE: ${RUN_MODE}  SOC_VERSION: ${SOC_VERSION}"
-echo "  Grid: ${GRID_ROWS}x${GRID_COLS}  N_RANKS: ${N_RANKS}"
+echo "  Grid: ${GRID_ROWS}x${GRID_COLS}  N_RANKS: ${N_RANKS}  DEVICE_ID: ${DEVICE_ID}"
 echo "  Tile: ${TOKEN_TILE}x${MODEL_TILE}  FfnTile: ${FFN_TILE}"
 echo "==================================================="
 
@@ -78,7 +80,7 @@ SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
 cd "${SCRIPT_DIR}"
 
 # Regenerate per-cell inputs + golden before running.  The host maps all
-# grid_rows * grid_cols cells to blocks on device 0.
+# grid_rows * grid_cols cells to blocks on the selected single device.
 if [ "${BUILD_ONLY}" -eq 0 ]; then
     python3 "${SCRIPT_DIR}/scripts/gen_data.py" \
         --grid-rows "${GRID_ROWS}" --grid-cols "${GRID_COLS}" \
@@ -108,4 +110,4 @@ echo ""
 echo "=== Running Single-device Multi-block FFN GridPipe ==="
 export N_RANKS=${N_RANKS}
 export FFN_GRID_DATA_DIR="${SCRIPT_DIR}/out"
-./distributed_ffn_grid
+./distributed_ffn_grid --device-id "${DEVICE_ID}"

--- a/kernels/manual/a2a3/distributed_ffn_grid/scripts/gen_data.py
+++ b/kernels/manual/a2a3/distributed_ffn_grid/scripts/gen_data.py
@@ -1,0 +1,175 @@
+#!/usr/bin/python3
+# coding=utf-8
+# -----------------------------------------------------------------------------------------------------------
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+#
+# Data generator for distributed FFN GridPipe demo.
+#
+# Layout (M4: grid_rows x grid_cols, row = data-parallel, col = model-parallel):
+#   T_total = T_per_row * grid_rows           (rows do not share tokens)
+#   F_total = Fi_per_col * grid_cols          (cols shard the intermediate dim)
+#   Rank r = row * grid_cols + col            (row-major)
+#   Row's token slice  : X_full[row*T : (row+1)*T, :]   shape [T, H]
+#   Col's weight slice : W_gate_full[:, col*Fi:(col+1)*Fi]   etc.
+#
+# Per-rank file layout (fp16 weights / inputs, fp32 golden):
+#   pe_<r>_x.bin       - X       [T, H]    fp16 row-major   -- shared across cols of a row
+#   pe_<r>_w_gate.bin  - W_gate  [H, Fi]   fp16 row-major   -- shared across rows of a col
+#   pe_<r>_w_up.bin    - W_up    [H, Fi]   fp16 row-major
+#   pe_<r>_w_down.bin  - W_down  [Fi, H]   fp16 row-major
+#   golden.bin         - y       [T_total, H]  fp32         -- full output; each row reads its slice
+#
+# golden = (PReLU((X_full @ W_gate_full) * (X_full @ W_up_full), alpha=0.1)) @ W_down_full
+#   W_gate_full = hstack(W_gate(col) for col in cols)   shape [H, F_total]
+#   W_up_full   = hstack(W_up(col)   for col in cols)
+#   W_down_full = vstack(W_down(col) for col in cols)   shape [F_total, H]
+#
+# Compatibility note:
+#   When --grid-rows 1 (M3 1xN), behaviour is byte-identical to the previous
+#   1xN generator: T_total == T_per_row, X is shared across all ranks, golden
+#   is [T, H] fp32.
+#
+# Kernel contract (D-2 / D-6):
+#   - alpha = 0.1.  If kernel hard-codes a different alpha, update BOTH sides.
+#   - Byte sizes must match ffn_config.hpp host mirrors (FFN_W_GATE_BYTES etc.).
+#   - fp16 weights, fp32 golden, 1e-3 absolute tolerance in PtoTestCommon::ResultCmp.
+#
+# Usage (M4 2x2):
+#   python3 gen_data.py --grid-rows 2 --grid-cols 2 --t 16 --h 64 --fi 64 --output-dir ./out
+# Usage (M3 1x2 back-compat via --n-ranks):
+#   python3 gen_data.py --n-ranks 2 --t 16 --h 64 --fi 64 --output-dir ./out
+
+import os
+import argparse
+from dataclasses import dataclass
+
+import numpy as np
+
+np.random.seed(19)
+
+PRELU_ALPHA = 0.1
+
+
+@dataclass
+class FfnDataConfig:
+    """Per-rank dimensions; total intermediate F = fi * grid_cols, total T = t * grid_rows."""
+
+    t: int           # token count per row (== FFN_TOKEN_TILE)
+    h: int           # hidden dim (== FFN_MODEL_TILE)
+    fi: int          # per-rank intermediate dim per col (== FFN_FFN_TILE)
+    grid_rows: int
+    grid_cols: int
+    output_dir: str = "./out"
+
+
+def _prelu(x: np.ndarray, alpha: float = PRELU_ALPHA) -> np.ndarray:
+    return np.where(x > 0, x, alpha * x)
+
+
+def gen_data(cfg: FfnDataConfig) -> None:
+    t, h, fi = cfg.t, cfg.h, cfg.fi
+    grid_rows, grid_cols = cfg.grid_rows, cfg.grid_cols
+    n_ranks = grid_rows * grid_cols
+    t_total = t * grid_rows
+    f_total = fi * grid_cols
+    os.makedirs(cfg.output_dir, exist_ok=True)
+
+    src_type = np.float16
+    dst_type = np.float32
+
+    # Inputs in {0, 1}: keeps fp16 (gate * up) below fp16 max (~65504).
+    # With H = 64 the elementwise hidden ≤ H = 64, hidden*hidden ≤ 4096 safe.
+    x_full = np.random.randint(0, 2, [t_total, h]).astype(src_type)
+    w_gate_full = np.random.randint(0, 2, [h, f_total]).astype(src_type)
+    w_up_full   = np.random.randint(0, 2, [h, f_total]).astype(src_type)
+    w_down_full = np.random.randint(0, 2, [f_total, h]).astype(src_type)
+
+    # Reference computation in fp32.  Down-cast inputs to fp32 for the math
+    # but persist weights in fp16 (kernel side TLOADs fp16 -> mixed-precision
+    # matmul).
+    x_f32 = x_full.astype(dst_type)
+    gate_full = x_f32 @ w_gate_full.astype(dst_type)
+    up_full   = x_f32 @ w_up_full.astype(dst_type)
+    act_full  = _prelu(gate_full * up_full, PRELU_ALPHA)
+    golden    = (act_full @ w_down_full.astype(dst_type)).astype(dst_type)
+
+    for row in range(grid_rows):
+        t_start = row * t
+        t_end = t_start + t
+        x_row = x_full[t_start:t_end, :]
+
+        for col in range(grid_cols):
+            rank = row * grid_cols + col
+            fi_start = col * fi
+            fi_end = fi_start + fi
+
+            x_path       = os.path.join(cfg.output_dir, f"pe_{rank}_x.bin")
+            w_gate_path  = os.path.join(cfg.output_dir, f"pe_{rank}_w_gate.bin")
+            w_up_path    = os.path.join(cfg.output_dir, f"pe_{rank}_w_up.bin")
+            w_down_path  = os.path.join(cfg.output_dir, f"pe_{rank}_w_down.bin")
+
+            # X is the same for every col rank within the same row.
+            x_row.tofile(x_path)
+            w_gate_full[:, fi_start:fi_end].astype(src_type).tofile(w_gate_path)
+            w_up_full[:, fi_start:fi_end].astype(src_type).tofile(w_up_path)
+            w_down_full[fi_start:fi_end, :].astype(src_type).tofile(w_down_path)
+
+            label = "block" if grid_cols == 1 else "rank"
+            print(f"  - {label}{rank} (row={row},col={col}): x{tuple(x_row.shape)} -> {x_path}")
+            print(f"             w_gate[{h},{fi}] -> {w_gate_path}")
+            print(f"             w_up[{h},{fi}]   -> {w_up_path}")
+            print(f"             w_down[{fi},{h}] -> {w_down_path}")
+
+    golden_path = os.path.join(cfg.output_dir, "golden.bin")
+    golden.tofile(golden_path)
+    print(f"  - golden{tuple(golden.shape)} fp32 -> {golden_path}")
+    print(
+        f"[INFO] Generated FFN data: T={t} (T_total={t_total}) H={h} Fi={fi} (F_total={f_total}) "
+        f"grid={grid_rows}x{grid_cols} n_ranks={n_ranks}"
+    )
+    print(f"[INFO] alpha={PRELU_ALPHA} (must match kernel TLRELU constant FFN_PRELU_ALPHA)")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Generate data for distributed FFN GridPipe demo")
+    parser.add_argument("--grid-rows", type=int, default=None,
+                        help="Grid rows (M4 2D layout).  If omitted, falls back to --n-ranks (1xN).")
+    parser.add_argument("--grid-cols", type=int, default=None,
+                        help="Grid cols (M4 2D layout).  If omitted, falls back to --n-ranks (1xN).")
+    parser.add_argument("--n-ranks", type=int, default=2,
+                        help="Back-compat: total ranks for 1xN grid (used when --grid-rows/--grid-cols absent)")
+    parser.add_argument("--t", type=int, required=True, help="Token count per row (T)")
+    parser.add_argument("--h", type=int, required=True, help="Hidden dim (H)")
+    parser.add_argument("--fi", type=int, required=True, help="Per-rank intermediate dim per col (Fi)")
+    parser.add_argument("--output-dir", type=str, default="./out", help="Output directory")
+
+    args = parser.parse_args()
+    if args.grid_rows is None and args.grid_cols is None:
+        grid_rows = 1
+        grid_cols = args.n_ranks
+    else:
+        if args.grid_rows is None or args.grid_cols is None:
+            parser.error("--grid-rows and --grid-cols must be specified together")
+        grid_rows = args.grid_rows
+        grid_cols = args.grid_cols
+
+    cfg = FfnDataConfig(
+        t=args.t,
+        h=args.h,
+        fi=args.fi,
+        grid_rows=grid_rows,
+        grid_cols=grid_cols,
+        output_dir=args.output_dir,
+    )
+    gen_data(cfg)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds `kernels/manual/a2a3/distributed_ffn_grid/`, an A2/A3 single-device multi-block FFN demo that drives a real GridPipe `TPUSH<Direction>` / `TPOP<Direction>` pipeline through the existing PTO ISA header stack.

The demo intentionally restricts TLOAD/TSTORE to the head and tail of the FFN. Every intermediate tile flows through the TPipe / GridPipe pop/push surface, so the same kernel source can lower to silicon GridPipe without revisiting the dataflow.

### TLOAD/TSTORE only at head and tail

| Stage | Movement | Instruction |
| --- | --- | --- |
| Head | GM `X` / `W_gate` / `W_up` / `W_down` → L1 | `TLOAD` (Cube, once per cell) |
| Cube → Vec (gate / up / down) | L1 / Acc → Vec UB | `TPUSH<C2V>` / `TPOP<C2V>` (`TPipe`) |
| Vec → Cube (hidden) | Vec UB → L1 | `TPUSH<V2C>` / `TPOP<V2C>` (`TPipe`) |
| Inter-cell EAST reduce | Vec UB ↔ peer GridPipe slot | `TPUSH<EAST>` / `TPOP<EAST>` (`GridPipe`) |
| Tail | Vec UB → GM `yOutput[row]` | `TSTORE` (final-column block, fp32 `[T, H]`) |

`gate_partial`, `up_partial`, `hidden`, `down_partial`, and the EAST reduce payload never touch GM through TLOAD/TSTORE — they ride the `TPipe` / `GridPipe` FIFO surface. This keeps the demo aligned with the silicon GridPipe programming model where intermediate-tile spill / fill is a back-end choice, not a kernel-source decision.

### Mock CCE-intrinsic API for neighbor counters

New header `include/pto/common/grid_counter_intrinsic.hpp` introduces two CCE-intrinsic-style functions that sit at the same layer as `dcci`:

- `mtspr_neighbor_counter(operand, kind, dir, value)` — publish a monotonically-increasing `Ready` or `Free` counter to the neighbor in direction `dir`. Hardware contract maps to `mtspr SPR_RDY_<DIR>, value` / `mtspr SPR_FREE_<DIR>, value`. Release ordering: prior payload writes must be globally visible before the peer observes the counter.
- `wfe_neighbor_counter(operand, kind, dir, threshold, maxSpins)` — block until the local mirror of the neighbor-produced counter reaches `threshold`. Hardware contract maps to `wfe SPR_RDY_<DIR>, threshold` / `wfe SPR_FREE_<DIR>, threshold`. Acquire ordering: subsequent loads must not be reordered above the wait.

`NeighborCounterOperand` carries the backend operand (today: a GM counter pointer). On A2/A3 the function bodies dispatch to `grid_pipe_mock_spr.hpp` (`MockMtsprCounter` + `MockTryWfeCounter`), which already implement the canonical pre-`dcci` → store → post-`dcci` → `dsb(DSB_DDR)` publish and the `dcci` + `pipe_barrier(PIPE_ALL)` spin.

`GridTPush.hpp` and `GridTPop.hpp` now go through these intrinsics for **all** ready/free synchronization — call sites no longer reference `grid_mock::*` for counters. Slot transfer remains on `HcclRemotePtr` plus the existing window layout.

### Adapting when real hardware supports neighbor SPR / WFE counters

When silicon exposes native neighbor counters, no demo kernel source changes:

1. Define `PTO_GRID_COUNTER_NATIVE_INTRINSIC` for the device target.
2. Provide compiler builtins with the same contract:
   ```
   __builtin_pto_mtspr_neighbor_counter(uint32_t kind, uint32_t dir, uint32_t value);   // release
   __builtin_pto_wfe_neighbor_counter (uint32_t kind, uint32_t dir, uint32_t threshold); // acquire
   ```
3. The header automatically swaps the mock body for the builtin path. `NeighborCounterOperand::addr` is ignored on the native path, so the GM ready/free counter region inside the GridPipe window becomes unused (slot region and `HcclRemotePtr` payload addressing remain).
4. Payload slot delivery (`a2a3_grid_payload::CopyGmSlotToTile` / `WriteTileToPeerGmSlot`) can be retargeted to the silicon's grid slot mechanism in a follow-up by replacing only the payload adaptor — no changes to `GridTPush.hpp` / `GridTPop.hpp` or to the demo kernel.

This separation is the reason the new intrinsic API was introduced rather than calling the mock helpers directly: only one file in the build (`grid_counter_intrinsic.hpp`) chooses between native lowering and the GM-counter mock.

### Header layer

- `include/pto/common/grid_pipe.hpp` — `GridDirection`, `GridShape`, `GridCoord`, `NeighborRankForPush / NeighborRankForPop`, `is_grid_pipe_v`.
- `include/pto/common/grid_pipe_mock_spr.hpp` — unified `MockMtsprCounter` / `MockTryWfeCounter` with the canonical publish/spin sequence; `Ready` and `Free` helpers are thin wrappers.
- `include/pto/common/grid_counter_intrinsic.hpp` — new CCE-intrinsic-style API (see above).
- `include/pto/npu/a2a3/grid_pipe_runtime.hpp` — window layout (`kWindowBytes`, `kReadyFlagOffset`, `kFreeFlagOffset`, `kSlotOffset`) and `InitGridPipeFromWindow`.
- `include/pto/npu/a2a3/GridTPush.hpp` / `GridTPop.hpp` — A2/A3 backend; counters go through the intrinsic API, payload still uses `HcclRemotePtr`.
- `include/pto/common/pto_instr.hpp` / `pto_instr_impl.hpp` — `GridDirection`-templated `TPUSH` / `TPOP` overloads. `TPUSH<SOURCE>` is rejected at compile time; unsupported targets emit a `static_assert`.

### Demo layer (single mixed-arch kernel)

- `distributed_ffn_grid_compute_kernel.cpp` (`dav-c220`) — single kernel with Cube and Vec branches gated by `__DAV_CUBE__` / `__DAV_VEC__`. They exchange gate / up / hidden / down intermediates through A2/A3 `TPipe` ready/free handshakes inside one launch, and run the row-local EAST `fp32` reduce via `TPOP<EAST>` + `TADD` + `TPUSH<EAST>` with the final-column block doing the tail TSTORE. This replaces the earlier dual `.so` (cube + vec) and host-side phase 0 / phase 1 doorbell sequencing.
- `main.cpp` / `kernel_launch.hpp` / `ffn_config.hpp` / `gridpipe_payload_inl.hpp` — ACL bootstrap, fake `HcclDeviceContext` with per-cell GridPipe windows on a single device, single-launch mixed kernel, `fp32` golden compare on the last-column block of each row.
- `scripts/gen_data.py` — NumPy `fp32` FFN reference with `alpha=0.1`, per-cell `fp16` X / W_gate / W_up / W_down shards, `fp32` `[T_total, H]` golden tensor.
- `CMakeLists.txt` / `run.sh` — single mixed device `.so` plus host binary; runs `gen_data` + cmake; launches on a single device.
- `README.md` / `README_zh.md` — design overview, head/tail TLOAD/TSTORE contract, neighbor counter intrinsic adaptation path, mock SPR/WFE expansion, ready/free flag layout, build/run flow.

## Validation

- Build: `bash kernels/manual/a2a3/distributed_ffn_grid/run.sh --build-only -v Ascend910B1` produces the mixed `.so` and the host binary.
- NPU `2x2`: `task-submit --device auto --run "bash kernels/manual/a2a3/distributed_ffn_grid/run.sh -r npu -v Ascend910B1 --grid-rows 2 --grid-cols 2"` → 3 / 3 deterministic runs, `ResultCmp=1`, `max_diff=0`.
- Regression: `cmake --build kernels/manual/a2a3/allgather_gemm/build -j8` `RC=0`.

## Limitations

- A2/A3 mock backend is **not silicon validation evidence** for LPU WSE. The design-doc section 5.5 RFCs (cross-core SPR visibility, `TMOV` slot address space) remain open and gate the LPU WSE silicon lowering.
- Negative / fault-injection kernels are planned as a follow-up PR.

## Test plan

- [ ] `bash kernels/manual/a2a3/distributed_ffn_grid/run.sh --build-only -v Ascend910B1` produces the mixed kernel `.so` and the host binary.
- [ ] `task-submit --device auto --run "bash kernels/manual/a2a3/distributed_ffn_grid/run.sh -r npu -v Ascend910B1 --grid-rows 2 --grid-cols 2"` prints `[SUCCESS]` and `ResultCmp=1` for all final-column blocks.
- [ ] `cmake --build kernels/manual/a2a3/allgather_gemm/build -j8` remains green.
