### PR TITLE
fix(backend): Support CPU sim barriers and alias-safe TTrans

### DIFF
--- a/include/pto/common/cpu_stub.hpp
+++ b/include/pto/common/cpu_stub.hpp
@@ -17,6 +17,7 @@ See LICENSE in the root of the software repository for the full text of the Lice
 #include <cstring>
 #include <cassert>
 #include <algorithm>
+#include <atomic>
 #include <filesystem>
 #include <fstream>
 #include <memory>
@@ -64,6 +65,45 @@ inline void pipe_barrier(pipe_t pipe)
 {
     (void)pipe;
 }
+
+// CCEC provides cache maintenance intrinsics and barrier constants for real
+// AICore builds. Host CPU sim kernels still see generated dcci/dsb calls, so
+// model them as full fences to preserve cross-thread ordering.
+#ifndef dcci
+template <typename... Args>
+inline void dcci(Args &&...)
+{
+    std::atomic_thread_fence(std::memory_order_seq_cst);
+}
+#endif
+#ifndef mem_dsb_t
+typedef int mem_dsb_t;
+#endif
+#ifndef dsb
+#define dsb(kind)                                            \
+    do {                                                     \
+        (void)(kind);                                        \
+        std::atomic_thread_fence(std::memory_order_seq_cst); \
+    } while (0)
+#endif
+#ifndef ENTIRE_DATA_CACHE
+#define ENTIRE_DATA_CACHE 0
+#endif
+#ifndef SINGLE_CACHE_LINE
+#define SINGLE_CACHE_LINE 0
+#endif
+#ifndef CACHELINE_OUT
+#define CACHELINE_OUT 0
+#endif
+#ifndef DSB_DDR
+#define DSB_DDR 0
+#endif
+#ifndef DSB_ALL
+#define DSB_ALL 0
+#endif
+#ifndef DSB_UB
+#define DSB_UB 0
+#endif
 
 constexpr pipe_t opPipeList[] = {};
 

--- a/include/pto/cpu/TTrans.hpp
+++ b/include/pto/cpu/TTrans.hpp
@@ -10,6 +10,8 @@ See LICENSE in the root of the software repository for the full text of the Lice
 #ifndef TTRANS_HPP
 #define TTRANS_HPP
 
+#include <array>
+
 #include <pto/common/pto_tile.hpp>
 #include "pto/cpu/tile_offsets.hpp"
 #include <type_traits>
@@ -182,30 +184,20 @@ template <typename DstTileData, typename SrcTileData>
 void TTrans_Impl(typename DstTileData::TileDType dst, typename SrcTileData::TileDType src, unsigned validRow,
                  unsigned validCol)
 {
+    using SrcDType = typename SrcTileData::DType;
+    std::array<SrcDType, SrcTileData::Rows * SrcTileData::Cols> srcSnapshot;
+
+    for (size_t r = 0; r < validRow; r++) {
+        for (size_t c = 0; c < validCol; c++) {
+            size_t srcTileIdx = GetTileElementOffset<SrcTileData>(r, c);
+            srcSnapshot[r * validCol + c] = src[srcTileIdx];
+        }
+    }
+
     for (size_t c = 0; c < validCol; c++) {
-        size_t subTileSrcC = c / SrcTileData::InnerCols;
-        size_t innerSrcC = c % SrcTileData::InnerCols;
-        size_t subTileDstC = c / DstTileData::InnerCols;
-        size_t innerDstC = c % DstTileData::InnerCols;
-
         for (size_t r = 0; r < validRow; r++) {
-            size_t srcTileIdx, dstTileIdx;
-            if constexpr (SrcTileData::SFractal == SLayout::NoneBox)
-                srcTileIdx = GetTileElementOffsetPlain<SrcTileData>(r, c);
-            else {
-                size_t subTileR = r / SrcTileData::InnerRows;
-                size_t innerR = r % SrcTileData::InnerRows;
-                srcTileIdx = GetElementOffsetSubfractals<SrcTileData>(subTileSrcC, innerSrcC, subTileR, innerR);
-            }
-
-            if constexpr (DstTileData::SFractal == SLayout::NoneBox)
-                dstTileIdx = GetTileElementOffsetPlain<DstTileData>(c, r);
-            else {
-                size_t subTileR = r / DstTileData::InnerRows;
-                size_t innerR = r % DstTileData::InnerRows;
-                dstTileIdx = GetElementOffsetSubfractals<DstTileData>(subTileR, innerR, subTileDstC, innerDstC);
-            }
-            dst[dstTileIdx] = src[srcTileIdx];
+            size_t dstTileIdx = GetTileElementOffset<DstTileData>(c, r);
+            dst[dstTileIdx] = srcSnapshot[r * validCol + c];
         }
     }
 }

--- a/tests/cpu/comm/st/testcase/urma_context.hpp
+++ b/tests/cpu/comm/st/testcase/urma_context.hpp
@@ -35,6 +35,8 @@ public:
 
 struct UrmaTestContext {
     int deviceId{-1};
+    aclrtStream stream{nullptr};
+    int aclStatus{0};
     void *devBuf{nullptr};
     UrmaWorkspaceManager urmaMgr;
 
@@ -45,6 +47,10 @@ struct UrmaTestContext {
 
     bool Setup(int rank_id, int n_ranks, int n_devices, int first_device_id, int root_rank, size_t commBytesNeeded)
     {
+        if (n_devices <= 0 || n_ranks <= 0) {
+            return false;
+        }
+        deviceId = rank_id % n_devices + first_device_id;
         if (commBytesNeeded > 0) {
             devBuf = malloc(commBytesNeeded);
             urmaMgr.urmaInfoDevice_ = devBuf;


### PR DESCRIPTION
## Summary
- Add CPU simulation fallbacks for generated dcci/dsb cache maintenance
  intrinsics and barrier constants so AIV kernels compile under CPU ST and
  a2a3sim
- Implement dcci as an inline variadic function template to preserve argument
  evaluation while modeling host-side cache maintenance as a full fence
- Snapshot TTrans source elements with a fixed-size std::array and route all
  tile indexing through GetTileElementOffset so overlapping src/dst tiles and
  subfractal layouts are handled correctly
- Add missing stream and status fields to the URMA CPU ST context so URMA
  async tests build with the same synchronization shape as other comm tests

## Testing
- [x] Verified dcci/dsb compile failures are resolved for affected a2a3sim
  model cases
- [x] Verified hc_pre.py, hc_head.py, decode_attention_*.py, decode_*.py,
  and moe.py mismatch cases pass after the TTrans alias fix
- [x] Verified cpu_st_comm build no longer fails on missing
  UrmaTestContext::stream