### PR TITLE
fix(cpu): correct TRSQRT tmp overload

### DIFF
--- a/include/pto/cpu/TRSqrt.hpp
+++ b/include/pto/cpu/TRSqrt.hpp
@@ -44,9 +44,9 @@ PTO_INTERNAL void TRSQRT_IMPL(TileDataDst &dst, TileDataSrc &src)
 
 template <auto PrecisionType = RsqrtAlgorithm::DEFAULT, typename TileDataDst, typename TileDataSrc,
           typename TmpTileData>
-PTO_INTERNAL void TSQRT_IMPL(TileDataDst &dst, TileDataSrc &src, TmpTileData &tmp)
+PTO_INTERNAL void TRSQRT_IMPL(TileDataDst &dst, TileDataSrc &src, TmpTileData &tmp)
 {
-    TRSQRT_IMPL(dst, src);
+    TRSQRT_IMPL<PrecisionType>(dst, src);
 }
 } // namespace pto
 


### PR DESCRIPTION
## Summary

- rename the CPU TRSQRT tmp overload from `TSQRT_IMPL` to `TRSQRT_IMPL`
- match the common TRSQRT wrapper and existing NPU overload names

## Validation

- `git diff --check -- include/pto/cpu/TRSqrt.hpp`
- verified the a2a3sim MoE path compiles past the previous CPU TRSQRT error and completes successfully

Fixes #133