### PR TITLE
Revert "Prevent fork PRs from using the persistent A5 runner"

### DIFF
--- a/.github/workflows/a5-smoke.yml
+++ b/.github/workflows/a5-smoke.yml
@@ -30,11 +30,6 @@ concurrency:
 
 jobs:
   smoke:
-    if: >-
-      ${{
-        github.event_name == 'workflow_dispatch' ||
-        github.event.pull_request.head.repo.full_name == github.repository
-      }}
     # The active A5 runner is managed by the non-root zoujiangjiangCI account on host 39.
     runs-on: [self-hosted, a5]
     timeout-minutes: 120
@@ -70,7 +65,7 @@ jobs:
           repository: ${{ steps.trigger.outputs.repository }}
           ref: ${{ steps.trigger.outputs.ref }}
           fetch-depth: 1
-          clean: true
+          clean: false
 
       - name: Record trigger summary
         shell: bash


### PR DESCRIPTION
This PR reverts commit `ae77d2024a7981308096a0de12f2a3cfcc21a120`.

Reverted scope:
- remove the same-repository-only guard for A5 Smoke
- restore `actions/checkout` with `clean: false`

No other files are changed.