### PR TITLE
fix(tile): accept statically zero valid_row/valid_col in GetValidRow/GetValidCol

### DIFF
--- a/include/pto/common/pto_tile.hpp
+++ b/include/pto/common/pto_tile.hpp
@@ -1606,7 +1606,7 @@ public:
     unsigned ColMaskInternal;
 
     template <int RowMask = ValidRow>
-    AICORE static constexpr std::enable_if_t<(RowMask > 0), unsigned> GetValidRow()
+    AICORE static constexpr std::enable_if_t<(RowMask >= 0), unsigned> GetValidRow()
     {
         return RowMask;
     }
@@ -1618,7 +1618,7 @@ public:
     }
 
     template <int ColMask = ValidCol>
-    AICORE static constexpr std::enable_if_t<(ColMask > 0), unsigned> GetValidCol()
+    AICORE static constexpr std::enable_if_t<(ColMask >= 0), unsigned> GetValidCol()
     {
         return ColMask;
     }


### PR DESCRIPTION
## Summary

Relax the SFINAE guard on `Tile::GetValidRow()` / `Tile::GetValidCol()` from `ValidRow/ColMask > 0` to `>= 0`, so a tile whose **static** valid_row (or valid_col) is `0` resolves these accessors (returning `0`) instead of failing to compile with `no matching member function for call to 'GetValidRow'`. The `DYNAMIC` (`== -1`) overload is unchanged.

```diff
-    AICORE static constexpr std::enable_if_t<(RowMask > 0), unsigned> GetValidRow()
+    AICORE static constexpr std::enable_if_t<(RowMask >= 0), unsigned> GetValidRow()
...
-    AICORE static constexpr std::enable_if_t<(ColMask > 0), unsigned> GetValidCol()
+    AICORE static constexpr std::enable_if_t<(ColMask >= 0), unsigned> GetValidCol()
```

## Why

PyPTO's dual-AIV no-op replay (`SplitMode::None` mixed cube+vec kernels on a2a3) rewrites the lane-1 tiles to a **static** `valid_shape` of `0` to keep pipe/sync state aligned without emitting real writes. Downstream tile ops read `src.GetValidRow()` / `GetValidCol()` unconditionally — e.g. `TMovToVec` (`include/pto/npu/a2a3/TMov.hpp`):

```cpp
uint64_t validSrcRow = src.GetValidRow();   // <- no overload for static RowMask==0
...
if (validRow == 0 || validCol == 0) { return; }   // already a no-op on 0
```

Today neither `(RowMask > 0)` nor `(RowMask == DYNAMIC)` matches a static `RowMask == 0`, so the lane-1 replay tile (`Tile<Vec, float, 5, 128, ..., RowMask=0, ColMask=0, ...>`) fails to compile. `TMovToVec` already early-returns when `validRow/validCol == 0`, so returning `0` here makes the zero-valid lane both **compile** and behave as the intended no-op.

## Validation

With this change plus the matching PTOAS verifier relaxation (ptoas 0.43, hw-native-sys/PTOAS#708 / #720), the Qwen3-14B `decode_layer.py` `online_softmax`→`fa_fused` fusion now compiles end-to-end (ptoas verify + InCore C++) and passes golden on an a2a3 device:

```
[RUN]   'out' PASS  shape=(16, 152064) dtype=torch.float32
[RUN] PASS
```

## Notes

This is the minimal `GetValidRow/GetValidCol` piece of the Rv=0 no-op support tracked in #143. It is offered as a ready-to-merge fix; if you'd prefer a broader/different approach (e.g. a dedicated `RowMask == 0` overload, or auditing the other ops that reject `valid_shape[0] == 0`), please feel free to use this PR as a reference.

Relates to #143 and hw-native-sys/PTOAS#708.