### PR TITLE
fix(backend): Correct reversed Copy_Data operands in CPU TPUT_IMPL

### DIFF
--- a/include/pto/cpu/comm/TPut.hpp
+++ b/include/pto/cpu/comm/TPut.hpp
@@ -18,19 +18,19 @@ namespace comm {
 template <typename GlobalDstData, typename GlobalSrcData, typename TileData, AtomicType atomicType>
 PTO_INTERNAL void TPUT_IMPL(GlobalDstData &dst, GlobalSrcData &src, TileData &src1)
 {
-    Copy_Data(src, dst);
+    Copy_Data<GlobalDstData, GlobalSrcData, atomicType>(dst, src);
 }
 
 template <typename GlobalDstData, typename GlobalSrcData, typename TileData>
 PTO_INTERNAL void TPUT_IMPL(GlobalDstData &dst, GlobalSrcData &src, TileData &ping, TileData &pong)
 {
-    Copy_Data(src, dst);
+    Copy_Data(dst, src);
 }
 
 template <DmaEngine engine = DmaEngine::SDMA, typename GlobalDstData, typename GlobalSrcData>
 PTO_INTERNAL AsyncEvent TPUT_ASYNC_IMPL(GlobalDstData &dst, GlobalSrcData &src, const AsyncSession &session)
 {
-    Copy_Data(src, dst);
+    Copy_Data(dst, src);
     return AsyncEvent(0, engine);
 }
 

--- a/tests/cpu/st/testcase/tput/tput_kernel.cpp
+++ b/tests/cpu/st/testcase/tput/tput_kernel.cpp
@@ -28,7 +28,7 @@ AICORE void runTPut(__gm__ T __out__ *out, __gm__ T __in__ *input)
     GlobalData inputGlobal(input);
     GlobalData outputGlobal(out);
 
-    comm::TPUT(inputGlobal, outputGlobal, srcTile);
+    comm::TPUT(outputGlobal, inputGlobal, srcTile);
     out = outputGlobal.data();
 }
 

--- a/tests/cpu/st/testcase/tput_async/tput_async_kernel.cpp
+++ b/tests/cpu/st/testcase/tput_async/tput_async_kernel.cpp
@@ -25,7 +25,7 @@ AICORE void runTPutAsync(__gm__ T __out__ *out, __gm__ T __in__ *input)
     GlobalData inputGlobal(input);
     GlobalData outputGlobal(out);
 
-    comm::TPUT_ASYNC(inputGlobal, outputGlobal, session);
+    comm::TPUT_ASYNC(outputGlobal, inputGlobal, session);
     out = outputGlobal.data();
 }
 


### PR DESCRIPTION
The CPU simulation backend for TPUT called Copy_Data(src, dst) instead
of Copy_Data(dst, src), reversing the data flow so that TPUT(dst, src)
behaved as src = dst. The ST kernel had the same reversal in its TPUT
call arguments, masking the bug.

## Summary
- Swap Copy_Data arguments from (src, dst) to (dst, src) in all three
  CPU TPUT_IMPL overloads (single-tile, ping-pong, async) to match
  Copy_Data's destination-first semantics
- Propagate atomicType template parameter to Copy_Data in the
  single-tile TPUT_IMPL overload so AtomicAdd is honoured in CPU sim
- Fix tput and tput_async ST kernels to call
  comm::TPUT/TPUT_ASYNC(outputGlobal, inputGlobal) instead of
  comm::TPUT/TPUT_ASYNC(inputGlobal, outputGlobal)

## Testing
- [x] All 4 CPU-sim tput ST cases pass (float, int32, int16, half)
- [x] All 4 CPU-sim tput_async ST cases pass (float, int32, int16, half)
- [x] max diff = 0 across all cases

Closes #122