### PR TITLE
perf(flash_atten): tune DSL pipeline params and remove redundant PIPE_V barriers

### DIFF
--- a/.claude/skills/pto-isa-flash-atten-a3-pipeline/SKILL.md
+++ b/.claude/skills/pto-isa-flash-atten-a3-pipeline/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: pto-isa-flash-atten-a3-pipeline
+description: >-
+  PTO-DSL Flash Attention four-stage cross-core software pipeline for Ascend
+  A3: compute_qk (Cube) -> compute_p (Vec) -> compute_pv (Cube) -> compute_gu
+  (Vec), staged through a GM software FIFO. Captures the steady-state rhythm
+  (cube-side per-tile emit_qk_pv interleaving, vec-side "drain GU then produce
+  P"), the QK_PRELOAD / EXP_RING / S1_TILE knobs and their invariants, the UB
+  192 KiB budget with the row_slice working-tile shrink, the empirical
+  S1 >= 16384 -> S1_TILE = 512 recommendation, and the op-pattern PIPE_V barrier removal recipe. Use
+  when tuning the in-tree DSL Flash Attention, porting the four-stage pipeline
+  to a new persistent-block kernel that mixes cube + vec stages through a GM
+  FIFO, choosing QK_PRELOAD / S1_TILE for a new shape mix, or deciding when a
+  PIPE_V barrier in generated C++ is safe to drop. Scoped to A3 non-causal
+  prefill with HEAD=128, S0=128, CUBE_S1=128 -- other Flash Attention flavors
+  (causal mask, GQA/MQA, KV-cache decode, A5 NZ/NZ+1 layout) belong in
+  sibling skills.
+---
+
+# PTO-ISA Flash Attention A3 Pipeline (4-Stage Cube/Vec + GM FIFO)
+
+A single, focused recipe: how to schedule a Flash Attention prefill kernel on Ascend A3 so the cube and vector cores cooperate through a GM-staged software FIFO at the rhythm of the 140 TFLOPS reference. The recipe is implemented in the in-tree PTO-DSL kernel under `kernels/python/flash_atten/`; everything you need to apply, tune, or port it lives in this skill -- the source tree is only there if you want to see it wired end-to-end.
+
+## Quick Start
+
+- Read [references/fa-4stage-pipeline-recipe.md](references/fa-4stage-pipeline-recipe.md) -- the full pipeline (stages, prologue / steady / epilogue, ring invariants, anti-patterns).
+- Read [references/ub-budget-and-tile-sizing.md](references/ub-budget-and-tile-sizing.md) -- 192 KiB UB budget, row_slice 64 KiB -> 32 KiB shrink, and the empirical `S1 >= 16384 -> S1_TILE = 512` recommendation.
+- Read [references/pipe-v-barrier-patterns.md](references/pipe-v-barrier-patterns.md) -- which generated-C++ `pipe_barrier(PIPE_V)` patterns are safe to drop and why.
+- Reproduce the canonical numbers on Ascend 910B2:
+  ```bash
+  cd ${repo}/kernels/python/flash_atten
+  python3 run.py                       # full case1..case8 sweep
+  python3 run.py --case case1          # one shape
+  ```
+  `run.py` rebuilds `build_artifacts/fa.so` per `FA_Q_ROWS`, and its default suite picks `FA_S1_TILE=512` automatically for `S1 >= 16384` (`case5..case8`) as an empirically good default.
+
+## Core Workflow
+
+1. **Diagnose** -- confirm the kernel is pipeline-bound (cube or vec idle while the other is busy, or `pipe_barrier(PIPE_V)` stalls dominating the vec side). For the generic profiling loop see [docs/coding/performance-best-practices.md](../../../docs/coding/performance-best-practices.md).
+2. **Apply the recipe** -- four-stage cross-core pipeline with prologue + steady + epilogue, GM-staged FIFO between stages, exp_max ring sized to `QK_PRELOAD`. See [references/fa-4stage-pipeline-recipe.md](references/fa-4stage-pipeline-recipe.md).
+3. **Size the tiles** -- start from the empirical defaults (`S1_TILE=256`, and recommended `512` for `S1 >= 16384`), confirm the row_slice shrink keeps the per-iteration working tile at 32 KiB, validate the UB budget on the host. See [references/ub-budget-and-tile-sizing.md](references/ub-budget-and-tile-sizing.md).
+4. **Patch barriers** -- run with the default `gu` pattern; only add `softmax-exp-sum` or `softmax-sum-add` after the patch tool confirms there is no direct tile dependency. See [references/pipe-v-barrier-patterns.md](references/pipe-v-barrier-patterns.md).
+5. **Verify** -- correctness vs a host FP32 reference at small shapes; latency and TFLOP/s vs `torch_npu.npu_fused_infer_attention_score` for all benchmark sizes.
+
+## Scope
+
+This skill is **deliberately narrow** -- it covers only the A3 non-causal prefill four-stage pipeline at the in-tree shape envelope (`HEAD=128`, `S0=128`, `CUBE_S1=128`). Anything outside that scope belongs in a different skill:
+
+- Causal mask, GQA / MQA, KV-cache decode, other head dims -> add a sibling skill, do not extend this one. `tile.triu` is not exposed in the current DSL so causal here is a hard "not supported", not a tuning knob.
+- A5 NZ / NZ+1 layout Flash Attention (`kernels/manual/a5/flash_atten/`) -> separate skill; the buffer pyramid and layout assumptions are different.
+- Matmul L2-reuse scheduling -> see the GEMM L2-schedule sibling skill.
+- Generic PTO optimization concepts (instruction selection, pipeline overlap methodology, profiling) -> covered by [docs/coding/opt.md](../../../docs/coding/opt.md) and [docs/coding/performance-best-practices.md](../../../docs/coding/performance-best-practices.md).
+- Build / constraints / debugging / review guardrails -> covered by [../pto-isa-dev/SKILL.md](../pto-isa-dev/SKILL.md).
+
+## Working Rules
+
+- Treat `EXP_RING == QK_PRELOAD` as a hard invariant. Changing one without the other lets softmax(t + QK_PRELOAD) clobber the rescale factor GU(t) is still using. The host raises a ValueError today; do not relax it.
+- Validate `S1 >= S1_TILE * QK_PRELOAD` and `S1 % S1_TILE == 0` on the host before launching -- surface a clear error rather than letting the FIFO underrun mid-kernel.
+- Keep `S1_TILE` selected per-shape rather than hard-coded: `S1_TILE=256` is the baseline empirical value, and `S1 >= 16384` is recommended to use 512 because it has measured better on the current default shapes. This is not a hard rule or a proof of optimality; treat it as the default heuristic to beat. See the UB budget reference for why a higher S1_TILE is not free.
+- The default `gu` PIPE_V removal pattern is stable and on by default. Adding `softmax-exp-sum` or `softmax-sum-add` requires the patch tool's direct-tile-dependency check to pass -- do not enable them blind.
+- Prefer the op-pattern barrier removal over the legacy line-number list (`FA_REMOVE_VEC_BARRIERS`). The line-number path is kept only as an experimental fallback and breaks on every ptoas emit churn.
+- This kernel is A3 only (`--pto-arch=a3 --npu-arch=dav-2201` in `compile.sh`). HEAD / S0 / CUBE_S1 are baked. Do not invent a CANN platform_config wiring for it -- the shape envelope is fixed.
+- When porting the four-stage pattern to a different cube+vec persistent-block kernel, keep prologue / steady / epilogue separate (do not collapse the prologue's QK_PRELOAD preloads into the steady loop) and keep the GM-staged FIFO between cube and vec rather than direct cube-to-vec eventing.
+
+## Where the Reference Implementation Lives
+
+`kernels/python/flash_atten/` -- the PTO-DSL Flash Attention kernel:
+
+- `kernels/fa_builder.py` -- the four-stage DSL builder: cube `compute_qk` + `compute_pv`, vec `compute_p` + `compute_gu`, the GM FIFO layout, the steady-state `emit_qk_pv_interleaved`, the vec "drain GU first" reordering, the `exp_max` ring and slot dispatch.
+- `scripts/patch_vec_barriers.py` -- the op-pattern PIPE_V barrier remover (`gu` / `softmax-exp-sum` / `softmax-sum-add`).
+- `compile.sh` -- end-to-end build: DSL -> MLIR -> ptoas C++ -> optional barrier patch -> bisheng -> `build_artifacts/fa.so`.
+- `run.py` -- per-case build flow (rebuilds per `FA_Q_ROWS`), `S1_TILE` auto-selection, host FP32 / `torch_npu` correctness + benchmark harness.
+
+`kernels/manual/common/flash_atten/` -- the manual C++ kernel this DSL version mirrors. Open it when you need to see what the DSL gave up (e.g. fused "wide K load + sub-tile matmul into ACC subview", `tile.triu` causal) and why.

--- a/.claude/skills/pto-isa-flash-atten-a3-pipeline/references/fa-4stage-pipeline-recipe.md
+++ b/.claude/skills/pto-isa-flash-atten-a3-pipeline/references/fa-4stage-pipeline-recipe.md
@@ -1,0 +1,191 @@
+# Flash Attention 4-Stage Cube/Vec Pipeline (A3 Non-Causal Prefill)
+
+A drop-in software-pipeline recipe for `Q @ K^T -> softmax -> @ V -> rescale-accumulate` on Ascend A3, run as a cooperating pair of cube + vec kernels staged through a GM software FIFO. Everything you need to apply, tune, and port the pattern lives in this file -- no source-file lookup required. The end of the file points at the in-tree implementation if you want to see it running.
+
+## 1. When to Use This Pattern
+
+Reach for this pipeline when **all** of these hold:
+
+- You are doing Flash Attention prefill on Ascend A3 (`--pto-arch=a3 --npu-arch=dav-2201`).
+- `HEAD = 128`, `S0 = 128` per Q block, `CUBE_S1 = 128`, non-causal attention. (Other variants belong in a sibling skill -- see scope.)
+- The work splits cleanly into four stages that alternate cube and vector: matmul `Q K^T`, streaming softmax, matmul `P V`, rescale + accumulate into `O`.
+- The single-core throughput of either pipe is limited by the other -- cube idling on QK while vec is still rescaling, or vec stalling on `pipe_barrier(PIPE_V)` while cube has the next QK ready.
+
+Skip this pattern (see section 9) when `S1 < S1_TILE * QK_PRELOAD` (FIFO cannot prime), when the shape is small enough that the prologue dominates (e.g. `Q_ROWS == S0` and `S1 == S1_TILE * QK_PRELOAD`), or when the kernel needs causal masking -- `tile.triu` is not exposed in the current DSL.
+
+## 2. Why It Works
+
+**Four-stage cross-core pipeline** splits the inner attention work into two cube stages (`compute_qk`, `compute_pv`) and two vector stages (`compute_p`, `compute_gu`). Each pair runs on its own pipe, so cube matmul and vec softmax / rescale overlap by construction:
+
+```text
+   tile_id:       0       1       2       3       4   ...
+   cube QK:    [QK0]   [QK1]   [QK2]   [QK3]   [QK4] ...
+   vec  P :          [P0]    [P1]    [P2]    [P3]   ...   (lags by QK_PRELOAD-1)
+   cube PV:                 [PV0]   [PV1]   [PV2]   ...
+   vec  GU:                        [GU0]   [GU1]   ...
+```
+
+**GM-staged software FIFO** between stages decouples cube and vec timing. The slot ring is 8-deep (`dir_mask=1/2 -> slot_num=8` on A3). Three logical pipes share one GM buffer:
+
+- `QK pipe` (cube -> vec, fp32 `[S0, S1_TILE]`)
+- `PV pipe` (cube -> vec, fp32 `[S0, HEAD]`)
+- `P pipe`  (vec -> cube, fp16 `[VecGuRows, S1_TILE]`)
+
+**QK_PRELOAD** lets cube emit several QK slots before vec ever starts. With `QK_PRELOAD = 3`, the steady state always has at least 3 QK tiles in flight, so any single-iteration stall on the vec side is absorbed before cube notices.
+
+**exp_max ring** sized to `QK_PRELOAD` (hard invariant `EXP_RING == QK_PRELOAD`) keeps the streaming-softmax rescale factor for `GU(t)` alive until `GU(t)` consumes it -- but no longer. Make the ring shorter and softmax(t + QK_PRELOAD) clobbers the factor GU(t) is still using; make it longer and vec UB runs out.
+
+## 3. Pipeline Skeleton (Drop-In Structure)
+
+The cube and vec kernels share a three-part envelope: **prologue** (prime the FIFO), **steady** (per-tile body), **epilogue** (drain). Keep the three sections distinct -- collapsing the prologue into the steady loop tends to break the lag-by-`QK_PRELOAD` invariant.
+
+```text
+# ----- cube kernel (compute_qk + compute_pv) -----
+for qb in range(qb_start, qb_end):
+    load Q[qb]
+    # prologue: emit QK[0..QK_PRELOAD-1] back-to-back
+    for kp in range(QK_PRELOAD):
+        emit_qk(kp)
+
+    # steady: per-tile, drain current PV then issue next QK
+    for tile_id in range(0, steady_tiles):
+        next_tile = tile_id + QK_PRELOAD
+        emit_qk_pv_interleaved(next_tile, tile_id)
+        # -> inside: tpop P; for sub in TILE_FACTOR { emit_pv_sub; emit_qk_sub }
+        # The interleaving keeps both ACC accumulators warm.
+
+    # epilogue: drain the last QK_PRELOAD PVs
+    for k in range(QK_PRELOAD):
+        emit_pv(steady_tiles + k)
+
+# ----- vec kernel (compute_p + compute_gu) -----
+for qb in range(qb_start, qb_end):
+    # prologue: softmax for the QK_PRELOAD tiles cube already pushed
+    for kp in range(QK_PRELOAD):
+        emit_softmax(exp_max_ring[kp], is_init=(kp == 0))
+
+    # steady: 140tflops order -- drain current PV/GU before producing next P
+    if steady_tiles > 0:
+        emit_gu(exp_max_ring[0], is_init=True)
+        emit_softmax(exp_max_ring[QK_PRELOAD % EXP_RING], is_init=False)
+        for tile_id in range(1, steady_tiles):
+            next_tile = tile_id + QK_PRELOAD
+            emit_gu_update_dispatch(tile_id)       # consume current PV, update O
+            emit_softmax_dispatch(next_tile)       # produce future P
+
+    # epilogue: drain the last QK_PRELOAD gus
+    for k in range(QK_PRELOAD):
+        emit_gu_any(steady_tiles + k)
+
+    # final divide + GM store of O
+```
+
+Two non-obvious rules:
+
+- **Cube interleaving** (`emit_qk_pv_interleaved`) walks the `TILE_FACTOR` sub-tiles of one logical S1 tile, interleaving `emit_pv_sub(current)` and `emit_qk_sub(next)`. The PV `talloc` happens on the first sub and the QK `tpush` happens on the last sub -- this matches the 140 TFLOPS reference and keeps the cube pipes back-to-back.
+- **Vec drain-first** is the inverse: in the steady-state body, `emit_gu_update_dispatch(tile_id)` runs **before** `emit_softmax_dispatch(next_tile)`. Producing the future P first looks symmetric but it leaves the rescale factor in `exp_max_ring[next_tile % EXP_RING]` overwritten before `GU(tile_id)` reads it.
+
+## 4. Knob Reference
+
+| Knob | Default | Other values | Hard invariant |
+| --- | --- | --- | --- |
+| `S1_TILE` (`FA_S1_TILE`) | 256 | 512 (recommended for `S1 >= 16384` by current measurements) | Must be a multiple of `CUBE_S1` (`= 128`); the current library implements only `{256, 512}`. Extending this set requires adapting the implementation and validating the new shape, not just changing the heuristic. The 16384 threshold is an empirical recommendation, not a hard rule. |
+| `QK_PRELOAD` (`FA_QK_PRELOAD`) | 3 (DSL) | 4 (manual parity) | Allow-list `{3, 4}`. |
+| `EXP_RING` (`FA_EXP_RING`) | `= QK_PRELOAD` | -- | Must equal `QK_PRELOAD`; host raises `ValueError` otherwise. |
+| `QK_PRELOAD * S1_TILE` floor on `S1` | -- | -- | `S1 >= QK_PRELOAD * S1_TILE` and `S1 % S1_TILE == 0`. |
+| `CAUSAL_MASK` | `False` | -- | `True` requires `tile.triu` which is not exposed in the current DSL. |
+
+The DSL builder's defaults come from the 140 TFLOPS reference, not the manual C++ kernel. The manual kernel uses `QK_PRELOAD = 4`; the DSL drops to 3 and shrinks `EXP_RING` to match, which is what frees the vec UB headroom that the row_slice working-tile shrink (see the UB budget reference) needs.
+
+## 5. Ring and Slot Invariants the Porter Must Enforce
+
+Validate on the host before building the kernel -- surface a clear error rather than letting the FIFO mis-pace:
+
+- `QK_PRELOAD == EXP_RING` -- see section 2; the host today refuses any mismatch.
+- `S1 >= S1_TILE * QK_PRELOAD` -- the prologue needs that many tiles to prime.
+- `S1 % S1_TILE == 0` -- the steady loop is `num_tiles = S1 // S1_TILE`.
+- `S1_TILE % CUBE_S1 == 0` -- `TILE_FACTOR = S1_TILE // CUBE_S1` must be integer for the sub-tile loop.
+- `Q_ROWS % S0 == 0` -- one Q block per AIC core walk.
+- Slot count is 8 on A3 (`dir_mask=1/2 -> slot_num=8`). Do not parameterize it; it is set by the platform.
+
+Soft rules:
+
+- Keep `EXP_RING` slot dispatch via `tile_id % EXP_RING`. The previous 8-slot unrolled ring (where `EXP_RING` was hard-wired to the slot count) wasted vec UB and only worked at `QK_PRELOAD = 4`.
+- When porting the four-stage envelope to a different cube+vec kernel, keep the three sections (prologue / steady / epilogue) and keep the GM FIFO. Direct cube-to-vec eventing without GM staging is tempting but the slot ring is what lets the two pipes lag by `QK_PRELOAD - 1` without coupling their timing.
+
+## 6. GM FIFO Layout Note
+
+The GM buffer is one block per AIC, partitioned per-pipe:
+
+```text
+GM_QK_OFF_F32 = 0
+GM_PV_OFF_F32 = (SLOT_SIZE_QK * SLOT_NUM) // 4
+GM_P_OFF_F32  = GM_PV_OFF_F32 + (SLOT_SIZE_PV * SLOT_NUM) // 4
+
+SLOT_SIZE_QK = S0 * S1_TILE * 4   # fp32 QK accumulator
+SLOT_SIZE_PV = S0 * HEAD    * 4   # fp32 PV accumulator
+SLOT_SIZE_P  = S0 * S1_TILE * 2   # fp16 softmax(QK) sent vec -> cube
+SLOT_NUM     = 8                  # A3 dir_mask=1/2
+```
+
+The QK slot is described to the DSL as a `[S0, S1_TILE]` fp32 tensor; cube writes it in `TILE_FACTOR` sub-tiles of `[S0, CUBE_S1]`, vec consumes it in `TILE_FACTOR` row_slices of `[Vec_S0, S1_TILE]` (`Vec_S0 = S0 / VEC_CORES / TILE_FACTOR`). The two views into the same GM region are what mediates the cube-vec width / row mismatch without any explicit transpose.
+
+The P slot is the symmetric story for vec -> cube: vec writes `[VecGuRows, S1_TILE]` (one row_slice per slice), cube reads `TILE_FACTOR` sub-tiles of `[S0, CUBE_S1]`. The PV slot is `[S0, HEAD]` and does not scale with `S1_TILE` because one PV is produced per logical S1 tile by accumulating sub-PV matmuls into the same accumulator.
+
+## 7. Verification
+
+The PTO-DSL Flash Attention kernel ships eight shape-specialized presets (`case1..case8`) and a `torch_npu` baseline harness. Use it as the regression rig:
+
+- Correctness:
+  - small shapes -- compare against a host FP32 PyTorch reference,
+  - all shapes -- compare against `torch_npu.npu_fused_infer_attention_score` (the run-time picks tolerance based on `Q_ROWS * S1`).
+- Latency / throughput: `run.py` reports per-case `fa_us`, `fused_us`, `speedup`, and TFLOP/s (matmul + scale + softmax op count, 140 TFLOPS convention).
+
+Regression watermark on Ascend 910B2 with the current default knobs (`QK_PRELOAD = 3`, baseline `S1_TILE = 256`, recommended/default-suite `S1_TILE = 512` for `S1 >= 16384`, default `gu` PIPE_V patch):
+
+| Case | S0 = S1 | fa us | torch_npu us | speedup |
+| ---- | ------: | ----: | -----------: | ------: |
+| case1 |   1024 | 43.82 |   137.71 | 3.14x |
+| case2 |   2048 | 56.92 |   154.92 | 2.72x |
+| case3 |   4096 | 113.83 |  207.80 | 1.83x |
+| case4 |   8192 | 283.12 |  365.81 | 1.29x |
+| case5 |  16384 | 953.47 |  974.65 | 1.02x |
+| case6 |  32768 | 3177.41 | 3159.95 | 0.99x |
+| case7 |  65536 | 12093.10 | 12152.60 | 1.00x |
+| case8 | 131072 | 48380.71 | 48061.93 | 0.99x |
+
+Reading the band:
+
+- `case1..case4` are launch / overhead favored -- the DSL kernel beats the fused op by 3.1x -> 1.3x as the shape grows.
+- `case5..case8` are compute-bound large prefill -- the kernel sits within +-2% of `torch_npu`. Anything materially below 0.95x at these shapes is a regression in the pipeline (re-check `QK_PRELOAD`, `EXP_RING`, and the `gu` PIPE_V patch).
+- `case4` (8192) is the last default-suite case below the empirical 16384 recommendation boundary: it still uses `S1_TILE = 256`, so it sees the largest scheduling overhead per S1 tile.
+
+## 8. Anti-Patterns
+
+Do not pick this schedule when:
+
+- `S1 < S1_TILE * QK_PRELOAD`. The prologue cannot prime and the steady loop runs zero iterations -- you spend the whole kernel in epilogue.
+- `Q_ROWS == S0` and `S1 == S1_TILE * QK_PRELOAD`. Steady-state is zero; the prologue + epilogue is all there is and the pipeline overlap never kicks in.
+- The shape needs causal masking. `tile.triu` is not exposed; sub-tile masking is not a workaround that fits this pipeline. Use a different recipe.
+- A new SoC or a different head dim. This kernel is locked to A3 / `HEAD = 128` / `S0 = 128` / `CUBE_S1 = 128`. Re-deriving the GM FIFO and UB budget for a new envelope is a separate Skill, not a parameter sweep.
+- You are tempted to make `EXP_RING > QK_PRELOAD` "just to have headroom". It is not headroom -- it is extra vec UB that the row_slice shrink needs.
+
+## 9. Contrast: Manual C++ Reference Kernel
+
+The kernel this DSL recipe mirrors is `kernels/manual/common/flash_atten/fa_performance_kernel.cpp`. The pipeline structure is **identical** (same four stages, same GM FIFO, same `QK_PRELOAD`-deep prologue + epilogue) but the manual version has three things this DSL version cannot do:
+
+- Fused "load wide K once, sub-tile matmul into ACC subview". The DSL MAT/RIGHT subview verifier rejects partial-column subviews, so the DSL kernel uses one full DSL tile at `S1_TILE` width.
+- `tile.triu`-based causal masking.
+- Ping-pong tile storage. `pto.alloc_tile` is single-output; the DSL builder uses Python aliases (`[buf, buf]`) to preserve the `[buf]` indexing pattern from the C++ source without pretending it has ping-pong storage. The L1 / L0 double-buffer still works because `--enable-insert-sync` schedules around it.
+
+The DSL kernel exists to validate that the Python DSL can express a production-grade four-stage pipeline at near-`torch_npu` performance. The manual kernel is the parity target, not the always-better baseline -- on `case5..case8` the DSL kernel is within +-2% of `torch_npu` (and so within noise of the manual C++ kernel).
+
+## In-Tree Reference
+
+The recipe was extracted from the PTO-DSL Flash Attention under `kernels/python/flash_atten/`:
+
+- `kernels/fa_builder.py` -- the four-stage DSL builder, the GM FIFO layout, the steady-state `emit_qk_pv_interleaved`, the vec "drain GU first" reordering, the `exp_max` ring and slot dispatch.
+- `run.py` -- per-case build flow (rebuilds `fa.so` per `FA_Q_ROWS`), `S1_TILE` auto-selection, host FP32 / `torch_npu` correctness + benchmark harness.
+- `compile.sh` -- DSL -> MLIR -> ptoas C++ -> optional barrier patch -> bisheng -> `build_artifacts/fa.so`.
+
+Open those files only when you want to see the recipe wired end-to-end. The formulas, invariants, and verification path in this file should be enough to apply the recipe to a new kernel on their own.

--- a/.claude/skills/pto-isa-flash-atten-a3-pipeline/references/pipe-v-barrier-patterns.md
+++ b/.claude/skills/pto-isa-flash-atten-a3-pipeline/references/pipe-v-barrier-patterns.md
@@ -1,0 +1,97 @@
+# PIPE_V Barrier Removal Patterns (Generated C++ Post-Patch)
+
+`ptoas` emits conservative `pipe_barrier(PIPE_V);` statements in `build_artifacts/fa.cpp` after every vec-side op that could theoretically race a later vec op. Most of them are redundant because some other event (MTE wait, direct tile-dependency edge) already provides the spacing. Removing them is worth between a few percent and double-digit percent on vec-bound shapes.
+
+This file documents the **op-pattern** removal strategy used by `scripts/patch_vec_barriers.py` (the line-number strategy is legacy -- see section 5). Apply only the patterns listed here, and only with the safety checks listed alongside.
+
+## 1. The Three Supported Patterns
+
+| Pattern name (and aliases) | Default | Removes the barrier in | Safety mechanism |
+| --- | --- | --- | --- |
+| `gu` (alias: `trowexpandmul-tadd`) | **on** | `TROWEXPANDMUL -> pipe_barrier(PIPE_V) -> wait_flag(PIPE_MTE2, PIPE_V) -> TADD` (the `compute_gu` rescale-and-add chain). | The `wait_flag(PIPE_MTE2, PIPE_V)` between the two ops already pins the order. The PIPE_V barrier is pure redundancy. |
+| `softmax-exp-sum` (alias: `texp-trowsum`) | off | `TEXP -> pipe_barrier(PIPE_V) -> TROWSUM` (the `compute_p` exp-then-rowsum sequence). | Removed only if `patch_vec_barriers.py` confirms the two ops share a **direct tile dependency** (the rowsum reads the exp's output tile). If the patch tool reports `softmax-exp-sum:direct-tile-dependency`, the barrier is kept. |
+| `softmax-sum-add` (alias: `trowsum-tadd`) | off | `TROWSUM -> pipe_barrier(PIPE_V) -> TADD` (the streaming-sum running-max update). | Same direct-tile-dependency check as `softmax-exp-sum`; emits `softmax-sum-add:direct-tile-dependency` when kept. |
+
+`gu` is on by default everywhere (`compile.sh` default `FA_REMOVE_VEC_BARRIER_PATTERNS=gu`, `run.py` propagates it). The other two are off by default because the direct-tile-dependency check is sufficient but not necessary -- ptoas may emit them in contexts the patch tool's tile-dependency walker does not cover, in which case removing them silently can race.
+
+To enable extras explicitly:
+
+```bash
+python3 run.py --remove-vec-barrier-patterns gu,softmax-sum-add
+FA_REMOVE_VEC_BARRIER_PATTERNS=gu,softmax-sum-add python3 run.py
+```
+
+To disable everything (for an A/B run vs the unpatched build):
+
+```bash
+python3 run.py --remove-vec-barrier-patterns none
+```
+
+## 2. How the Patch Tool Works
+
+`scripts/patch_vec_barriers.py` runs **between** ptoas (which emits `build_artifacts/fa.cpp`) and bisheng (which builds `build_artifacts/fa.so`). It is line-level text patching, but the scanner is op-aware:
+
+1. Parse the C++ line-by-line.
+2. For each pattern, identify the operation triple (e.g. `TROWEXPANDMUL` line, candidate `pipe_barrier(PIPE_V);` line, `TADD` line) and the spacing op between them (`wait_flag(PIPE_MTE2, PIPE_V)` for `gu`).
+3. For the two `softmax-*` patterns, additionally walk the tile-dependency graph between the producer op and the consumer op. If the producer's output tile is the consumer's input tile, the barrier is **kept** (the direct dependency already serializes the two ops on the PIPE_V scheduler, so removing the barrier here would be wrong as well as redundant).
+4. Emit `build_artifacts/fa_patched.cpp` with only the matched lines removed; bisheng then compiles this file.
+
+The "kept due to direct-tile-dependency" decisions are tallied in the patch tool's summary so you can see how many barriers each pattern actually removed.
+
+## 3. Reading the Patch Output
+
+The patch step prints something like:
+
+```text
+patch_vec_barriers: applied patterns={gu}
+                    removed=N1 (gu=N1)
+                    skipped due to direct-tile-dependency: softmax-exp-sum=0 softmax-sum-add=0
+```
+
+What the numbers mean:
+
+- `removed=N1 (gu=N1)` -- N1 PIPE_V barriers were dropped because they matched the `gu` triple and had the MTE wait spacing. This is the stable, expected count.
+- A nonzero `skipped due to direct-tile-dependency` count when you asked for `softmax-*` patterns means those patterns matched but were kept. That is the patch tool refusing to introduce a race -- treat the count as informational, not a warning.
+- If `removed=0` for `gu` on a build that previously had `removed > 0`, the ptoas emit changed shape (e.g. inserted a different op between `TROWEXPANDMUL` and `TADD`). Investigate the C++ diff, do not change the pattern names.
+
+## 4. When to Add a New Pattern (and What to Reject)
+
+Adding a new pattern is a non-trivial change -- both the pattern matcher and the dependency walker need entries. A new pattern is justifiable only when:
+
+- The barrier is **provably redundant** -- another barrier, event, or direct tile dependency already serializes the two ops on the PIPE_V scheduler.
+- The pattern matches a **specific op triple**, not a "this barrier looks unused" heuristic. A pattern that says "remove every PIPE_V barrier after TADD" is too broad and will race in some emit context the author has not seen.
+- The removal is measurable on at least one of `case1..case8` and is neutral on the others.
+
+Things to reject:
+
+- Patterns whose safety argument is "we tested it on case4 and it passed". Pattern safety needs an event-ordering argument, not just a passing benchmark.
+- Patterns that depend on a specific ptoas version. ptoas emit churns; pattern matchers need to fail closed (no match -> no removal) when the surrounding C++ shape changes.
+- Patterns that overlap. If two patterns can match the same barrier, the patch summary becomes ambiguous. Make pattern matchers mutually exclusive in their op triple.
+
+## 5. Legacy: Line-Number Removal (`FA_REMOVE_VEC_BARRIERS`)
+
+There is a parallel removal path that takes generated-C++ line numbers directly:
+
+```bash
+FA_REMOVE_VEC_BARRIERS=123,145,167 bash compile.sh
+```
+
+This existed before the op-pattern path and is kept only for one-off experiments where a porter wants to A/B a single suspected barrier. It is **not suitable for default use**:
+
+- Every ptoas emit churn (new op, new pass, new layout) renumbers the file. The line list is stale on the next build.
+- There is no safety check. The line is removed if it is a `pipe_barrier(PIPE_V);`, regardless of what surrounds it.
+
+If you find yourself reaching for it, the answer is almost always to add a new op-pattern (see section 4) -- not to maintain a line list.
+
+## 6. Operational Rules
+
+- Keep `gu` on for any benchmark you report. Disabling it makes the numbers incomparable to the documented case1..case8 watermark.
+- Treat the `softmax-*` patterns as opt-in experiments. If they help on a specific shape, document the shape and the pattern set together; do not flip them on by default.
+- Re-run the case sweep after any ptoas / bisheng version bump. If the patch tool's `removed=` count changes materially, audit the matched lines before trusting the build.
+- Never combine line-number and op-pattern removal in the same build. `compile.sh` accepts both flags but the patch tool then applies them in sequence and the diagnostics get confusing.
+
+## In-Tree Reference
+
+- `kernels/python/flash_atten/scripts/patch_vec_barriers.py` -- the matcher and dependency walker. The pattern-to-alias table (`PATTERN_ALIASES`) is the authoritative list of supported names.
+- `kernels/python/flash_atten/compile.sh` -- where the patch tool is invoked (between ptoas and bisheng) and where `FA_REMOVE_VEC_BARRIER_PATTERNS` / `FA_REMOVE_VEC_BARRIERS` are read.
+- `kernels/python/flash_atten/run.py` -- `--remove-vec-barrier-patterns` / `--remove-vec-barriers` CLI plumbing through to `compile.sh`.

--- a/.claude/skills/pto-isa-flash-atten-a3-pipeline/references/ub-budget-and-tile-sizing.md
+++ b/.claude/skills/pto-isa-flash-atten-a3-pipeline/references/ub-budget-and-tile-sizing.md
@@ -1,0 +1,97 @@
+# UB Budget and Tile Sizing (S1_TILE, row_slice shrink, empirical S1 >= 16384 recommendation)
+
+The Flash Attention four-stage pipeline lives or dies on the vec UB budget. This file is the standalone reference for **how the working tile is sized, why the row_slice shrink is needed, and why the default suite recommends `S1_TILE=512` for `S1 >= 16384`**. The companion pipeline reference covers the timing knobs (`QK_PRELOAD`, `EXP_RING`); this file is purely about memory.
+
+## 1. Why UB Sizing Is the Real Constraint
+
+The four-stage pipeline keeps three fp32 working tiles co-resident in vec UB during steady state:
+
+- the QK working tile (fp32 from cube, `[Vec_S0, S1_TILE]`),
+- the P / softmax working tile (fp32 -> fp16, `[Vec_S0, S1_TILE]`),
+- the PV / O working tile (fp32, `[VecGuRows, HEAD]`),
+
+plus the `exp_max_ring` slots (`[EXP_RING]` x `[TILE_FACTOR]`) and the running `O` and `running_sum` per row_slice. The 192 KiB UB budget on A3 fits all of them only when the per-iteration working tile stays at **32 KiB**. The whole reason `row_slice` exists is to keep the per-iteration tile at 32 KiB even at `S1_TILE = 256`.
+
+## 2. Row-Slice Shrink Formula
+
+Vec walks each logical S1 tile in `TILE_FACTOR` slices along the M direction:
+
+```text
+HEAD        = 128
+VEC_CORES   = 2
+CUBE_S1     = 128
+S1_TILE     = 256 or 512
+TILE_FACTOR = S1_TILE // CUBE_S1                # 2 at 256, 4 at 512
+Vec_S0      = S0 // VEC_CORES // TILE_FACTOR    # 32 at 256, 16 at 512
+VecGuRows   = S0 // VEC_CORES                   # 64 (full subblock, GU/PV)
+```
+
+Per-iteration working-tile size (fp32, `[Vec_S0, S1_TILE]`):
+
+```text
+work_tile_bytes = Vec_S0 * S1_TILE * 4
+                = 32 * 256 * 4 = 32 KiB         at S1_TILE = 256
+                = 16 * 512 * 4 = 32 KiB         at S1_TILE = 512
+```
+
+The size is **constant in 32 KiB by construction** -- the row_slice count grows with `S1_TILE` so the per-slice tile shrinks. Without the row_slice loop, the working tile at `S1_TILE = 256` would be `64 * 256 * 4 = 64 KiB`, which does not co-exist with the other two working tiles in 192 KiB UB. This is the original reason the row_slice loop exists in the manual kernel and the reason the DSL kernel inherits it.
+
+GU and PV do **not** row-split (they operate on the full subblock `VecGuRows = S0 / VEC_CORES = 64`). Only the QK -> softmax -> P chain walks per row_slice. The vec side therefore reads a P slot as `TILE_FACTOR` row_slices of `[Vec_S0, S1_TILE]`, but feeds it into PV consumption as one full `[VecGuRows, HEAD]` view.
+
+## 3. The S1 >= 16384 Tile Recommendation
+
+`run.py` picks `S1_TILE` per shape, not per kernel build. The default suite currently uses:
+
+```python
+def _default_case_s1_tile(seq_len):
+    return 512 if seq_len >= 16384 else 256
+```
+
+This is a **scheduling-overhead heuristic**, not an architectural limit and not a proof of global optimality:
+
+- `S1_TILE = 256` is the baseline empirical value and is the default builder value.
+- For the current large-S1 default shapes (`case5..case8`, `S1 >= 16384`), `S1_TILE = 512` has measured better because it halves `num_tiles_s1` and reduces per-tile FIFO + sync overhead. The working tile stays 32 KiB because `TILE_FACTOR` doubles to 4 and `Vec_S0` halves to 16.
+- For other shape mixes, `S1 >= 16384 -> 512` is a recommended starting point, not a mandatory rule. If a sweep shows 256 or another supported tile size is faster while satisfying the UB and FIFO constraints, document the shape-specific result.
+
+This is the **flash-attn analogue of the GEMM 32 MiB safety-ratio cliff** only in the sense that it is an empirical threshold where one knob may jump because the cost model crosses a boundary. Treat it as a heuristic default, not a hard rule.
+
+Porters with a different shape mix can sweep within the tile sizes implemented by the current library (`{256, 512}`). Supporting any other tile size is an implementation change: update the builder allow-list, re-derive section 2, and adapt the pipeline/barrier assumptions before treating the result as supported.
+
+## 4. Why a Higher S1_TILE Is Not Free
+
+Two costs scale with `S1_TILE`:
+
+- **GM FIFO slot size.** `SLOT_SIZE_QK = S0 * S1_TILE * 4` and `SLOT_SIZE_P = S0 * S1_TILE * 2`. With `SLOT_NUM = 8` on A3 the GM bytes per AIC block grow linearly. This is GM, not UB, so it is generally fine -- but it costs DMA bandwidth proportionally.
+- **`exp_max` ring footprint.** The ring is `EXP_RING * TILE_FACTOR` rescale-factor tiles, and `TILE_FACTOR = S1_TILE / CUBE_S1`. Going to `S1_TILE = 512` doubles `TILE_FACTOR` (2 -> 4), which doubles the per-ring-slot rescale storage on the vec side. The row_slice shrink rebalances the per-iteration working tile, but the ring itself grows.
+
+The cumulative effect is why the default recommendation only switches to 512 at `S1 >= 16384`. At smaller S1 the per-tile FIFO overhead has not yet dominated in the current benchmark suite, so paying the extra ring footprint has not measured better.
+
+## 5. Constraints the Porter Must Enforce
+
+Validate on the host before building the kernel:
+
+- `S1_TILE in {256, 512}` -- the tile-size allow-list implemented by the current library. Extending it requires code changes and shape-specific validation, not just a documentation change.
+- `S1_TILE % CUBE_S1 == 0` -- `TILE_FACTOR` integer.
+- `S0 % (VEC_CORES * TILE_FACTOR) == 0` -- `Vec_S0` integer (`32` at 256, `16` at 512 for `S0 = 128`, `VEC_CORES = 2`).
+- `S1 % S1_TILE == 0` and `S1 >= S1_TILE * QK_PRELOAD` -- see the pipeline reference for why.
+- `EXP_RING == QK_PRELOAD` -- the ring is sized by the pipeline knobs, but it lives in vec UB. Re-check section 1 after any change.
+
+The host validates the first three today via `ValueError` in `fa_builder.py`; the last two are checked in `run.py::_num_tiles`.
+
+## 6. The "FA UB Cliff": Symptom Catalogue
+
+If the kernel builds but ptoas reports local-memory allocation failure or the vec stalls profile out, the working tile is too big:
+
+- Symptom: `local memory allocation failed` from ptoas on a build that previously worked. Cause: someone raised `EXP_RING` without re-checking UB, or added a new vec working tile. Fix: revert the ring change, or split the new tile by row_slice.
+- Symptom: `case5..case8` speedup drops from ~1.0x to ~0.7x with no other change. Possible cause: `S1_TILE` stayed at 256 (e.g. `FA_S1_TILE` env var pinned for a manual sweep) even though 512 is the current recommended default for those shapes. Fix: rerun with the default 512 recommendation and compare before changing the heuristic.
+- Symptom: `case1..case4` speedup drops while `case5..case8` stays put. Possible cause: `S1_TILE` switched to 512 too aggressively below the empirical 16384 boundary. Fix: restore the default 256 baseline for small S1 unless a shape-specific sweep proves otherwise.
+
+## 7. Anti-Patterns
+
+- Removing the row_slice loop "because it adds a loop level". The loop is what keeps the per-iteration tile at 32 KiB. Without it the kernel does not fit in UB.
+- Setting `EXP_RING > QK_PRELOAD` to "have headroom". It does not buy timing slack -- the timing invariant is set by `QK_PRELOAD` alone. It only burns UB.
+- Sweeping `S1_TILE` above 512 without re-deriving section 2. The working-tile budget rebalance only works because `TILE_FACTOR` cleanly divides `S0 / VEC_CORES`. At `S1_TILE = 1024`, `Vec_S0` would be 8 and the row_slice count 8 -- the row_slice loop overhead starts to dominate, and PV / GU do not split, so the asymmetry grows. If you go there, treat it as a new schedule, not a tuning step.
+
+## In-Tree Reference
+
+The numbers in this file come from `kernels/python/flash_atten/kernels/fa_builder.py` constants (`HEAD`, `S0`, `VEC_CORES`, `CUBE_S1`, `S1_TILE`, `TILE_FACTOR`, `Vec_S0`, `VecGuRows`, `SLOT_SIZE_*`, `SLOT_NUM`) and the `_default_case_s1_tile` heuristic in `kernels/python/flash_atten/run.py`. Open those files only when you need to see the budget wired end-to-end; the formulas, cutover, and validation list in this file should be enough to size a new shape on its own.

--- a/kernels/python/flash_atten/README.md
+++ b/kernels/python/flash_atten/README.md
@@ -23,6 +23,54 @@ The case is useful for validating that the Python DSL can express a production-s
 - PTO assembler `ptoas`
 - Python environment with `ptodsl`, `torch`, and `torch_npu`
 
+## External Dependencies
+
+This example is not self-contained. It depends on the PTO Python DSL package
+provided by the external `huawei-csl/pto-dsl` repository:
+
+```text
+https://github.com/huawei-csl/pto-dsl
+```
+
+The version used to validate this example is:
+
+```text
+pto-dsl package version: 0.1.2
+upstream branch: main
+commit: 6755794cfc145c8ffe4fae92483aa20148e57327
+commit date: 2026-05-18 11:18:56 +0200
+```
+
+`ptodsl` is used in two places:
+
+- `kernels/fa_builder.py` imports `ptodsl` to construct the PTO MLIR module.
+- `run.py` imports `ptodsl` benchmark and NPU device helpers.
+
+Install a compatible `pto-dsl` package before building or running this example.
+For example, to install the current upstream main branch:
+
+```bash
+python3 -m pip install --user --upgrade git+https://github.com/huawei-csl/pto-dsl.git
+```
+
+You can verify which `ptodsl` package Python will use with:
+
+```bash
+python3 -c "import ptodsl, inspect; from ptodsl import to_ir_module; print(ptodsl.__file__); print(inspect.signature(to_ir_module))"
+```
+
+The `PTO_LIB_PATH` environment variable used by `compile.sh` is separate from
+the Python `ptodsl` package. `PTO_LIB_PATH` must point to this PTO-ISA tile
+library checkout so that `bisheng` can find headers under `include/`.
+
+The full runtime/build dependency set is:
+
+- `ptodsl` from `https://github.com/huawei-csl/pto-dsl`
+- `torch` and `torch_npu`
+- Ascend CANN runtime/toolkit with `bisheng`
+- `ptoas` compatible with the MLIR emitted by the installed `ptodsl`
+- this repository's PTO C++ headers, supplied through `PTO_LIB_PATH`
+
 ## Directory Layout
 
 ```text
@@ -30,7 +78,11 @@ kernels/python/flash_atten/
 ├── caller.cpp              # Host shim exported as call_kernel for ctypes
 ├── compile.sh              # Generates MLIR/C++ and builds build_artifacts/fa.so
 ├── kernels/
-│   └── fa_builder.py       # PTO Python DSL Flash Attention kernel builder
+│   ├── fa_builder.py       # PTO Python DSL Flash Attention kernel builder
+│   └── ptodsl_compat.py    # Local compatibility layer for ptodsl 0.1.2
+├── scripts/
+│   └── patch_vec_barriers.py
+│                           # Generated-C++ PIPE_V barrier patch helper
 └── run.py                  # Build, run, verify, and benchmark entry point
 ```
 
@@ -39,6 +91,8 @@ Generated files are placed under `build_artifacts/`:
 ```text
 build_artifacts/fa.mlir     # MLIR emitted by fa_builder.py
 build_artifacts/fa.cpp      # C++ emitted by ptoas
+build_artifacts/fa_patched.cpp
+                           # Optional C++ after compile.sh barrier patching
 build_artifacts/fa.so       # Shared library loaded by run.py
 build_artifacts/fa_summary_*.tsv
 ```
@@ -49,12 +103,12 @@ Current shape and feature constraints are intentionally aligned with the manual 
 
 - `HEAD = 128`
 - `S0 = 128` per Q block
-- `TILE_S1 = 256`
+- `TILE_S1 = 256` by default; `FA_S1_TILE=512` is available for experiments
 - `CUBE_S1 = 128`
-- `QK_PRELOAD = 4`
+- `QK_PRELOAD = 3` in the DSL-tuned runtime path (`FA_QK_PRELOAD=4` is available for experiments; `MANUAL_QK_PRELOAD = 4` is kept only as the parity target metadata)
 - non-causal attention only
 - total Q rows are configured by `FA_Q_ROWS` and must be a multiple of `128`
-- total KV rows are supplied at runtime by `run.py`; each S1 length must be compatible with `S1_TILE=256` and `QK_PRELOAD=4`
+- total KV rows are supplied at runtime by `run.py`; each S1 length must be at least `S1_TILE * QK_PRELOAD` and divisible by the selected `S1_TILE`
 
 The generated shared library is specialized for the current `FA_Q_ROWS`, while S1 is handled at runtime.
 
@@ -92,7 +146,7 @@ python3 run.py --case case1
 python3 run.py
 ```
 
-The default suite runs `case1` to `case8` and recompiles the kernel for each `FA_Q_ROWS` value:
+The default suite runs `case1` to `case8` and recompiles the kernel for each `FA_Q_ROWS` value. It uses `TILE_S1=256` for `case1` to `case4`, and `TILE_S1=512` for `case5` to `case8` (`S1 >= 16384`).
 
 | Case | Q rows (S0 total) | KV rows (S1) |
 | --- | ---: | ---: |
@@ -130,6 +184,48 @@ Reuse an existing `build_artifacts/fa.so` when it was already compiled for the s
 ```bash
 FA_Q_ROWS=1024 bash compile.sh
 FA_Q_ROWS=1024 FA_BENCH_LENGTHS=1024 python3 run.py --no-build
+```
+
+## Removing Redundant PIPE_V Barriers
+
+`compile.sh` can patch selected `pipe_barrier(PIPE_V);` statements after `ptoas` emits C++ and before `bisheng` builds the shared library. Prefer op-pattern based removal over fixed generated-C++ line numbers:
+
+The stable `gu` pattern is enabled by default for `compile.sh` and `run.py`. Additional patterns can be supplied explicitly:
+
+```bash
+python3 run.py --case case1
+python3 run.py --remove-vec-barrier-patterns gu,softmax-sum-add
+```
+
+The same option can be passed through the environment:
+
+```bash
+FA_REMOVE_VEC_BARRIER_PATTERNS=gu,softmax-sum-add python3 run.py
+```
+
+Pass `--remove-vec-barrier-patterns none` to disable the default `gu` patch for comparison runs.
+
+Supported patterns:
+
+| Pattern | Aliases | Effect | Notes |
+| --- | --- | --- | --- |
+| `gu` | `trowexpandmul-tadd` | Removes the vector barrier in `TROWEXPANDMUL -> pipe_barrier(PIPE_V) -> wait_flag(PIPE_MTE2, PIPE_V) -> TADD`. | Stable strategy. It targets redundant V-pipe barriers in `compute_gu` where the MTE wait already provides spacing. |
+| `softmax-exp-sum` | `texp-trowsum` | Attempts to remove the barrier in `TEXP -> pipe_barrier(PIPE_V) -> TROWSUM`. | Guarded by direct tile-dependency checks. If `TROWSUM` reads a tile written by `TEXP`, the candidate is kept and reported as skipped. |
+| `softmax-sum-add` | `trowsum-tadd` | Removes barriers in `TROWSUM -> pipe_barrier(PIPE_V) -> TADD` when there is no direct tile dependency. | Experimental strategy. It can be combined with `gu`; small and mid-sized cases may improve, while large cases are usually close to neutral. |
+
+The build log reports how many barriers were actually removed, for example:
+
+```text
+Patched generated C++ -> .../fa_patched.cpp (removed 74 PIPE_V barriers; lines=0, patterns=74)
+Skipped PIPE_V barrier pattern candidates: softmax-exp-sum:direct-tile-dependency=2
+```
+
+For line-number based experiments, `--remove-vec-barriers line1,line2,...` and `FA_REMOVE_VEC_BARRIERS` are also available. This mode depends on the current generated C++ line numbers and is not recommended as the default workflow.
+
+Performance validation should cover the full default case set. `ptodsl` event timing can occasionally report invalid 0.x us timings for the `ctypes` custom kernel launch path; use the conservative synchronized timing mode when validating barrier-removal performance:
+
+```bash
+python3 run.py --timing sync
 ```
 
 ## Output and Correctness

--- a/kernels/python/flash_atten/README_zh.md
+++ b/kernels/python/flash_atten/README_zh.md
@@ -23,6 +23,50 @@ https://github.com/huawei-csl/pto-dsl/tree/main/examples/aot/flash_attention/140
 - PTO 汇编器 `ptoas`
 - 包含 `ptodsl`、`torch`、`torch_npu` 的 Python 环境
 
+## 外部依赖
+
+本用例不是自包含示例。它依赖外部 `huawei-csl/pto-dsl` 仓提供的 PTO Python DSL 包：
+
+```text
+https://github.com/huawei-csl/pto-dsl
+```
+
+本用例已验证的版本信息如下：
+
+```text
+pto-dsl package version: 0.1.2
+upstream branch: main
+commit: 6755794cfc145c8ffe4fae92483aa20148e57327
+commit date: 2026-05-18 11:18:56 +0200
+```
+
+`ptodsl` 在两处被使用：
+
+- `kernels/fa_builder.py` 导入 `ptodsl` 来构造 PTO MLIR module。
+- `run.py` 导入 `ptodsl` 的 benchmark 和 NPU device helper。
+
+构建或运行本用例前，需要先安装兼容版本的 `pto-dsl` 包。例如安装当前上游 main 分支：
+
+```bash
+python3 -m pip install --user --upgrade git+https://github.com/huawei-csl/pto-dsl.git
+```
+
+可以用下面的命令确认 Python 实际导入的是哪个 `ptodsl` 包：
+
+```bash
+python3 -c "import ptodsl, inspect; from ptodsl import to_ir_module; print(ptodsl.__file__); print(inspect.signature(to_ir_module))"
+```
+
+`compile.sh` 使用的 `PTO_LIB_PATH` 与 Python `ptodsl` 包是两类不同依赖。`PTO_LIB_PATH` 必须指向当前 PTO-ISA tile library 仓库 checkout，以便 `bisheng` 找到 `include/` 下的头文件。
+
+完整的构建/运行依赖包括：
+
+- 来自 `https://github.com/huawei-csl/pto-dsl` 的 `ptodsl`
+- `torch` 和 `torch_npu`
+- 包含 `bisheng` 的 Ascend CANN runtime/toolkit
+- 与已安装 `ptodsl` 生成的 MLIR 兼容的 `ptoas`
+- 通过 `PTO_LIB_PATH` 提供的本仓 PTO C++ 头文件
+
 ## 目录结构
 
 ```text
@@ -30,7 +74,11 @@ kernels/python/flash_atten/
 ├── caller.cpp              # Host 侧 shim，导出供 ctypes 调用的 call_kernel
 ├── compile.sh              # 生成 MLIR/C++，并构建 build_artifacts/fa.so
 ├── kernels/
-│   └── fa_builder.py       # PTO Python DSL Flash Attention kernel 构造器
+│   ├── fa_builder.py       # PTO Python DSL Flash Attention kernel 构造器
+│   └── ptodsl_compat.py    # ptodsl 0.1.2 本地兼容层
+├── scripts/
+│   └── patch_vec_barriers.py
+│                           # 生成 C++ 的 PIPE_V barrier patch helper
 └── run.py                  # 构建、运行、校验和性能测试入口
 ```
 
@@ -39,6 +87,8 @@ kernels/python/flash_atten/
 ```text
 build_artifacts/fa.mlir     # fa_builder.py 生成的 MLIR
 build_artifacts/fa.cpp      # ptoas 生成的 C++
+build_artifacts/fa_patched.cpp
+                           # compile.sh 删除 barrier 后的可选 C++ 产物
 build_artifacts/fa.so       # run.py 加载的动态库
 build_artifacts/fa_summary_*.tsv
 ```
@@ -49,12 +99,12 @@ build_artifacts/fa_summary_*.tsv
 
 - `HEAD = 128`
 - 每个 Q block 的 `S0 = 128`
-- `TILE_S1 = 256`
+- 默认 `TILE_S1 = 256`；可通过 `FA_S1_TILE=512` 进行实验
 - `CUBE_S1 = 128`
-- `QK_PRELOAD = 4`
+- DSL 调优后的运行路径使用 `QK_PRELOAD = 3`（可通过 `FA_QK_PRELOAD=4` 进行实验；`MANUAL_QK_PRELOAD = 4` 仅保留为 parity 目标元数据）
 - 仅支持非 causal attention
 - Q 总行数通过 `FA_Q_ROWS` 配置，并且必须是 `128` 的整数倍
-- KV 总行数由 `run.py` 在运行时传入；每个 S1 长度需要满足 `S1_TILE=256` 和 `QK_PRELOAD=4` 的整除约束
+- KV 总行数由 `run.py` 在运行时传入；每个 S1 长度需要不小于 `S1_TILE * QK_PRELOAD`，并且能被所选 `S1_TILE` 整除
 
 生成的动态库会针对当前 `FA_Q_ROWS` 特化，S1 长度则在运行时处理。
 
@@ -92,7 +142,7 @@ python3 run.py --case case1
 python3 run.py
 ```
 
-默认集合会运行 `case1` 到 `case8`，并针对每个 `FA_Q_ROWS` 重新编译 kernel：
+默认集合会运行 `case1` 到 `case8`，并针对每个 `FA_Q_ROWS` 重新编译 kernel。`case1` 到 `case4` 使用 `TILE_S1=256`，`case5` 到 `case8`（`S1 >= 16384`）使用 `TILE_S1=512`：
 
 | Case | Q rows（S0 total） | KV rows（S1） |
 | --- | ---: | ---: |
@@ -130,6 +180,48 @@ FA_Q_ROWS=1024 FA_BENCH_LENGTHS=1024 FA_BENCH_WARMUP=20 FA_BENCH_ITERS=200 pytho
 ```bash
 FA_Q_ROWS=1024 bash compile.sh
 FA_Q_ROWS=1024 FA_BENCH_LENGTHS=1024 python3 run.py --no-build
+```
+
+## 删除冗余 PIPE_V Barrier
+
+`compile.sh` 支持在 `ptoas` 生成 C++ 后、`bisheng` 编译前删除选定的 `pipe_barrier(PIPE_V);`。推荐使用基于 op pattern 的方式，而不是依赖生成文件中的固定行号：
+
+稳定的 `gu` pattern 已作为 `compile.sh` 和 `run.py` 的默认行为启用。需要额外 pattern 时可以显式传入：
+
+```bash
+python3 run.py --case case1
+python3 run.py --remove-vec-barrier-patterns gu,softmax-sum-add
+```
+
+也可以通过环境变量传入：
+
+```bash
+FA_REMOVE_VEC_BARRIER_PATTERNS=gu,softmax-sum-add python3 run.py
+```
+
+需要关闭默认 `gu` patch 做对比时，可以传入 `--remove-vec-barrier-patterns none`。
+
+当前支持的 pattern：
+
+| Pattern | 别名 | 作用 | 说明 |
+| --- | --- | --- | --- |
+| `gu` | `trowexpandmul-tadd` | 删除 `TROWEXPANDMUL -> pipe_barrier(PIPE_V) -> wait_flag(PIPE_MTE2, PIPE_V) -> TADD` 中的 vector barrier | 当前稳定策略，用于减少 `compute_gu` 阶段中 MTE wait 已经提供间隔时的冗余 V pipe barrier。 |
+| `softmax-exp-sum` | `texp-trowsum` | 尝试删除 `TEXP -> pipe_barrier(PIPE_V) -> TROWSUM` 中的 barrier | 带直接 tile 依赖检查。若 `TROWSUM` 读取 `TEXP` 写出的 tile，该候选会被保留并在编译日志中报告 skipped。 |
+| `softmax-sum-add` | `trowsum-tadd` | 删除 `TROWSUM -> pipe_barrier(PIPE_V) -> TADD` 中无直接 tile 依赖的 barrier | 实验策略，可与 `gu` 组合验证；对小/中尺寸 case 可能有收益，大尺寸通常接近持平。 |
+
+编译日志会输出实际删除数量，例如：
+
+```text
+Patched generated C++ -> .../fa_patched.cpp (removed 74 PIPE_V barriers; lines=0, patterns=74)
+Skipped PIPE_V barrier pattern candidates: softmax-exp-sum:direct-tile-dependency=2
+```
+
+需要按行号复现实验时，也可以使用 `--remove-vec-barriers line1,line2,...` 或 `FA_REMOVE_VEC_BARRIERS`，但该方式依赖当前生成 C++ 的行号，不适合作为默认方案。
+
+性能验证时建议至少运行默认全量 case。`ptodsl` event timing 对 `ctypes` 自定义 kernel launch 偶发可能出现不可信的 0.x us 结果；此时应使用更保守的同步计时模式：
+
+```bash
+python3 run.py --timing sync
 ```
 
 ## 输出与正确性

--- a/kernels/python/flash_atten/caller.cpp
+++ b/kernels/python/flash_atten/caller.cpp
@@ -5,10 +5,9 @@
  * Please refer to the License for details. You may not use this file except in compliance with the License.
  *
  * Host shim for the pto-dsl flash-attention kernel. compile.sh injects
- *   -DKERNEL_CPP="\"build_artifacts/fa.cpp\""
- * which makes this TU include the ptoas-generated kernel that defines
- * `call_both`. The single exported symbol `call_kernel` is what run.py
- * calls via ctypes.
+ * KERNEL_CPP with the generated or patched kernel source that defines
+ * `call_both`. The single exported symbol `call_kernel` is what run.py calls
+ * via ctypes.
  */
 
 #ifndef KERNEL_CPP

--- a/kernels/python/flash_atten/compile.sh
+++ b/kernels/python/flash_atten/compile.sh
@@ -7,8 +7,12 @@
 # benchmark lengths.
 #
 # Usage:
-#   bash compile.sh                                # build build_artifacts/fa.so
-#   PTO_LIB_PATH=/abs/pto-isa bash compile.sh      # override include path
+#   bash compile.sh
+#   bash compile.sh --remove-vec-barriers line1,line2,...      # remove selected PIPE_V barriers
+#   bash compile.sh --remove-vec-barrier-patterns gu,softmax-sum-add
+#   FA_REMOVE_VEC_BARRIERS=line1,line2,... bash compile.sh     # same via env
+#   FA_REMOVE_VEC_BARRIER_PATTERNS=gu,softmax-sum-add bash compile.sh
+#   PTO_LIB_PATH=/abs/pto-isa bash compile.sh                  # override include path
 
 set -euo pipefail
 
@@ -17,18 +21,73 @@ ARTIFACT_DIR="${SCRIPT_DIR}/build_artifacts"
 PTO_LIB_PATH="${PTO_LIB_PATH:-/sources/pto-isa}"
 PTOAS="${PTOAS:-ptoas}"
 BISHENG="${BISHENG:-bisheng}"
+REMOVE_VEC_BARRIER_LINES="${FA_REMOVE_VEC_BARRIERS:-}"
+REMOVE_VEC_BARRIER_PATTERNS="${FA_REMOVE_VEC_BARRIER_PATTERNS:-gu}"
+
+usage() {
+    cat >&2 <<EOF
+Usage: $0 [--remove-vec-barriers line1,line2,...] [--remove-vec-barrier-patterns gu,softmax-exp-sum,softmax-sum-add]
+
+Environment:
+  FA_REMOVE_VEC_BARRIERS          Comma-separated generated-C++ line numbers to patch.
+  FA_REMOVE_VEC_BARRIER_PATTERNS  Comma-separated pattern names. Defaults to stable pattern: gu.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --remove-vec-barriers)
+            if [[ $# -lt 2 || -z "$2" ]]; then
+                echo "--remove-vec-barriers requires a comma-separated line list" >&2
+                usage
+                exit 2
+            fi
+            REMOVE_VEC_BARRIER_LINES="$2"
+            shift 2
+            ;;
+        --remove-vec-barrier-patterns)
+            if [[ $# -lt 2 || -z "$2" ]]; then
+                echo "--remove-vec-barrier-patterns requires a comma-separated pattern list" >&2
+                usage
+                exit 2
+            fi
+            REMOVE_VEC_BARRIER_PATTERNS="$2"
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Unknown argument: $1" >&2
+            usage
+            exit 2
+            ;;
+    esac
+done
 
 mkdir -p "${ARTIFACT_DIR}"
 
 MLIR_PATH="${ARTIFACT_DIR}/fa.mlir"
 GENERATED_CPP="${ARTIFACT_DIR}/fa.cpp"
+PATCHED_CPP="${ARTIFACT_DIR}/fa_patched.cpp"
 LIB_PATH="${ARTIFACT_DIR}/fa.so"
 
 echo "==> Building runtime-S1 fa -> ${LIB_PATH}"
-rm -f "${MLIR_PATH}" "${GENERATED_CPP}" "${LIB_PATH}"
+rm -f "${MLIR_PATH}" "${GENERATED_CPP}" "${PATCHED_CPP}" "${LIB_PATH}"
 
-python "${SCRIPT_DIR}/kernels/fa_builder.py" > "${MLIR_PATH}"
+python3 "${SCRIPT_DIR}/kernels/fa_builder.py" > "${MLIR_PATH}"
 "${PTOAS}" --pto-arch=a3 --enable-insert-sync "${MLIR_PATH}" > "${GENERATED_CPP}"
+
+COMPILE_CPP="${GENERATED_CPP}"
+if [[ -n "${REMOVE_VEC_BARRIER_LINES}${REMOVE_VEC_BARRIER_PATTERNS}" ]]; then
+    python3 "${SCRIPT_DIR}/scripts/patch_vec_barriers.py" \
+        "${GENERATED_CPP}" \
+        "${PATCHED_CPP}" \
+        --remove-vec-barriers "${REMOVE_VEC_BARRIER_LINES}" \
+        --remove-vec-barrier-patterns "${REMOVE_VEC_BARRIER_PATTERNS}"
+    COMPILE_CPP="${PATCHED_CPP}"
+fi
 
 "${BISHENG}" \
     -I"${PTO_LIB_PATH}/include" \
@@ -43,8 +102,12 @@ python "${SCRIPT_DIR}/kernels/fa_builder.py" > "${MLIR_PATH}"
     -cce-enable-mix \
     --npu-arch=dav-2201 -DMEMORY_BASE \
     -std=gnu++17 \
-    -DKERNEL_CPP="\"${GENERATED_CPP}\"" \
+    -DKERNEL_CPP="\"${COMPILE_CPP}\"" \
     "${SCRIPT_DIR}/caller.cpp" \
     -o "${LIB_PATH}"
 
+echo "Generated ${GENERATED_CPP}"
+if [[ "${COMPILE_CPP}" != "${GENERATED_CPP}" ]]; then
+    echo "Patched ${COMPILE_CPP}"
+fi
 echo "Done. Built ${LIB_PATH}"

--- a/kernels/python/flash_atten/kernels/fa_builder.py
+++ b/kernels/python/flash_atten/kernels/fa_builder.py
@@ -11,15 +11,15 @@ Host-visible shape:
   * HEAD is fixed at 128 (current kernel locks head dim to manual case).
   * `S0` here is the per-AIC-core Q-block size and stays at 128.
   * `Q_ROWS` is the total Q sequence length; configurable per case via the
-    FA_Q_ROWS env var (defaults to 128). It must be a multiple of S0=128
-    because the kernel iterates Q in S0-row blocks across cores. Common
-    Prefill cases set FA_Q_ROWS to 1024..131072.
+    FA_Q_ROWS env var. The builder fallback is 128, while run.py's built-in
+    default suite sets FA_Q_ROWS to 1024..131072. Q_ROWS must be a multiple
+    of S0=128 because the kernel iterates Q in S0-row blocks across cores.
   * S1 (total KV rows) is taken at runtime via the kernel argument, so the
     same .so handles any S1 that satisfies the S1_TILE / QK_PRELOAD
     multiplicity check in run.py::_num_tiles.
 
-Internal S1 tiling is intentionally set to the manual `TILE_S1=256` for
-parity experiments.
+Internal S1 tiling defaults to the manual `TILE_S1=256` for parity
+experiments. `FA_S1_TILE=512` is available for large-shape benchmark runs.
 
 The reference C++ kernel is a 4-stage cross-core software-pipelined Flash
 Attention:
@@ -32,15 +32,12 @@ Attention:
 DSL constraints relative to the C++ source:
 
   * `tile.triu` is not exposed -> CAUSAL_MASK=False only.
-  * MAT/RIGHT subview verifier rejects partial-column subviews -> we cannot
-    fuse "load wide K once, sub-tile matmul into ACC subview"; this parity
-    experiment therefore uses one DSL tile with TILE_S1=256.
-  * `--enable-insert-sync` requires careful event-slot reuse at QK_PRELOAD=4;
-    the 8-slot `exp_max` ring keeps softmax(t+4) from clobbering gu(t)'s
-    rescale factor.
-  * TILE_S1=256 is expected to stress VEC UB allocation; keep this variant
-    as the direct manual-parity experiment even when ptoas reports local-memory
-    allocation failures.
+  * MAT/RIGHT subview verifier rejects partial-column subviews -> this builder
+    emits CUBE_S1-width K/V loads inside each runtime S1 tile.
+  * `--enable-insert-sync` requires careful event-slot reuse. EXP_RING is kept
+    equal to QK_PRELOAD so softmax and GU use matching rescale slots.
+  * TILE_S1=256 is the manual-parity default; TILE_S1=512 trades larger
+    per-tile buffers for fewer runtime S1 tiles in large benchmark cases.
   * `pto.alloc_tile` is single-output -> Python aliases (`[buf, buf]`)
     preserve the `[buf]` indexing pattern from the C++ source without
     pretending we have ping-pong storage.
@@ -53,8 +50,10 @@ variant per sequence length.
 import math
 import os
 
-from ptodsl import pto, tile, to_ir_module
+from ptodsl import pto, tile
 from ptodsl import scalar as s
+
+from ptodsl_compat import as_tensor, slice_view, to_ir_module_with_meta
 
 
 const = s.const
@@ -66,9 +65,9 @@ const = s.const
 # the manual case's benchmark intent (S0/CUBE_S0 = 1 in generated_cases.h).
 # Host-visible Q[128,128] / K[128,1024] / V[1024,128] / O[128,128].
 #
-# TILE_S1=256 mirrors the manual kernel. This intentionally ignores the
-# previous smaller-tile workaround so compile/on-board behavior can expose the
-# exact DSL-vs-manual resource gap.
+# TILE_S1=256 mirrors the manual kernel. FA_S1_TILE=512 is reserved for large
+# default benchmark cases where fewer runtime S1 tiles reduce scheduling
+# overhead.
 # =============================================================================
 MANUAL_S0 = 128
 MANUAL_HEAD = 128
@@ -90,10 +89,16 @@ VEC_CORES = 2
 # KiB UB. VecGuRows = S0_HALF (full subblock row count) is used by GU/PV which
 # do not row-split.
 CUBE_S1 = 128
-S1_TILE = 256
+S1_TILE = int(os.environ.get("FA_S1_TILE", "256"))
+if S1_TILE not in (256, 512):
+    raise ValueError("FA_S1_TILE must be 256 or 512, got {}".format(S1_TILE))
+if S1_TILE % CUBE_S1 != 0:
+    raise ValueError("FA_S1_TILE={} must be a multiple of CUBE_S1={}".format(S1_TILE, CUBE_S1))
 TILE_FACTOR = S1_TILE // CUBE_S1
-Vec_S0 = S0 // VEC_CORES // TILE_FACTOR     # = 32 (per row_slice)
-VecGuRows = S0 // VEC_CORES                 # = 64 (full subblock = S0_HALF)
+Vec_S0 = S0 // VEC_CORES // TILE_FACTOR  # = 32 (per row_slice)
+VecGuRows = S0 // VEC_CORES  # = 64 (full subblock = S0_HALF)
+if VecGuRows % TILE_FACTOR != 0:
+    raise ValueError("VecGuRows={} must be divisible by TILE_FACTOR={}".format(VecGuRows, TILE_FACTOR))
 
 Q_ROWS = int(os.environ.get("FA_Q_ROWS", "128"))
 if Q_ROWS % S0 != 0:
@@ -104,15 +109,19 @@ if Q_ROWS % S0 != 0:
     )
 NUM_Q_BLOCKS = Q_ROWS // S0
 
-# QK preload depth. Manual defaults to 4; the exp_max ring below has one slot
-# per preloaded logical S1 tile so GU never reads a slot after softmax overwrote
-# it for tile+QK_PRELOAD.
-QK_PRELOAD = 4
+# QK preload depth. The 140tflops DSL path defaults to 3; this keeps a shorter
+# steady-state distance between softmax and GU than the manual-parity QK=4 path.
+QK_PRELOAD = int(os.environ.get("FA_QK_PRELOAD", os.environ.get("FA_DSL_QK_PRELOAD", "3")))
+if QK_PRELOAD not in (3, 4):
+    raise ValueError("FA_QK_PRELOAD must be 3 or 4, got {}".format(QK_PRELOAD))
+EXP_RING = int(os.environ.get("FA_EXP_RING", os.environ.get("FA_DSL_EXP_RING", str(QK_PRELOAD))))
+if EXP_RING != QK_PRELOAD:
+    raise ValueError("FA_EXP_RING must currently equal FA_QK_PRELOAD ({}), got {}".format(QK_PRELOAD, EXP_RING))
 
 # Per-pipe slot sizes (bytes).
-SLOT_SIZE_QK = S0 * S1_TILE * 4   # fp32 QK accumulator
-SLOT_SIZE_PV = S0 * HEAD * 4      # fp32 PV accumulator
-SLOT_SIZE_P = S0 * S1_TILE * 2    # fp16 softmax(QK) sent vec -> cube
+SLOT_SIZE_QK = S0 * S1_TILE * 4  # fp32 QK accumulator
+SLOT_SIZE_PV = S0 * HEAD * 4  # fp32 PV accumulator
+SLOT_SIZE_P = S0 * S1_TILE * 2  # fp16 softmax(QK) sent vec -> cube
 
 # `dir_mask=1`/`dir_mask=2` always map to slot_num=8 on a3.
 SLOT_NUM = 8
@@ -127,12 +136,11 @@ SPLIT_UP_DOWN = 1  # TileSplitAxis::TILE_UP_DOWN
 
 
 # =============================================================================
-# Type definitions exposed to the DSL via meta_data().
+# Type definitions exposed to the DSL frontend as module-level lazy globals.
 # =============================================================================
 def meta_data():
     fp16 = pto.float16
     fp32 = pto.float32
-    ffts_ty = pto.ffts_type
     ptr_fp16 = pto.PtrType(fp16)
     ptr_fp32 = pto.PtrType(fp32)
     i64 = pto.int64
@@ -156,9 +164,7 @@ def meta_data():
     # Vec consumes the QK slot in TILE_FACTOR row_slices of [Vec_S0, S1_TILE]
     # each, mirroring the manual `compute_p` row_slice loop and shrinking the
     # per-iteration UB working tile from 64 KiB to 32 KiB at S1_TILE=256.
-    qk_vec_slot_part_ty = pto.SubTensorType(
-        shape=[Vec_S0, S1_TILE], dtype=fp32
-    )
+    qk_vec_slot_part_ty = pto.SubTensorType(shape=[Vec_S0, S1_TILE], dtype=fp32)
     # PV slot (cube -> vec, fp32 [S0, HEAD]); width does not scale with S1_TILE
     # because one PV is produced per logical TILE_S1 by accumulating sub-PV
     # matmuls into the same accumulator (manual C++ semantic).
@@ -189,33 +195,21 @@ def meta_data():
         memory_space="MAT",
         config=pto.TileBufConfig(blayout="RowMajor", slayout="ColMajor"),
     )
-    k_right_ty = pto.TileBufType(
-        shape=[HEAD, CUBE_S1], dtype=fp16, memory_space="RIGHT"
-    )
+    k_right_ty = pto.TileBufType(shape=[HEAD, CUBE_S1], dtype=fp16, memory_space="RIGHT")
     qk_acc_ty = pto.TileBufType(shape=[S0, CUBE_S1], dtype=fp32, memory_space="ACC")
     p_recv_ty = pto.TileBufType(shape=[S0, CUBE_S1], dtype=fp16, memory_space="MAT")
     p_left_ty = pto.TileBufType(shape=[S0, CUBE_S1], dtype=fp16, memory_space="LEFT")
     v_mat_ty = pto.TileBufType(shape=[CUBE_S1, HEAD], dtype=fp16, memory_space="MAT")
-    v_right_ty = pto.TileBufType(
-        shape=[CUBE_S1, HEAD], dtype=fp16, memory_space="RIGHT"
-    )
+    v_right_ty = pto.TileBufType(shape=[CUBE_S1, HEAD], dtype=fp16, memory_space="RIGHT")
     pv_acc_ty = pto.TileBufType(shape=[S0, HEAD], dtype=fp32, memory_space="ACC")
 
     # ---- Vec tiles (UB). The QK softmax stage uses Vec_S0 rows per row_slice
     # iteration (manual alignment), while PV/GU stages use the full VecGuRows
     # row count of the subblock.
-    qk_vec_ty = pto.TileBufType(
-        shape=[Vec_S0, S1_TILE], dtype=fp32, memory_space="VEC"
-    )
-    p_fp32_ty = pto.TileBufType(
-        shape=[Vec_S0, S1_TILE], dtype=fp32, memory_space="VEC"
-    )
-    p_fp16_ty = pto.TileBufType(
-        shape=[Vec_S0, S1_TILE], dtype=fp16, memory_space="VEC"
-    )
-    pv_vec_ty = pto.TileBufType(
-        shape=[Vec_S0, HEAD], dtype=fp32, memory_space="VEC"
-    )
+    qk_vec_ty = pto.TileBufType(shape=[Vec_S0, S1_TILE], dtype=fp32, memory_space="VEC")
+    p_fp32_ty = pto.TileBufType(shape=[Vec_S0, S1_TILE], dtype=fp32, memory_space="VEC")
+    p_fp16_ty = pto.TileBufType(shape=[Vec_S0, S1_TILE], dtype=fp16, memory_space="VEC")
+    pv_vec_ty = pto.TileBufType(shape=[Vec_S0, HEAD], dtype=fp32, memory_space="VEC")
     o_vec_ty = pto.TileBufType(shape=[Vec_S0, HEAD], dtype=fp32, memory_space="VEC")
 
     # Reduction tile (per-row scalar). Per-slice = [Vec_S0, 1]; running state
@@ -226,19 +220,30 @@ def meta_data():
         memory_space="VEC",
         config=pto.TileBufConfig(blayout="ColMajor", slayout="NoneBox"),
     )
-    red_row_ty = pto.TileBufType(
-        shape=[1, Vec_S0], dtype=fp32, memory_space="VEC"
-    )
+    red_row_ty = pto.TileBufType(shape=[1, Vec_S0], dtype=fp32, memory_space="VEC")
 
     return locals()
+
+
+# Runtime values are injected by to_ir_module_with_meta(meta_data=...). The
+# placeholders make that dynamic contract visible to static checkers.
+ptr_fp16 = ptr_fp32 = i64 = None
+qkv_tensor_ty = o_tensor_ty = None
+q_sub_ty = kt_sub_ty = v_sub_ty = o_sub_slice_ty = None
+qk_slot_ty = qk_slot_part_ty = qk_vec_slot_ty = qk_vec_slot_part_ty = None
+pv_slot_ty = pv_slot_part_ty = pv_vec_slot_ty = pv_vec_slot_part_ty = None
+p_slot_ty = p_slot_part_ty = p_cube_slot_ty = p_cube_slot_part_ty = None
+q_mat_ty = q_left_ty = k_mat_ty = k_right_ty = qk_acc_ty = None
+p_recv_ty = p_left_ty = v_mat_ty = v_right_ty = pv_acc_ty = None
+qk_vec_ty = p_fp32_ty = p_fp16_ty = pv_vec_ty = o_vec_ty = None
+red_ty = red_row_ty = None
 
 
 # =============================================================================
 # Module
 # =============================================================================
-@to_ir_module(meta_data=meta_data, module=True)
+@to_ir_module_with_meta(meta_data=meta_data, module=True)
 def module():
-
     # -------------------------------------------------------------------------
     # Helper: even share of NUM_Q_BLOCKS across this core grid.
     # The C++ kernel uses one Q-row block per AIC core (block_idx -> Q rows);
@@ -271,7 +276,6 @@ def module():
     ) -> None:
         c0 = const(0)
         c1 = const(1)
-        c2 = const(2)
         cS0 = const(S0)
         cHEAD = const(HEAD)
         cCUBE_S1 = const(CUBE_S1)
@@ -293,48 +297,21 @@ def module():
         gm_p = pto.add_ptr(gm_blk_fp16, const(2 * GM_P_OFF_F32))
 
         # ---- QK pipe (cube producer): l2g2l GM-staged slot ----
-        qk_slot_view = pto.as_tensor(
-            qk_slot_ty,
-            ptr=gm_qk,
-            shape=[cS0, cS1_TILE],
-            strides=[cS1_TILE, c1],
-        )
+        qk_slot_view = as_tensor(qk_slot_ty, ptr=gm_qk, shape=[cS0, cS1_TILE], strides=[cS1_TILE, c1])
         qk_pipe = pto.initialize_l2g2l_pipe(
-            dir_mask=1,
-            slot_size=SLOT_SIZE_QK,
-            slot_num=SLOT_NUM,
-            gm_addr=qk_slot_view,
-            flag_base=0,
+            dir_mask=1, slot_size=SLOT_SIZE_QK, slot_num=SLOT_NUM, gm_addr=qk_slot_view, flag_base=0
         )
 
         # ---- PV pipe (cube producer): l2g2l GM-staged slot ----
-        pv_slot_view = pto.as_tensor(
-            pv_slot_ty,
-            ptr=gm_pv,
-            shape=[cS0, cHEAD],
-            strides=[cHEAD, c1],
-        )
+        pv_slot_view = as_tensor(pv_slot_ty, ptr=gm_pv, shape=[cS0, cHEAD], strides=[cHEAD, c1])
         pv_pipe = pto.initialize_l2g2l_pipe(
-            dir_mask=1,
-            slot_size=SLOT_SIZE_PV,
-            slot_num=SLOT_NUM,
-            gm_addr=pv_slot_view,
-            flag_base=4,
+            dir_mask=1, slot_size=SLOT_SIZE_PV, slot_num=SLOT_NUM, gm_addr=pv_slot_view, flag_base=4
         )
 
         # ---- P pipe (cube consumer of vec output): l2g2l GM-staged slot ----
-        p_slot_view_cube = pto.as_tensor(
-            p_cube_slot_ty,
-            ptr=gm_p,
-            shape=[cS0, cS1_TILE],
-            strides=[cS1_TILE, c1],
-        )
+        p_slot_view_cube = as_tensor(p_cube_slot_ty, ptr=gm_p, shape=[cS0, cS1_TILE], strides=[cS1_TILE, c1])
         p_pipe = pto.initialize_l2g2l_pipe(
-            dir_mask=2,
-            slot_size=SLOT_SIZE_P,
-            slot_num=SLOT_NUM,
-            gm_addr=p_slot_view_cube,
-            flag_base=2,
+            dir_mask=2, slot_size=SLOT_SIZE_P, slot_num=SLOT_NUM, gm_addr=p_slot_view_cube, flag_base=2
         )
 
         # ---- Allocate cube tiles. Match the manual kernel's ping-pong for
@@ -360,19 +337,9 @@ def module():
         v_right = [v_right_a, v_right_a]
         pv_acc = [pv_acc_a, pv_acc_a]
 
-        tv_q = pto.as_tensor(
-            qkv_tensor_ty, ptr=gm_q, shape=[s0, cHEAD], strides=[cHEAD, c1]
-        )
-        tv_k = pto.as_tensor(
-            qkv_tensor_ty,
-            ptr=gm_k,
-            shape=[cHEAD, s1],
-            strides=[c1, cHEAD],
-            layout="DN",
-        )
-        tv_v = pto.as_tensor(
-            qkv_tensor_ty, ptr=gm_v, shape=[s1, cHEAD], strides=[cHEAD, c1]
-        )
+        tv_q = as_tensor(qkv_tensor_ty, ptr=gm_q, shape=[s0, cHEAD], strides=[cHEAD, c1])
+        tv_k = as_tensor(qkv_tensor_ty, ptr=gm_k, shape=[cHEAD, s1], strides=[c1, cHEAD], layout="DN")
+        tv_v = as_tensor(qkv_tensor_ty, ptr=gm_v, shape=[s1, cHEAD], strides=[cHEAD, c1])
 
         qk_entry = pto.declare_global(qk_slot_ty)
         p_entry = pto.declare_global(p_cube_slot_ty)
@@ -381,7 +348,7 @@ def module():
         # Closures over the shared tile state. The steady state overlaps PV for
         # the current S1 tile with QK for the next S1 tile at CUBE_S1 granularity.
         def emit_qk_sub(s1_tile_idx, sub, b):
-            kt_view = pto.slice_view(
+            kt_view = slice_view(
                 kt_sub_ty,
                 source=tv_k,
                 offsets=[c0, s1_tile_idx * cS1_TILE + const(sub * CUBE_S1)],
@@ -390,11 +357,8 @@ def module():
             pto.load(kt_view, k_mat[b])
             tile.mov(k_mat[b], k_right[b])
             tile.matmul(q_left, k_right[b], qk_acc[b])
-            slot_part = pto.slice_view(
-                qk_slot_part_ty,
-                source=qk_entry,
-                offsets=[c0, const(sub * CUBE_S1)],
-                sizes=[cS0, cCUBE_S1],
+            slot_part = slice_view(
+                qk_slot_part_ty, source=qk_entry, offsets=[c0, const(sub * CUBE_S1)], sizes=[cS0, cCUBE_S1]
             )
             pto.store(qk_acc[b], slot_part)
 
@@ -405,19 +369,13 @@ def module():
             pto.tpush(qk_entry, qk_pipe, SPLIT_UP_DOWN)
 
         def emit_pv_sub(t_idx, sub, b):
-            p_part = pto.slice_view(
-                p_cube_slot_part_ty,
-                source=p_entry,
-                offsets=[c0, const(sub * CUBE_S1)],
-                sizes=[cS0, cCUBE_S1],
+            p_part = slice_view(
+                p_cube_slot_part_ty, source=p_entry, offsets=[c0, const(sub * CUBE_S1)], sizes=[cS0, cCUBE_S1]
             )
             pto.load(p_part, p_recv[b])
             tile.mov(p_recv[b], p_left[b])
-            v_view = pto.slice_view(
-                v_sub_ty,
-                source=tv_v,
-                offsets=[t_idx * cS1_TILE + const(sub * CUBE_S1), c0],
-                sizes=[cCUBE_S1, cHEAD],
+            v_view = slice_view(
+                v_sub_ty, source=tv_v, offsets=[t_idx * cS1_TILE + const(sub * CUBE_S1), c0], sizes=[cCUBE_S1, cHEAD]
             )
             pto.load(v_view, v_mat[b])
             tile.mov(v_mat[b], v_right[b])
@@ -429,12 +387,7 @@ def module():
         def push_pv(b):
             pto.tfree(p_pipe, SPLIT_UP_DOWN, entry=p_entry)
             pto.talloc(pv_entry, pv_pipe, SPLIT_UP_DOWN)
-            pv_part = pto.slice_view(
-                pv_slot_part_ty,
-                source=pv_entry,
-                offsets=[c0, c0],
-                sizes=[cS0, cHEAD],
-            )
+            pv_part = slice_view(pv_slot_part_ty, source=pv_entry, offsets=[c0, c0], sizes=[cS0, cHEAD])
             pto.store(pv_acc[b], pv_part)
             pto.tpush(pv_entry, pv_pipe, SPLIT_UP_DOWN)
 
@@ -458,12 +411,7 @@ def module():
 
         # ---- Q-block loop ----
         for qb in pto.range(qb_start, qb_end, c1):
-            q_view = pto.slice_view(
-                q_sub_ty,
-                source=tv_q,
-                offsets=[qb * cS0, c0],
-                sizes=[cS0, cHEAD],
-            )
+            q_view = slice_view(q_sub_ty, source=tv_q, offsets=[qb * cS0, c0], sizes=[cS0, cHEAD])
             pto.load(q_view, q_mat)
             tile.mov(q_mat, q_left)
 
@@ -475,15 +423,13 @@ def module():
             # ---- steady state ------------------------------------------------
             # Match the 140tflops schedule: consume current P/PV and emit the
             # next QK slot at CUBE_S1 sub-tile granularity.
-            for base in pto.range(c0, steady_tiles, cPRELOAD):
-                emit_qk_pv_interleaved(base + cPRELOAD + const(0), base + const(0), 0)
-                emit_qk_pv_interleaved(base + cPRELOAD + const(1), base + const(1), 1)
-                emit_qk_pv_interleaved(base + cPRELOAD + const(2), base + const(2), 0)
-                emit_qk_pv_interleaved(base + cPRELOAD + const(3), base + const(3), 1)
+            for tile_id in pto.range(c0, steady_tiles, c1):
+                next_tile = tile_id + cPRELOAD
+                emit_qk_pv_interleaved(next_tile, tile_id, 0)
 
             # ---- epilogue: drain the last QK_PRELOAD PVs -------------------
             for k in range(QK_PRELOAD):
-                b = k % 2
+                b = 0
                 t_idx = steady_tiles + const(k)
                 emit_pv(t_idx, b)
 
@@ -492,21 +438,17 @@ def module():
     # =========================================================================
     @pto.func(kernel="vector")
     def vector_kernel(
-        gm_slot_buffer: "ptr_fp32",
-        gm_slot_buffer_fp16: "ptr_fp16",
-        gm_o: "ptr_fp32",
-        s0_i64: "i64",
-        s1_i64: "i64",
+        gm_slot_buffer: "ptr_fp32", gm_slot_buffer_fp16: "ptr_fp16", gm_o: "ptr_fp32", s0_i64: "i64", s1_i64: "i64"
     ) -> None:
         c0 = const(0)
         c1 = const(1)
+        c2 = const(2)
         cS0 = const(S0)
         cS0_HALF = const(S0_HALF)
         cVecGuRows = const(VecGuRows)
         cVec_S0 = const(Vec_S0)
         cHEAD = const(HEAD)
         cS1_TILE = const(S1_TILE)
-        cSLOT_NUM = const(SLOT_NUM)
         cPRELOAD = const(QK_PRELOAD)
         s0 = s.index_cast(s0_i64)
         s1 = s.index_cast(s1_i64)
@@ -525,47 +467,20 @@ def module():
         # Vec sees one slot as [VecGuRows, S1_TILE] -- SPLIT_UP_DOWN halves
         # the row count when crossing into the subblock; per row_slice we
         # tload a [Vec_S0, S1_TILE] partition.
-        qk_slot_view = pto.as_tensor(
-            qk_vec_slot_ty,
-            ptr=gm_qk,
-            shape=[cVecGuRows, cS1_TILE],
-            strides=[cS1_TILE, c1],
-        )
+        qk_slot_view = as_tensor(qk_vec_slot_ty, ptr=gm_qk, shape=[cVecGuRows, cS1_TILE], strides=[cS1_TILE, c1])
         qk_pipe = pto.initialize_l2g2l_pipe(
-            dir_mask=1,
-            slot_size=SLOT_SIZE_QK,
-            slot_num=SLOT_NUM,
-            gm_addr=qk_slot_view,
-            flag_base=0,
+            dir_mask=1, slot_size=SLOT_SIZE_QK, slot_num=SLOT_NUM, gm_addr=qk_slot_view, flag_base=0
         )
         # ---- PV pipe (vec consumer): l2g2l GM-staged slot ----
-        pv_slot_view = pto.as_tensor(
-            pv_vec_slot_ty,
-            ptr=gm_pv,
-            shape=[cVecGuRows, cHEAD],
-            strides=[cHEAD, c1],
-        )
+        pv_slot_view = as_tensor(pv_vec_slot_ty, ptr=gm_pv, shape=[cVecGuRows, cHEAD], strides=[cHEAD, c1])
         pv_pipe = pto.initialize_l2g2l_pipe(
-            dir_mask=1,
-            slot_size=SLOT_SIZE_PV,
-            slot_num=SLOT_NUM,
-            gm_addr=pv_slot_view,
-            flag_base=4,
+            dir_mask=1, slot_size=SLOT_SIZE_PV, slot_num=SLOT_NUM, gm_addr=pv_slot_view, flag_base=4
         )
 
         # ---- P pipe (vec producer): l2g2l GM-staged slot ----
-        p_slot_view = pto.as_tensor(
-            p_slot_ty,
-            ptr=gm_p,
-            shape=[cVecGuRows, cS1_TILE],
-            strides=[cS1_TILE, c1],
-        )
+        p_slot_view = as_tensor(p_slot_ty, ptr=gm_p, shape=[cVecGuRows, cS1_TILE], strides=[cS1_TILE, c1])
         p_pipe = pto.initialize_l2g2l_pipe(
-            dir_mask=2,
-            slot_size=SLOT_SIZE_P,
-            slot_num=SLOT_NUM,
-            gm_addr=p_slot_view,
-            flag_base=2,
+            dir_mask=2, slot_size=SLOT_SIZE_P, slot_num=SLOT_NUM, gm_addr=p_slot_view, flag_base=2
         )
 
         # ---- Vec tile allocations.
@@ -573,8 +488,8 @@ def module():
         # iter overwrites the previous), so a single allocation per type is
         # enough. Reduce/state tiles are per-row_slice arrays because each
         # row_slice tracks its own running_max/running_sum independently.
-        qk_vec = pto.alloc_tile(qk_vec_ty)      # [Vec_S0, S1_TILE] working
-        tmp = pto.alloc_tile(qk_vec_ty)         # [Vec_S0, S1_TILE] row-reduce scratch
+        qk_vec = pto.alloc_tile(qk_vec_ty)  # [Vec_S0, S1_TILE] working
+        tmp = pto.alloc_tile(qk_vec_ty)  # [Vec_S0, S1_TILE] row-reduce scratch
         p_fp32 = pto.alloc_tile(p_fp32_ty)
         p_fp16 = pto.alloc_tile(p_fp16_ty)
         pv_vec = [pto.alloc_tile(pv_vec_ty) for _ in range(TILE_FACTOR)]
@@ -583,21 +498,17 @@ def module():
         running_sum = [pto.alloc_tile(red_ty) for _ in range(TILE_FACTOR)]
         local_max = [pto.alloc_tile(red_ty) for _ in range(TILE_FACTOR)]
         local_sum = [pto.alloc_tile(red_ty) for _ in range(TILE_FACTOR)]
-        # Manual uses an 8-slot exp_max FIFO. With QK_PRELOAD=4, softmax(t+4)
-        # and gu(t) hit different slots for every steady tile.
-        exp_max_ring = [
-            [pto.alloc_tile(red_ty) for _ in range(TILE_FACTOR)]
-            for _ in range(SLOT_NUM)
-        ]
+        # The shorter 140tflops-style preload only needs one exp_max slot per
+        # preloaded logical S1 tile.
+        exp_max_ring = [[pto.alloc_tile(red_ty) for _ in range(TILE_FACTOR)] for _ in range(EXP_RING)]
 
         scale = const(1.0 / math.sqrt(HEAD), s.float32)
+        cEXP_RING = const(EXP_RING)
 
         sb_idx = s.index_cast(pto.get_subblock_idx())
         row_off_sb = sb_idx * cS0_HALF
 
-        tv_o = pto.as_tensor(
-            o_tensor_ty, ptr=gm_o, shape=[s0, cHEAD], strides=[cHEAD, c1]
-        )
+        tv_o = as_tensor(o_tensor_ty, ptr=gm_o, shape=[s0, cHEAD], strides=[cHEAD, c1])
 
         qk_entry = pto.declare_global(qk_vec_slot_ty)
         p_entry = pto.declare_global(p_slot_ty)
@@ -615,7 +526,7 @@ def module():
             pto.tpop_into(qk_entry, qk_pipe, SPLIT_UP_DOWN)
             pto.talloc(p_entry, p_pipe, SPLIT_UP_DOWN)
             for row_slice in range(TILE_FACTOR):
-                slot_part = pto.slice_view(
+                slot_part = slice_view(
                     qk_vec_slot_part_ty,
                     source=qk_entry,
                     offsets=[const(row_slice * Vec_S0), c0],
@@ -657,11 +568,8 @@ def module():
                     tile.add(running_sum_r, local_sum_r, running_sum_r)
 
                 tile.cvt(p_fp32, p_fp16)
-                p_part = pto.slice_view(
-                    p_slot_part_ty,
-                    source=p_entry,
-                    offsets=[const(row_slice * Vec_S0), c0],
-                    sizes=[cVec_S0, cS1_TILE],
+                p_part = slice_view(
+                    p_slot_part_ty, source=p_entry, offsets=[const(row_slice * Vec_S0), c0], sizes=[cVec_S0, cS1_TILE]
                 )
                 pto.store(p_fp16, p_part)
             pto.tpush(p_entry, p_pipe, SPLIT_UP_DOWN)
@@ -673,7 +581,7 @@ def module():
         def emit_gu(exp_max_slots, is_init):
             pto.tpop_into(pv_entry, pv_pipe, SPLIT_UP_DOWN)
             for row_slice in range(TILE_FACTOR):
-                pv_part = pto.slice_view(
+                pv_part = slice_view(
                     pv_vec_slot_part_ty,
                     source=pv_entry,
                     offsets=[const(row_slice * Vec_S0), c0],
@@ -683,13 +591,43 @@ def module():
                 if is_init:
                     tile.mov(pv_vec[row_slice], o_tile[row_slice])
                 else:
-                    tile.row_expand_mul(
-                        o_tile[row_slice],
-                        exp_max_slots[row_slice],
-                        o_tile[row_slice],
-                    )
+                    tile.row_expand_mul(o_tile[row_slice], exp_max_slots[row_slice], o_tile[row_slice])
                     tile.add(o_tile[row_slice], pv_vec[row_slice], o_tile[row_slice])
             pto.tfree(pv_pipe, SPLIT_UP_DOWN, entry=pv_entry)
+
+        def emit_softmax_dispatch(tile_id):
+            mod = tile_id % cEXP_RING
+            with pto.if_context(mod == c0, has_else=True) as branch0:
+                emit_softmax(exp_max_ring[0], is_init=False)
+            with branch0.else_context():
+                with pto.if_context(mod == c1, has_else=True) as branch1:
+                    emit_softmax(exp_max_ring[1], is_init=False)
+                with branch1.else_context():
+                    with pto.if_context(mod == c2, has_else=(EXP_RING > 3)) as branch2:
+                        emit_softmax(exp_max_ring[2], is_init=False)
+                    if EXP_RING > 3:
+                        with branch2.else_context():
+                            emit_softmax(exp_max_ring[3], is_init=False)
+
+        def emit_gu_update_dispatch(tile_id):
+            mod = tile_id % cEXP_RING
+            with pto.if_context(mod == c0, has_else=True) as branch0:
+                emit_gu(exp_max_ring[0], is_init=False)
+            with branch0.else_context():
+                with pto.if_context(mod == c1, has_else=True) as branch1:
+                    emit_gu(exp_max_ring[1], is_init=False)
+                with branch1.else_context():
+                    with pto.if_context(mod == c2, has_else=(EXP_RING > 3)) as branch2:
+                        emit_gu(exp_max_ring[2], is_init=False)
+                    if EXP_RING > 3:
+                        with branch2.else_context():
+                            emit_gu(exp_max_ring[3], is_init=False)
+
+        def emit_gu_any(tile_id):
+            with pto.if_context(tile_id == c0, has_else=True) as branch:
+                emit_gu(exp_max_ring[0], is_init=True)
+            with branch.else_context():
+                emit_gu_update_dispatch(tile_id)
 
         for qb in pto.range(qb_start, qb_end, c1):
             # ---- vec prologue: softmax(0..QK_PRELOAD-1) --------------------
@@ -700,61 +638,25 @@ def module():
             # current PV/GU tile before producing the future P tile.
             with pto.if_context(steady_tiles > c0):
                 emit_gu(exp_max_ring[0], is_init=True)
-                emit_softmax(exp_max_ring[4], is_init=False)
-                emit_gu(exp_max_ring[1], is_init=False)
-                emit_softmax(exp_max_ring[5], is_init=False)
-                emit_gu(exp_max_ring[2], is_init=False)
-                emit_softmax(exp_max_ring[6], is_init=False)
-                emit_gu(exp_max_ring[3], is_init=False)
-                emit_softmax(exp_max_ring[7], is_init=False)
+                emit_softmax(exp_max_ring[QK_PRELOAD % EXP_RING], is_init=False)
 
-                for base in pto.range(cPRELOAD, steady_tiles, cPRELOAD):
-                    with pto.if_context((base % cSLOT_NUM) == c0, has_else=True) as ring_branch:
-                        emit_gu(exp_max_ring[0], is_init=False)
-                        emit_softmax(exp_max_ring[4], is_init=False)
-                        emit_gu(exp_max_ring[1], is_init=False)
-                        emit_softmax(exp_max_ring[5], is_init=False)
-                        emit_gu(exp_max_ring[2], is_init=False)
-                        emit_softmax(exp_max_ring[6], is_init=False)
-                        emit_gu(exp_max_ring[3], is_init=False)
-                        emit_softmax(exp_max_ring[7], is_init=False)
-                    with ring_branch.else_context():
-                        emit_gu(exp_max_ring[4], is_init=False)
-                        emit_softmax(exp_max_ring[0], is_init=False)
-                        emit_gu(exp_max_ring[5], is_init=False)
-                        emit_softmax(exp_max_ring[1], is_init=False)
-                        emit_gu(exp_max_ring[6], is_init=False)
-                        emit_softmax(exp_max_ring[2], is_init=False)
-                        emit_gu(exp_max_ring[7], is_init=False)
-                        emit_softmax(exp_max_ring[3], is_init=False)
+                for tile_id in pto.range(c1, steady_tiles, c1):
+                    next_tile = tile_id + cPRELOAD
+                    emit_gu_update_dispatch(tile_id)
+                    emit_softmax_dispatch(next_tile)
 
             # ---- vec epilogue: drain last QK_PRELOAD gus -------------------
-            with pto.if_context(steady_tiles == c0, has_else=True) as branch:
-                for k in range(QK_PRELOAD):
-                    slot = exp_max_ring[k]
-                    emit_gu(slot, is_init=(k == 0))
-            with branch.else_context():
-                with pto.if_context((steady_tiles % cSLOT_NUM) == c0, has_else=True) as drain_branch:
-                    for k in range(QK_PRELOAD):
-                        emit_gu(exp_max_ring[k], is_init=False)
-                with drain_branch.else_context():
-                    for k in range(QK_PRELOAD):
-                        emit_gu(exp_max_ring[QK_PRELOAD + k], is_init=False)
+            for k in range(QK_PRELOAD):
+                tile_id = steady_tiles + const(k)
+                emit_gu_any(tile_id)
 
             # Final divide + GM store, one row_slice at a time.
             for row_slice in range(TILE_FACTOR):
-                tile.row_expand_div(
-                    o_tile[row_slice],
-                    running_sum[row_slice],
-                    o_tile[row_slice],
-                )
-                o_view = pto.slice_view(
+                tile.row_expand_div(o_tile[row_slice], running_sum[row_slice], o_tile[row_slice])
+                o_view = slice_view(
                     o_sub_slice_ty,
                     source=tv_o,
-                    offsets=[
-                        qb * cS0 + row_off_sb + const(row_slice * Vec_S0),
-                        c0,
-                    ],
+                    offsets=[qb * cS0 + row_off_sb + const(row_slice * Vec_S0), c0],
                     sizes=[cVec_S0, cHEAD],
                 )
                 pto.store(o_tile[row_slice], o_view)
@@ -764,7 +666,7 @@ def module():
     # =========================================================================
     @pto.func
     def call_both(
-        ffts_addr: "ffts_ty",
+        ffts_addr: pto.ffts_type,
         gm_slot_buffer: "ptr_fp32",
         gm_slot_buffer_fp16: "ptr_fp16",
         gm_q: "ptr_fp16",

--- a/kernels/python/flash_atten/kernels/ptodsl_compat.py
+++ b/kernels/python/flash_atten/kernels/ptodsl_compat.py
@@ -1,0 +1,66 @@
+"""
+Copyright (c) 2026 Huawei Technologies Co., Ltd.
+This program is free software, you can redistribute it and/or modify it under
+the terms and conditions of CANN Open Software License Agreement Version 2.0
+(the "License"). Please refer to the License for details. You may not use this
+file except in compliance with the License.
+
+Compatibility helpers for the validated ptodsl 0.1.2 API.
+
+ptodsl 0.1.2 exposes pto.as_tensor() and pto.slice_view() as shape-dynamic
+helpers that infer result types. This flash-attention builder needs explicit
+TensorType/SubTensorType results so ptoas can preserve concrete slot and tile
+shapes. Keep the private MLIR calls isolated here so the kernel builder does not
+spread version-specific internals across the implementation.
+"""
+
+from mlir.dialects import pto as _mlir_pto
+from ptodsl import pto, to_ir_module
+from ptodsl.api.scalar import _unwrap
+from ptodsl.api.type_def import _materialize
+from ptodsl.utils.codegen import with_loc
+
+_ORIG_AS_TENSOR = pto.as_tensor
+_ORIG_SLICE_VIEW = pto.slice_view
+
+
+def _compat_layout_attr(layout):
+    if layout is None:
+        return None
+    if isinstance(layout, str):
+        return _mlir_pto.LayoutAttr.get(getattr(_mlir_pto.Layout, layout))
+    return layout
+
+
+@with_loc
+def as_tensor(tensor_type=None, *, ptr, shape, strides, layout=None):
+    if tensor_type is None:
+        return _ORIG_AS_TENSOR(ptr=ptr, shape=shape, strides=strides, layout=layout)
+    kwargs = {}
+    layout_attr = _compat_layout_attr(layout)
+    if layout_attr is not None:
+        kwargs["layout"] = layout_attr
+    return _mlir_pto.MakeTensorViewOp(
+        _materialize(tensor_type), _unwrap(ptr), [_unwrap(v) for v in shape], [_unwrap(v) for v in strides], **kwargs
+    ).result
+
+
+@with_loc
+def slice_view(subtensor_type=None, *, source, offsets, sizes):
+    if subtensor_type is None:
+        return _ORIG_SLICE_VIEW(source=source, offsets=offsets, sizes=sizes)
+    return _mlir_pto.PartitionViewOp(
+        _materialize(subtensor_type),
+        _unwrap(source),
+        offsets=[_unwrap(v) for v in offsets],
+        sizes=[_unwrap(v) for v in sizes],
+    ).result
+
+
+def to_ir_module_with_meta(*, meta_data, module=False):
+    def decorator(fn):
+        globals_to_update = fn.__globals__
+        globals_to_update.update(meta_data())
+        return to_ir_module(module=module)(fn)
+
+    return decorator

--- a/kernels/python/flash_atten/run.py
+++ b/kernels/python/flash_atten/run.py
@@ -11,8 +11,8 @@ Runner for the pto-dsl flash-attention port. By default this invokes
 resulting .so, then benchmarks each `FA_BENCH_LENGTHS` entry as the KV seqlen
 S1. Pass `--no-build` to reuse an existing `build_artifacts/fa.so`.
 
-When `FA_Q_ROWS` and `FA_BENCH_LENGTHS` are not set, the default benchmark
-matrix matches `fa_benchmark_shapes.md` and is named case1..case8.
+When `FA_Q_ROWS` and `FA_BENCH_LENGTHS` are not set, the built-in default
+benchmark matrix is named case1..case8.
 """
 
 import argparse
@@ -23,21 +23,21 @@ import math
 import os
 import subprocess
 import sys
-
-import torch
-import torch_npu  # noqa: F401  -- registers the npu backend
+import time
 
 THIS_DIR = os.path.dirname(os.path.abspath(__file__))
-sys.path.insert(0, os.path.join(THIS_DIR, "kernels"))
-import fa_builder  # noqa: E402
-
-from ptodsl import do_bench  # noqa: E402
-from ptodsl.utils.npu_info import get_num_cube_cores, get_test_device  # noqa: E402
 
 ARTIFACT_DIR = os.path.join(THIS_DIR, "build_artifacts")
 COMPILE_SCRIPT = os.path.join(THIS_DIR, "compile.sh")
 SUMMARY_TSV = os.environ.get("FA_SUMMARY_TSV", "")
 CASE_ID = os.environ.get("FA_CASE_ID", "direct")
+
+fa_builder = None
+torch = None
+torch_npu = None
+do_bench = None
+get_num_cube_cores = None
+get_test_device = None
 
 # Default single-case length. The top-level default path runs DEFAULT_BENCH_CASES
 # unless FA_Q_ROWS or FA_BENCH_LENGTHS is explicitly set.
@@ -63,33 +63,68 @@ ATOL_FUSED_ONLY = 5e-3
 RTOL_FUSED_ONLY = 5e-3
 
 
+def _load_builder():
+    global fa_builder
+    if fa_builder is not None:
+        return fa_builder
+
+    kernels_dir = os.path.join(THIS_DIR, "kernels")
+    if kernels_dir not in sys.path:
+        sys.path.insert(0, kernels_dir)
+    import fa_builder as _fa_builder
+
+    fa_builder = _fa_builder
+    return fa_builder
+
+
+def _load_runtime_deps():
+    global torch, torch_npu, do_bench, get_num_cube_cores, get_test_device
+    if torch is not None:
+        return
+
+    _load_builder()
+    import torch as _torch
+    import torch_npu as _torch_npu
+    from ptodsl import do_bench as _do_bench
+    from ptodsl.utils.npu_info import get_num_cube_cores as _get_num_cube_cores
+    from ptodsl.utils.npu_info import get_test_device as _get_test_device
+
+    torch = _torch
+    torch_npu = _torch_npu
+    do_bench = _do_bench
+    get_num_cube_cores = _get_num_cube_cores
+    get_test_device = _get_test_device
+
+
 def _manual_target_summary():
+    builder = _load_builder()
     return (
         "manual target: S0={s0} HEAD={head} CUBE_S0={cube_s0} "
         "CUBE_S1={cube_s1} TILE_S1={tile_s1} QK_PRELOAD={preload} "
         "causal={causal}"
     ).format(
-        s0=fa_builder.MANUAL_S0,
-        head=fa_builder.MANUAL_HEAD,
-        cube_s0=fa_builder.MANUAL_CUBE_S0,
-        cube_s1=fa_builder.MANUAL_CUBE_S1,
-        tile_s1=fa_builder.MANUAL_TILE_S1,
-        preload=fa_builder.MANUAL_QK_PRELOAD,
-        causal=fa_builder.MANUAL_CAUSAL_MASK,
+        s0=builder.MANUAL_S0,
+        head=builder.MANUAL_HEAD,
+        cube_s0=builder.MANUAL_CUBE_S0,
+        cube_s1=builder.MANUAL_CUBE_S1,
+        tile_s1=builder.MANUAL_TILE_S1,
+        preload=builder.MANUAL_QK_PRELOAD,
+        causal=builder.MANUAL_CAUSAL_MASK,
     )
 
 
 def _dsl_effective_summary():
+    builder = _load_builder()
     return (
         "dsl effective: Q_ROWS={q_rows} HEAD={head} CUBE_S0={cube_s0} "
         "S1_TILE={s1_tile} QK_PRELOAD={preload} NUM_Q_BLOCKS={q_blocks}"
     ).format(
-        q_rows=fa_builder.Q_ROWS,
-        head=fa_builder.HEAD,
-        cube_s0=fa_builder.S0,
-        s1_tile=fa_builder.S1_TILE,
-        preload=fa_builder.QK_PRELOAD,
-        q_blocks=fa_builder.NUM_Q_BLOCKS,
+        q_rows=builder.Q_ROWS,
+        head=builder.HEAD,
+        cube_s0=builder.S0,
+        s1_tile=builder.S1_TILE,
+        preload=builder.QK_PRELOAD,
+        q_blocks=builder.NUM_Q_BLOCKS,
     )
 
 
@@ -106,6 +141,29 @@ def _bench_iters():
 
 def _bench_warmup():
     return int(os.environ.get("FA_BENCH_WARMUP", "10"))
+
+
+def _bench_timing_mode():
+    mode = os.environ.get("FA_BENCH_TIMING", "event").strip().lower()
+    if mode not in {"event", "sync"}:
+        raise ValueError("FA_BENCH_TIMING must be 'event' or 'sync', got {!r}".format(mode))
+    return mode
+
+
+def _sync_bench(fn, warmup_iters, benchmark_iters, unit="us"):
+    _load_runtime_deps()
+    factor = {"s": 1.0, "ms": 1e3, "us": 1e6, "ns": 1e9}[unit]
+    for _ in range(warmup_iters):
+        fn()
+    torch.npu.synchronize()
+
+    total = 0.0
+    for _ in range(benchmark_iters):
+        start = time.perf_counter()
+        fn()
+        torch.npu.synchronize()
+        total += time.perf_counter() - start
+    return total * factor / benchmark_iters
 
 
 def _default_suite_requested(args):
@@ -131,6 +189,10 @@ def _selected_default_cases(case_arg):
 def _default_summary_tsv():
     stamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
     return os.path.join(ARTIFACT_DIR, "fa_summary_{}_{}.tsv".format(stamp, os.getpid()))
+
+
+def _default_case_s1_tile(seq_len):
+    return 512 if seq_len >= 16384 else 256
 
 
 def _summary_fields():
@@ -167,15 +229,14 @@ def _append_summary_row(row):
 
 
 def _num_tiles(seq_len):
-    if seq_len % fa_builder.S1_TILE != 0:
-        raise ValueError("seq_len {} is not a multiple of S1_TILE={}".format(seq_len, fa_builder.S1_TILE))
-    num_tiles = seq_len // fa_builder.S1_TILE
-    if num_tiles < fa_builder.QK_PRELOAD or (num_tiles - fa_builder.QK_PRELOAD) % fa_builder.QK_PRELOAD != 0:
+    builder = _load_builder()
+    if seq_len % builder.S1_TILE != 0:
+        raise ValueError("seq_len {} is not a multiple of S1_TILE={}".format(seq_len, builder.S1_TILE))
+    num_tiles = seq_len // builder.S1_TILE
+    if num_tiles < builder.QK_PRELOAD:
         raise ValueError(
             "seq_len {} maps to {} tiles; the current QK_PRELOAD={} runtime loop requires "
-            "num_tiles >= QK_PRELOAD and (num_tiles - QK_PRELOAD) % QK_PRELOAD == 0".format(
-                seq_len, num_tiles, fa_builder.QK_PRELOAD
-            )
+            "num_tiles >= QK_PRELOAD".format(seq_len, num_tiles, builder.QK_PRELOAD)
         )
     return num_tiles
 
@@ -185,19 +246,25 @@ def _lib_path():
 
 
 def _require_lib():
+    builder = _load_builder()
     p = _lib_path()
     if not os.path.exists(p):
         raise FileNotFoundError(
             "Missing prebuilt .so: {}\n"
             "    Run `bash compile.sh` (or `python3 run.py` without --no-build) for the current "
-            "FA_Q_ROWS={} to build the runtime-S1 kernel.".format(p, fa_builder.Q_ROWS)
+            "FA_Q_ROWS={} to build the runtime-S1 kernel.".format(p, builder.Q_ROWS)
         )
     return p
 
 
-def _build_lib():
+def _build_lib(remove_vec_barriers="", remove_vec_barrier_patterns=""):
     print("[fa] compiling PTODSL flash kernel...")
-    subprocess.run(["bash", COMPILE_SCRIPT], cwd=THIS_DIR, check=True)
+    cmd = ["bash", COMPILE_SCRIPT]
+    if remove_vec_barriers:
+        cmd.extend(["--remove-vec-barriers", remove_vec_barriers])
+    if remove_vec_barrier_patterns:
+        cmd.extend(["--remove-vec-barrier-patterns", remove_vec_barrier_patterns])
+    subprocess.run(cmd, cwd=THIS_DIR, check=True)
     return _require_lib()
 
 
@@ -213,11 +280,14 @@ def _to_void_p(t):
 
 
 def _block_dim():
-    return min(fa_builder.NUM_Q_BLOCKS, get_num_cube_cores())
+    _load_runtime_deps()
+    builder = _load_builder()
+    return min(builder.NUM_Q_BLOCKS, get_num_cube_cores())
 
 
 def _slot_elems(block_dim):
-    return fa_builder.GM_ELEMS_PER_BLOCK * block_dim
+    builder = _load_builder()
+    return builder.GM_ELEMS_PER_BLOCK * block_dim
 
 
 def attn_flops_matmul_softmax_scale(
@@ -245,6 +315,7 @@ def tflops(flops, ms):
 
 def fa_reference(q, k, v):
     """Plain torch fp32 reference: O = softmax(QK^T * scale) @ V."""
+    _load_runtime_deps()
     scale = 1.0 / math.sqrt(q.shape[1])
     scores = q.float() @ k.float().T * scale
     return (torch.softmax(scores, dim=-1) @ v.float()).float()
@@ -252,6 +323,7 @@ def fa_reference(q, k, v):
 
 def fused_attention(q, k, v):
     """torch_npu fused reference for benchmarking the speedup ratio."""
+    _load_runtime_deps()
     scale = 1.0 / math.sqrt(q.shape[1])
     out, _ = torch_npu.npu_fused_infer_attention_score(
         q.unsqueeze(0), k.unsqueeze(0), v.unsqueeze(0), num_heads=1, input_layout="BSH", scale=scale, next_tokens=65535
@@ -260,8 +332,10 @@ def fused_attention(q, k, v):
 
 
 def _alloc_io(seq_len, device):
-    Q_ROWS = fa_builder.Q_ROWS
-    HEAD = fa_builder.HEAD
+    _load_runtime_deps()
+    builder = _load_builder()
+    Q_ROWS = builder.Q_ROWS
+    HEAD = builder.HEAD
     block_dim = _block_dim()
 
     q = torch.randn((Q_ROWS, HEAD), dtype=torch.float16, device=device)
@@ -286,9 +360,11 @@ def _invoke(lib, block_dim, gm_slot, q, k, v, o, stream_ptr):
     )
 
 
-def benchmark(lib, device, num_tiles, warmup, iters):
+def benchmark(lib, device, num_tiles, warmup, iters, timing_mode):
+    _load_runtime_deps()
+    builder = _load_builder()
     torch.manual_seed(0)
-    seq_len = fa_builder.S1_TILE * num_tiles
+    seq_len = builder.S1_TILE * num_tiles
     q, k, v, gm_slot, o, block_dim = _alloc_io(seq_len, device)
     stream_ptr = torch.npu.current_stream()._as_parameter_
 
@@ -298,8 +374,12 @@ def benchmark(lib, device, num_tiles, warmup, iters):
     def run_fused():
         fused_attention(q, k, v)
 
-    kernel_us = do_bench(run_kernel, warmup_iters=warmup, benchmark_iters=iters, unit="us")
-    fused_us = do_bench(run_fused, warmup_iters=warmup, benchmark_iters=iters, unit="us")
+    if timing_mode == "sync":
+        kernel_us = _sync_bench(run_kernel, warmup_iters=warmup, benchmark_iters=iters, unit="us")
+        fused_us = _sync_bench(run_fused, warmup_iters=warmup, benchmark_iters=iters, unit="us")
+    else:
+        kernel_us = do_bench(run_kernel, warmup_iters=warmup, benchmark_iters=iters, unit="us")
+        fused_us = do_bench(run_fused, warmup_iters=warmup, benchmark_iters=iters, unit="us")
 
     # One untimed correctness probe per length so silent miscompiles don't
     # hide behind a passing benchmark.
@@ -328,8 +408,8 @@ def benchmark(lib, device, num_tiles, warmup, iters):
         )
         ref_label = "npu_fused (host fp32 ref skipped, qk_elems={:.1e})".format(qk_elems)
 
-    matmul_flops = 4 * fa_builder.Q_ROWS * fa_builder.HEAD * seq_len
-    attention_flops = attn_flops_matmul_softmax_scale(1, fa_builder.Q_ROWS, seq_len, fa_builder.HEAD)
+    matmul_flops = 4 * builder.Q_ROWS * builder.HEAD * seq_len
+    attention_flops = attn_flops_matmul_softmax_scale(1, builder.Q_ROWS, seq_len, builder.HEAD)
     kernel_ms = kernel_us / 1000.0
     fused_ms = fused_us / 1000.0
     return {
@@ -349,6 +429,7 @@ def benchmark(lib, device, num_tiles, warmup, iters):
 
 
 def _print_row(r):
+    builder = _load_builder()
     print(
         "  s0={s0:>6} s1={seq_len:>6}  tiles={num_tiles:>3}  "
         "fa={kernel_us:8.2f}us ({kernel_gflops:7.1f} GF/s, {kernel_tflops:6.2f} TFLOP/s)  "
@@ -356,15 +437,16 @@ def _print_row(r):
         "({fused_gflops:7.1f} GF/s, {fused_tflops:6.2f} TFLOP/s)  "
         "speedup={speedup:.2f}x  "
         "err: ours={err_kernel:.2e} npu_fused_infer_attention={err_fused:.2e}  "
-        "ref={ref}".format(s0=fa_builder.Q_ROWS, **r)
+        "ref={ref}".format(s0=builder.Q_ROWS, **r)
     )
 
 
 def _append_benchmark_summary(result, status="OK", note=""):
+    builder = _load_builder()
     _append_summary_row(
         {
             "case_id": CASE_ID,
-            "q_rows": fa_builder.Q_ROWS,
+            "q_rows": builder.Q_ROWS,
             "seq_len": result["seq_len"],
             "tiles": result["num_tiles"],
             "status": status,
@@ -389,6 +471,31 @@ def _parse_args():
     parser.add_argument(
         "--case", help="comma-separated default benchmark cases to run (case1..case8); defaults to all cases"
     )
+    parser.add_argument(
+        "--timing",
+        choices=("event", "sync"),
+        default=_bench_timing_mode(),
+        help="benchmark timing mode; event uses torch NPU events, sync uses host timing with torch.npu.synchronize()",
+    )
+    parser.add_argument(
+        "--remove-vec-barriers",
+        default=os.environ.get("FA_REMOVE_VEC_BARRIERS", ""),
+        metavar="LINES",
+        help=(
+            "comma-separated generated-C++ line numbers whose pipe_barrier(PIPE_V) should be removed "
+            "during build; also accepted via FA_REMOVE_VEC_BARRIERS"
+        ),
+    )
+    parser.add_argument(
+        "--remove-vec-barrier-patterns",
+        default=os.environ.get("FA_REMOVE_VEC_BARRIER_PATTERNS", "gu"),
+        metavar="PATTERNS",
+        help=(
+            "comma-separated generated-C++ PIPE_V barrier patterns to remove during build; "
+            "defaults to stable pattern: gu; experimental: softmax-exp-sum, softmax-sum-add; "
+            "also accepted via FA_REMOVE_VEC_BARRIER_PATTERNS"
+        ),
+    )
     return parser.parse_args()
 
 
@@ -402,19 +509,31 @@ def _run_default_suite(args):
         )
 
     summary_tsv = SUMMARY_TSV or _default_summary_tsv()
-    print("[fa] running default benchmark suite from fa_benchmark_shapes.md")
+    print("[fa] running built-in default benchmark suite")
     print("[fa] selected cases: {}".format(", ".join(case_id for case_id, _, _ in cases)))
     print("[fa] summary TSV: {}".format(summary_tsv))
 
     for case_id, s0, s1 in cases:
-        print("\n{:=^110}".format(" {} S0={} S1={} ".format(case_id, s0, s1)))
+        s1_tile = _default_case_s1_tile(s1)
+        print("\n{:=^110}".format(" {} S0={} S1={} TILE_S1={} ".format(case_id, s0, s1, s1_tile)))
         env = os.environ.copy()
         env.update(
-            {"FA_CASE_ID": case_id, "FA_Q_ROWS": str(s0), "FA_BENCH_LENGTHS": str(s1), "FA_SUMMARY_TSV": summary_tsv}
+            {
+                "FA_CASE_ID": case_id,
+                "FA_Q_ROWS": str(s0),
+                "FA_BENCH_LENGTHS": str(s1),
+                "FA_S1_TILE": str(s1_tile),
+                "FA_SUMMARY_TSV": summary_tsv,
+            }
         )
         cmd = [sys.executable, os.path.abspath(__file__)]
         if args.no_build:
             cmd.append("--no-build")
+        if (not args.no_build) and args.remove_vec_barriers:
+            cmd.extend(["--remove-vec-barriers", args.remove_vec_barriers])
+        if (not args.no_build) and args.remove_vec_barrier_patterns:
+            cmd.extend(["--remove-vec-barrier-patterns", args.remove_vec_barrier_patterns])
+        cmd.extend(["--timing", args.timing])
         subprocess.run(cmd, cwd=THIS_DIR, env=env, check=True)
 
     print("\n[fa] default benchmark suite done.")
@@ -427,30 +546,39 @@ def main():
         _run_default_suite(args)
         return
 
+    _load_runtime_deps()
+    builder = _load_builder()
     device = get_test_device()
     torch.npu.set_device(device)
 
     lengths = _bench_lengths()
     targets = [(L, _num_tiles(L)) for L in lengths]
-    lib_path = _require_lib() if args.no_build else _build_lib()
+    lib_path = (
+        _require_lib() if args.no_build else _build_lib(args.remove_vec_barriers, args.remove_vec_barrier_patterns)
+    )
     lib = _load_lib(lib_path)
 
     warmup = _bench_warmup()
     iters = _bench_iters()
+    timing_mode = args.timing
 
     print("\n{:=^110}".format(" Benchmark (pto-dsl fa) "))
     print("  " + _manual_target_summary())
     print("  " + _dsl_effective_summary())
-    print("  same host-visible shape and QK_PRELOAD as the manual non-causal S0=128 path")
+    print("  same host-visible shape as the manual non-causal S0=128 path; QK_PRELOAD is DSL-tuned")
     print("  TFLOP/s counts matmul + scale + softmax operations, matching 140tflops/run.py")
     print("  reference kernel: torch_npu.npu_fused_infer_attention_score")
     print("  host fp32 reference is skipped when Q_ROWS*S1 > {}".format(HOST_REF_MAX_QK_ELEMS))
-    print("  cores={}  warmup={}  iters={}".format(get_num_cube_cores(), warmup, iters))
-    print("  S0(Q_ROWS)={}  S1 lengths: {}".format(fa_builder.Q_ROWS, list(lengths)))
+    if (not args.no_build) and args.remove_vec_barriers:
+        print("  removed PIPE_V barrier lines: {}".format(args.remove_vec_barriers))
+    if (not args.no_build) and args.remove_vec_barrier_patterns:
+        print("  removed PIPE_V barrier patterns: {}".format(args.remove_vec_barrier_patterns))
+    print("  cores={}  warmup={}  iters={} timing={}".format(get_num_cube_cores(), warmup, iters, timing_mode))
+    print("  S0(Q_ROWS)={}  S1 lengths: {}".format(builder.Q_ROWS, list(lengths)))
     print("-" * 110)
 
     for _, nt in targets:
-        result = benchmark(lib, device, num_tiles=nt, warmup=warmup, iters=iters)
+        result = benchmark(lib, device, num_tiles=nt, warmup=warmup, iters=iters, timing_mode=timing_mode)
         _print_row(result)
         _append_benchmark_summary(result)
 

--- a/kernels/python/flash_atten/scripts/patch_vec_barriers.py
+++ b/kernels/python/flash_atten/scripts/patch_vec_barriers.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+"""
+Copyright (c) 2026 Huawei Technologies Co., Ltd.
+This program is free software, you can redistribute it and/or modify it under
+the terms and conditions of CANN Open Software License Agreement Version 2.0
+(the "License"). Please refer to the License for details. You may not use this
+file except in compliance with the License.
+
+Patch selected generated-C++ PIPE_V barriers for flash-attention experiments.
+"""
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+PATTERN_ALIASES = {
+    "gu": "gu",
+    "trowexpandmul-tadd": "gu",
+    "softmax-exp-sum": "softmax-exp-sum",
+    "texp-trowsum": "softmax-exp-sum",
+    "softmax-sum-add": "softmax-sum-add",
+    "trowsum-tadd": "softmax-sum-add",
+}
+DISABLED_PATTERNS = {"none", "off", "disable", "disabled"}
+CALL_RE = re.compile(r"^\s*([A-Za-z_][\w]*)\s*(?:<[^;]*)?\((.*)\);\s*$")
+TILE_VAR_RE = re.compile(r"\bv\d+\b")
+
+
+def _parse_patterns(raw_patterns):
+    raw_pattern_set = {
+        part.strip() for part in raw_patterns.split(",") if part.strip() and part.strip() not in DISABLED_PATTERNS
+    }
+    unknown_patterns = sorted(raw_pattern_set - set(PATTERN_ALIASES))
+    if unknown_patterns:
+        supported = ", ".join(sorted(PATTERN_ALIASES))
+        raise SystemExit(
+            "unknown --remove-vec-barrier-patterns entries: {}; supported: {}".format(unknown_patterns, supported)
+        )
+    return {PATTERN_ALIASES[part] for part in raw_pattern_set}
+
+
+def _parse_lines(raw_lines):
+    try:
+        return {int(part.strip()) for part in raw_lines.split(",") if part.strip()}
+    except ValueError as exc:
+        raise SystemExit("invalid --remove-vec-barriers list: {!r}: {}".format(raw_lines, exc)) from exc
+
+
+def _op_name(line):
+    stripped = line.strip()
+    if not stripped or stripped.startswith("//"):
+        return ""
+    head = stripped.split("(", 1)[0]
+    return head.split("<", 1)[0].strip()
+
+
+def _call_tile_vars(line):
+    match = CALL_RE.match(line)
+    if not match:
+        return []
+    return TILE_VAR_RE.findall(match.group(2))
+
+
+def _has_direct_tile_dependency(prev_line, next_line):
+    prev_vars = _call_tile_vars(prev_line)
+    next_vars = _call_tile_vars(next_line)
+    if not prev_vars or not next_vars:
+        return False
+
+    prev_writes = {prev_vars[0]}
+    prev_reads = set(prev_vars[1:])
+    next_writes = {next_vars[0]}
+    next_reads = set(next_vars[1:])
+
+    return bool((prev_writes & next_reads) or (prev_writes & next_writes) or (prev_reads & next_writes))
+
+
+def _collect_pattern_lines(lines, patterns):
+    pattern_lines = {}
+    skipped_pattern_counts = {}
+
+    def add_pattern_line(lineno, reason):
+        pattern_lines.setdefault(lineno, set()).add(reason)
+
+    def skip_pattern(reason):
+        skipped_pattern_counts[reason] = skipped_pattern_counts.get(reason, 0) + 1
+
+    if "gu" in patterns:
+        for idx, line in enumerate(lines):
+            if _op_name(line) != "TROWEXPANDMUL":
+                continue
+            j = idx + 1
+            candidate = None
+            while j < len(lines):
+                op = _op_name(lines[j])
+                if op == "pipe_barrier" and lines[j].strip() == "pipe_barrier(PIPE_V);" and candidate is None:
+                    candidate = j + 1
+                    j += 1
+                    continue
+                if op == "wait_flag" and "PIPE_MTE2, PIPE_V" in lines[j]:
+                    j += 1
+                    continue
+                if op == "TADD" and candidate is not None:
+                    add_pattern_line(candidate, "gu")
+                break
+
+    if "softmax-exp-sum" in patterns:
+        for idx, line in enumerate(lines):
+            if _op_name(line) != "TEXP":
+                continue
+            barrier_lineno = idx + 2
+            next_idx = idx + 1
+            if next_idx >= len(lines) or lines[next_idx].strip() != "pipe_barrier(PIPE_V);":
+                continue
+            after_idx = next_idx + 1
+            if after_idx < len(lines) and _op_name(lines[after_idx]) == "TROWSUM":
+                if _has_direct_tile_dependency(line, lines[after_idx]):
+                    skip_pattern("softmax-exp-sum:direct-tile-dependency")
+                else:
+                    add_pattern_line(barrier_lineno, "softmax-exp-sum")
+
+    if "softmax-sum-add" in patterns:
+        for idx, line in enumerate(lines):
+            if _op_name(line) != "TROWSUM":
+                continue
+            barrier_lineno = idx + 2
+            next_idx = idx + 1
+            if next_idx >= len(lines) or lines[next_idx].strip() != "pipe_barrier(PIPE_V);":
+                continue
+            after_idx = next_idx + 1
+            if after_idx < len(lines) and _op_name(lines[after_idx]) == "TADD":
+                if _has_direct_tile_dependency(line, lines[after_idx]):
+                    skip_pattern("softmax-sum-add:direct-tile-dependency")
+                else:
+                    add_pattern_line(barrier_lineno, "softmax-sum-add")
+
+    return pattern_lines, skipped_pattern_counts
+
+
+def patch_file(src, dst, raw_lines="", raw_patterns=""):
+    patterns = _parse_patterns(raw_patterns)
+    experimental_patterns = sorted(patterns - {"gu"})
+    if experimental_patterns:
+        print(
+            "warning: experimental PIPE_V barrier pattern(s) may affect benchmark timing or performance: "
+            + ",".join(experimental_patterns),
+            file=sys.stderr,
+        )
+
+    remove_lines = _parse_lines(raw_lines)
+    lines = src.read_text().splitlines()
+    pattern_lines, skipped_pattern_counts = _collect_pattern_lines(lines, patterns)
+
+    patched = []
+    seen = set()
+    bad_lines = []
+    for lineno, line in enumerate(lines, start=1):
+        by_line = lineno in remove_lines
+        by_pattern = lineno in pattern_lines
+        if by_line or by_pattern:
+            if by_line:
+                seen.add(lineno)
+            if line.strip() != "pipe_barrier(PIPE_V);":
+                bad_lines.append((lineno, line.strip()))
+                patched.append(line)
+            else:
+                indent = line[: len(line) - len(line.lstrip())]
+                if by_line:
+                    reason = "--remove-vec-barriers"
+                else:
+                    reason = "--remove-vec-barrier-patterns=" + ",".join(sorted(pattern_lines[lineno]))
+                patched.append("{}/* removed PIPE_V barrier via {} */".format(indent, reason))
+        else:
+            patched.append(line)
+
+    missing = sorted(remove_lines - seen)
+    if missing or bad_lines:
+        if missing:
+            print("line numbers outside generated file: {}".format(missing), file=sys.stderr)
+        for lineno, text in bad_lines:
+            print("line {} is not a PIPE_V barrier: {!r}".format(lineno, text), file=sys.stderr)
+        raise SystemExit(2)
+
+    dst.write_text("\n".join(patched) + "\n")
+    pattern_total = len(pattern_lines)
+    removed_total = len(remove_lines | set(pattern_lines))
+    print(
+        "Patched generated C++ -> {} (removed {} PIPE_V barriers; lines={}, patterns={})".format(
+            dst, removed_total, len(remove_lines), pattern_total
+        )
+    )
+    if skipped_pattern_counts:
+        skipped = ", ".join("{}={}".format(reason, count) for reason, count in sorted(skipped_pattern_counts.items()))
+        print("Skipped PIPE_V barrier pattern candidates: {}".format(skipped))
+
+
+def _parse_args():
+    parser = argparse.ArgumentParser(description="Patch selected generated-C++ PIPE_V barriers.")
+    parser.add_argument("src", type=Path)
+    parser.add_argument("dst", type=Path)
+    parser.add_argument("--remove-vec-barriers", default="")
+    parser.add_argument("--remove-vec-barrier-patterns", default="")
+    return parser.parse_args()
+
+
+def main():
+    args = _parse_args()
+    patch_file(args.src, args.dst, args.remove_vec_barriers, args.remove_vec_barrier_patterns)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
# perf(flash_atten): tune DSL pipeline params and remove redundant PIPE_V barriers

This PR improves both performance and engineering quality of `kernels/python/flash_atten`.

## Performance Optimizations

The perf work comes from two sources. The first is the redundant `pipe_barrier(PIPE_V)` elimination ported from https://github.com/huawei-csl/pto-dsl/pull/138: an op-pattern based patch is applied to the C++ emitted by `ptoas`. The stable `gu` pattern (`TROWEXPANDMUL -> pipe_barrier(PIPE_V) -> wait_flag(PIPE_MTE2,PIPE_V) -> TADD`) is enabled by default. Optional `softmax-exp-sum` / `softmax-sum-add` patterns are guarded by direct tile-dependency checks. The legacy line-number based `--remove-vec-barriers` is kept only as an experimental option.

The second is the DSL kernel pipeline tuning aligned with https://github.com/huawei-csl/pto-dsl:

1. **Tune DSL kernel pipeline parameters**
   - `kernels/python/flash_atten/kernels/fa_builder.py:143` changes `S1_TILE` from a hard-coded 256 to a configurable `FA_S1_TILE=256/512`. Large cases default to 512 to reduce tile count and scheduling overhead for large S1.
   - `QK_PRELOAD` is lowered from the hand-written-parity value 4 to the DSL default 3 (with `FA_QK_PRELOAD=4` available as an opt-in). `EXP_RING` is shrunk to match preload, reducing vector-side exp-max ring resource usage.
2. **Reshape the cube / vector steady-state pipeline**
   - On the cube side, instead of unrolling once with `QK_PRELOAD=4`, we now emit per-tile `emit_qk_pv_interleaved(next_tile, tile_id, 0)`, which matches the 140tflops example rhythm of "consume the current PV/P while issuing the next QK".
   - On the vector side, we first drain the current GU and then produce the future softmax/P, dispatching ring slots via `tile_id % EXP_RING` to avoid the previous 8-slot ring unroll path.

## Differences vs. the 140tflops Example

Reference: https://github.com/huawei-csl/pto-dsl/tree/main/examples/aot/flash_attention/140tflops

| Aspect | This repo (`kernels/python/flash_atten`) | 140tflops example |
| --- | --- | --- |
| Q dimension | `FA_Q_ROWS` is configurable; the default suite case1..case8 covers 1024..131072; `compute_qb_range` spreads multiple Q blocks across compute blocks | `run.py` hard-codes `s0 = 128 * 24`, more of a single perf sample |
| S1 tile | One builder supports `FA_S1_TILE=256/512` | Two separate builders: `fa_dsl_builder.py` for 256, `fa_dsl_builder_tile512.py` for 512 |
| preload / ring | Defaults to `QK_PRELOAD=3`, may be set to 4; `EXP_RING` must equal preload | 256 tile defaults to 3, 512 tile defaults to 4 |
| Cube schedule | Keeps the 140tflops `emit_qk_pv_interleaved` and issues the next QK while PV of the current tile is in flight | Same `compute_qk_pv_interleaved` shape |
| Vector softmax | Closer to the hand-written macro: row max on the unscaled QK first, then apply scale into the exp argument | The 140tflops 256 variant does `muls(scale)` first, then row max / update |
| Build flow | `run.py` can auto-recompile per case; default case1..case8 with TSV summary output | Requires manual `compile.sh` / `compile_tile512.sh` first; `run.py` only loads `fa_dsl.so` |
| Barrier patch | Pattern-based PIPE_V barrier removal with a default stable `gu` pattern and direct dependency checks | Only supports line-number based removal with fixed line numbers in the README; fragile against ptoas output drift |
| Correctness / benchmark | Skips host FP32 reference for very large shapes (uses the NPU fused reference instead) to avoid blowing up the QK matrix; supports event and sync timing | Runs torch FP32 reference for all S1 by default and emits a plot; more memory-hungry at large S1 |

Engineering advantages of this implementation over the 140tflops example:

- More productionized: multi-case, automatic recompile, summary TSV, both sync and event timing — suitable for systematic regression runs.
- Substantially wider shape coverage: `FA_Q_ROWS` extends to case1..case8, S1 is passed at runtime, and 256/512 tile selection is environment driven.
- More robust patching of generated code: pattern-based removal survives `ptoas` output changes that fixed line numbers do not.
- More realistic correctness verification at large shapes: the host reference is not forced to materialize a huge QK matrix when above a size threshold.

## Specification / Documentation

- `README.md` / `README_zh.md` explicitly document this example's dependency on the external `huawei-csl/pto-dsl` repo.
- Record the validated version information:

  ```text
  pto-dsl package version: 0.1.2
  upstream branch: main
  commit: 6755794cfc145c8ffe4fae92483aa20148e57327
  commit date: 2026-05-18 11:18:56 +0200
  ```

- The full build / runtime dependency set is listed: `ptodsl`, `torch` + `torch_npu`, Ascend CANN runtime / toolkit (`bisheng`), a `ptoas` compatible with the installed `ptodsl`, and this repo's PTO C++ headers exposed via `PTO_LIB_PATH`.

## Performance Numbers

S0 = S1, default case set (`python3 run.py`):

| case | S0=S1 | fa us | torch_npu us | speedup |
| --- | ---: | ---: | ---: | ---: |
| case1 | 1024 | 43.82 | 137.71 | 3.14x |
| case2 | 2048 | 56.92 | 154.92 | 2.72x |
| case3 | 4096 | 113.83 | 207.80 | 1.83x |
| case4 | 8192 | 283.12 | 365.81 | 1.29x |
| case5 | 16384 | 953.47 | 974.65 | 1.02x |
| case6 | 32768 | 3177.41 | 3159.95 | 0.99x |
| case7 | 65536 | 12093.10 | 12152.60 | 1.00x |
| case8 | 131072 | 48380.71 | 48061.93 | 0.99x |

## New Skill: `pto-isa-flash-atten-a3-pipeline`

This PR also adds a new Claude / Codex skill under [.claude/skills/pto-isa-flash-atten-a3-pipeline/](.claude/skills/pto-isa-flash-atten-a3-pipeline/) that distills the tuning work in this PR into a reusable recipe. It is sibling to the existing `pto-isa-dev` skill and is deliberately narrow: A3 non-causal prefill at the in-tree shape envelope (`HEAD=128`, `S0=128`, `CUBE_S1=128`).

### Contents

- [SKILL.md](.claude/skills/pto-isa-flash-atten-a3-pipeline/SKILL.md) — entrypoint: when to use, quick start (`python3 run.py [--case caseN]`), core workflow (diagnose -> apply recipe -> size tiles -> patch barriers -> verify), scope boundaries, and working rules.
- [references/fa-4stage-pipeline-recipe.md](.claude/skills/pto-isa-flash-atten-a3-pipeline/references/fa-4stage-pipeline-recipe.md) — the full four-stage `compute_qk (Cube) -> compute_p (Vec) -> compute_pv (Cube) -> compute_gu (Vec)` pipeline staged through a GM software FIFO: prologue / steady / epilogue, the cube-side per-tile `emit_qk_pv_interleaved` interleaving, the vec-side "drain GU then produce P" reordering, the `EXP_RING == QK_PRELOAD` invariant, and the anti-patterns that broke earlier revisions.
- [references/ub-budget-and-tile-sizing.md](.claude/skills/pto-isa-flash-atten-a3-pipeline/references/ub-budget-and-tile-sizing.md) — the 192 KiB UB budget accounting, the row_slice 64 KiB -> 32 KiB working-tile shrink, and the empirical `S1 >= 16384 -> S1_TILE = 512` recommendation (with the host-side validation rules `S1 >= S1_TILE * QK_PRELOAD` and `S1 % S1_TILE == 0`).
- [references/pipe-v-barrier-patterns.md](.claude/skills/pto-isa-flash-atten-a3-pipeline/references/pipe-v-barrier-patterns.md) — which generated-C++ `pipe_barrier(PIPE_V)` patterns are safe to drop and why: the default-on `gu` pattern, the dependency-checked optional `softmax-exp-sum` / `softmax-sum-add` patterns, and why the legacy line-number `FA_REMOVE_VEC_BARRIERS` path is kept only as an experimental fallback.

### Purpose

The skill exists so future tuning / porting work on this kernel does not have to rediscover the choices captured in this PR:

- **Apply** — given a new shape mix, pick `QK_PRELOAD`, `EXP_RING`, and `S1_TILE` without re-deriving the invariants or the UB budget.
- **Port** — when bringing the four-stage pattern to a different cube + vec persistent-block kernel, preserve the load-bearing parts (separate prologue / steady / epilogue, GM-staged FIFO between cube and vec, `EXP_RING == QK_PRELOAD`) rather than the incidental ones.
- **Patch** — decide when a `pipe_barrier(PIPE_V)` in ptoas-emitted C++ is safe to drop, using the op-pattern direct-tile-dependency check rather than fragile line numbers.
- **Delegate** — anything outside the A3 non-causal prefill envelope (causal mask, GQA / MQA, KV-cache decode, A5 NZ / NZ+1 layout Flash Attention, matmul L2 scheduling, generic PTO optimization concepts) is explicitly punted to sibling skills so this one does not grow.
