### PR TITLE
fix(backend): Expose MaskPattern TSCATTER overload

### DIFF
--- a/include/pto/common/pto_instr.hpp
+++ b/include/pto/common/pto_instr.hpp
@@ -1757,6 +1757,14 @@ PTO_INST RecordEvent TSCATTER(TileDataD &dst, TileDataS &src, TileDataI &indexes
     return {};
 }
 
+template <MaskPattern maskPattern, typename TileDataD, typename TileDataS, typename... WaitEvents>
+PTO_INST RecordEvent TSCATTER(TileDataD &dst, TileDataS &src, WaitEvents &...events)
+{
+    TSYNC(events...);
+    MAP_INSTR_IMPL_T(TSCATTER, PTO_TEMPLATE_ARGS(maskPattern), dst, src);
+    return {};
+}
+
 template <typename TileDataDst, typename TileDataSrc, typename... WaitEvents>
 PTO_INST RecordEvent TCOLEXPAND(TileDataDst &dst, TileDataSrc &src, WaitEvents &...events)
 {

--- a/include/pto/costmodel/pto_instr.hpp
+++ b/include/pto/costmodel/pto_instr.hpp
@@ -1424,6 +1424,14 @@ PTO_INST RecordEvent TSCATTER(TileDataD &dst, TileDataS &src, TileDataI &indexes
     return {};
 }
 
+template <MaskPattern maskPattern, typename TileDataD, typename TileDataS, typename... WaitEvents>
+PTO_INST RecordEvent TSCATTER(TileDataD &dst, TileDataS &src, WaitEvents &...events)
+{
+    TSYNC(events...);
+    MAP_INSTR_IMPL_T(TSCATTER, PTO_TEMPLATE_ARGS(maskPattern), dst, src);
+    return {};
+}
+
 template <typename TileDataDst, typename TileDataSrc, typename... WaitEvents>
 PTO_INST RecordEvent TCOLEXPAND(TileDataDst &dst, TileDataSrc &src, WaitEvents &...events)
 {


### PR DESCRIPTION
## Summary
- Add the public `TSCATTER<MaskPattern>(dst, src, ...)` overload in `include/pto/common/pto_instr.hpp`
- Mirror the same overload in `include/pto/costmodel/pto_instr.hpp` so common and costmodel instruction wrappers stay aligned
- Forward the mask-pattern form through the existing `MAP_INSTR_IMPL_T(TSCATTER, PTO_TEMPLATE_ARGS(maskPattern), dst, src)` backend dispatch without changing the indexed 3-argument TSCATTER API

## Testing
- [x] `git diff --check` passes
- [x] CPU ST `tscatter` target not completed locally; this machine uses GCC 10.3.1 and fails on unrelated C++20/toolchain support before the target can finish (`<format>`, `_Float16`, `__builtin_bit_cast`)

Fixes #139