### PR TITLE
refactor: Enable CPU simulation without __PTO_AUTO__ guard

### DIFF
--- a/include/pto/common/cpu_stub.hpp
+++ b/include/pto/common/cpu_stub.hpp
@@ -18,6 +18,8 @@ See LICENSE in the root of the software repository for the full text of the Lice
 #include <type_traits>
 #include <dlfcn.h>
 
+#include "pto/common/type.hpp"
+
 #define __global__
 #define AICORE
 #define __aicore__

--- a/include/pto/common/pto_tile.hpp
+++ b/include/pto/common/pto_tile.hpp
@@ -1540,8 +1540,16 @@ public:
 #endif
 #endif
 
-#if (defined(__CPU_SIM) && defined(__PTO_AUTO__)) || defined(__COSTMODEL)
+#if defined(__CPU_SIM) || defined(__COSTMODEL)
     TileDType &data()
+    {
+        if (!data_) {
+            internalBuffer.resize(Rows * Cols);
+            data_ = internalBuffer.data();
+        }
+        return data_;
+    }
+    const TileDType &data() const
     {
         if (!data_) {
             internalBuffer.resize(Rows * Cols);
@@ -1670,9 +1678,9 @@ private:
     }
     bool isKAligned_; // K-Alignedment for A3
 
-#if (defined(__CPU_SIM) && defined(__PTO_AUTO__)) || defined(__COSTMODEL)
-    std::vector<DType> internalBuffer;
-    TileDType data_ = nullptr;
+#if defined(__CPU_SIM) || defined(__COSTMODEL)
+    mutable std::vector<DType> internalBuffer;
+    mutable TileDType data_ = nullptr;
 #else
     TileDType data_;
 #endif

--- a/include/pto/cpu/ElementOp.h
+++ b/include/pto/cpu/ElementOp.h
@@ -269,16 +269,6 @@ struct ElementOpCal<DType, ElementOp::OP_EXPDIF> {
     }
 };
 
-#if defined(__GNUC__) && !defined(__clang__)
-template <>
-struct ElementOpCal<half, ElementOp::OP_EXPDIF> {
-    static void apply(half &dst, const half &src0, const half &src1)
-    {
-        dst = std::exp(src0 - src1);
-    }
-};
-#endif
-
 template <typename DType>
 struct ElementOpCal<DType, ElementOp::OP_FMOD> {
     static void apply(DType &dst, DType &src0, DType &src1, size_t)


### PR DESCRIPTION
## Summary
- Relax conditional guard from `(__CPU_SIM && __PTO_AUTO__) || __COSTMODEL`
  to `__CPU_SIM || __COSTMODEL` for Tile::data() and its backing storage,
  so CPU simulation works outside of auto mode
- Add a const overload of Tile::data() and mark `internalBuffer` / `data_`
  as `mutable` to support lazy buffer allocation from const contexts
- Add `#include "pto/common/type.hpp"` in cpu_stub.hpp to make required
  type declarations directly available
- Remove the redundant GCC-only `ElementOpCal<half, OP_EXPDIF>`
  specialization in ElementOp.h; the generic template covers this case

## Testing
- [x] All unit tests pass
- [x] Code review completed
- [x] Pre-commit hooks pass
