### PR TITLE
fix(cpu): Correct sim trace sharing and tile mask semantics

### DIFF
--- a/docs/PTOISA.md
+++ b/docs/PTOISA.md
@@ -141,7 +141,7 @@ This page is the source-synchronized ISA index generated from `docs/isa/manifest
 | Complex | [`TPARTMAX`](isa/tile/ops/irregular-and-complex/tpartmax.md) | Partial elementwise max with implementation-defined handling of mismatched valid regions. |
 | Complex | [`TPARTMIN`](isa/tile/ops/irregular-and-complex/tpartmin.md) | Partial elementwise min with implementation-defined handling of mismatched valid regions. |
 | Complex | [`TGATHERB`](isa/tile/ops/irregular-and-complex/tgatherb.md) | Gather elements using byte offsets. |
-| Complex | [`TSCATTER`](isa/tile/ops/irregular-and-complex/tscatter.md) | Scatter rows of a source tile into a destination tile using per-element row indices. |
+| Complex | [`TSCATTER`](isa/tile/ops/irregular-and-complex/tscatter.md) | Scatter source elements into a destination tile using per-element flattened offsets. |
 | Complex | [`TQUANT`](isa/tile/ops/irregular-and-complex/tquant.md) | Quantize a tile (e.g. FP32 to FP8) producing exponent/scaling/max outputs. |
 | Communication | [`TPUT`](isa/comm/TPUT.md) | Remote write: transfer local data to remote NPU memory (GM → UB → GM). |
 | Communication | [`TGET`](isa/comm/TGET.md) | Remote read: read remote NPU data to local memory (GM → UB → GM). |

--- a/docs/PTOISA_zh.md
+++ b/docs/PTOISA_zh.md
@@ -141,7 +141,7 @@
 | 复杂指令 | [`TPARTMAX`](isa/tile/ops/irregular-and-complex/tpartmax_zh.md) | 部分逐元素最大值，对不匹配的有效区域具有实现定义的处理方式。 |
 | 复杂指令 | [`TPARTMIN`](isa/tile/ops/irregular-and-complex/tpartmin_zh.md) | 部分逐元素最小值，对不匹配的有效区域具有实现定义的处理方式。 |
 | 复杂指令 | [`TGATHERB`](isa/tile/ops/irregular-and-complex/tgatherb_zh.md) | 使用字节偏移量收集元素。 |
-| 复杂指令 | [`TSCATTER`](isa/tile/ops/irregular-and-complex/tscatter_zh.md) | 使用逐元素行索引将源 Tile 的行散播到目标 Tile 中。 |
+| 复杂指令 | [`TSCATTER`](isa/tile/ops/irregular-and-complex/tscatter_zh.md) | 使用逐元素扁平偏移将源 Tile 元素散播到目标 Tile 中。 |
 | 复杂指令 | [`TQUANT`](isa/tile/ops/irregular-and-complex/tquant_zh.md) | 量化 Tile（例如 FP32 到 FP8），生成指数/缩放/最大值输出。 |
 | 通信 | [`TPUT`](isa/comm/communication-runtime_zh.md) | 远程写：将本地数据传输到远端 NPU 内存（GM → UB → GM）。 |
 | 通信 | [`TGET`](isa/comm/communication-runtime_zh.md) | 远程读：将远端 NPU 数据读取到本地内存（GM → UB → GM）。 |

--- a/docs/figures/isa/TSCATTER.svg
+++ b/docs/figures/isa/TSCATTER.svg
@@ -33,11 +33,11 @@ svg { font-family: Arial, Helvetica, sans-serif; }
 <rect x="0" y="0" width="1200" height="720" class="frame" />
 <rect x="24" y="24" width="1152" height="672" class="panel" />
 <text x="40" y="46" class="title">TSCATTER</text>
-<text x="40" y="72" class="subtitle">Scatter rows of a source tile into a destination tile using per-element row indices.</text>
+<text x="40" y="72" class="subtitle">Scatter source elements into a destination tile using per-element flattened offsets.</text>
 <text x="40" y="92" class="meta">Template: complex</text>
 <text x="1160" y="92" class="meta" text-anchor="end">Legend: outline=example; dashed=valid rows/cols (Rv,Cv); shaded=masked; r down / c right; ortho arrows=dataflow</text>
 <line x1="36" y1="104" x2="1164" y2="104" stroke="#e2e8f0" stroke-width="1.5" />
-<text x="600" y="140" class="subtitle" text-anchor="middle" fill="#C53A79">dst[ idx[r,c], c ] = src[r,c]</text>
+<text x="600" y="140" class="subtitle" text-anchor="middle" fill="#C53A79">dst_flat[ idx[r,c] ] = src[r,c]</text>
 <text x="485" y="168" class="tileLabel" text-anchor="middle">src</text>
 <rect x="430" y="178" width="110" height="110" class="tileBorder" />
 <rect x="430" y="178" width="22" height="22" class="cell" />
@@ -72,7 +72,7 @@ svg { font-family: Arial, Helvetica, sans-serif; }
 <path d="M 440 188 L 440 222" class="axisLine" marker-end="url(#axisArrow)" />
 <text x="478" y="192" class="axisText">c</text>
 <text x="438" y="226" class="axisText" text-anchor="end">r</text>
-<text x="715" y="168" class="tileLabel" text-anchor="middle">row idx</text>
+<text x="715" y="168" class="tileLabel" text-anchor="middle">flat idx</text>
 <rect x="660" y="178" width="110" height="110" class="tileBorder" />
 <rect x="660" y="178" width="22" height="22" class="cell" />
 <rect x="682" y="178" width="22" height="22" class="cell" />
@@ -82,7 +82,7 @@ svg { font-family: Arial, Helvetica, sans-serif; }
 <rect x="660" y="200" width="22" height="22" class="cell" />
 <rect x="682" y="200" width="22" height="22" class="cell" />
 <rect x="704" y="200" width="22" height="22" class="cell cellHL" stroke="#C53A79" />
-<text x="715" y="212" class="cellText" text-anchor="middle" dominant-baseline="middle">rr</text>
+<text x="715" y="212" class="cellText" text-anchor="middle" dominant-baseline="middle">k</text>
 <rect x="726" y="200" width="22" height="22" class="cell" />
 <rect x="748" y="200" width="22" height="22" class="cell cellMasked" />
 <rect x="660" y="222" width="22" height="22" class="cell" />
@@ -152,8 +152,8 @@ svg { font-family: Arial, Helvetica, sans-serif; }
 <text x="56" y="528" class="procTitle">Procedure (conceptual)</text>
 <text x="56" y="554" class="procText" xml:space="preserve">
   <tspan x="56" dy="0">for r,c in valid(src):</tspan>
-  <tspan x="56" dy="16">  rr = idx[r,c]</tspan>
-  <tspan x="56" dy="16">  dst[rr, c] = src[r,c]</tspan>
+  <tspan x="56" dy="16">  k = idx[r,c]</tspan>
+  <tspan x="56" dy="16">  dst_flat[k] = src[r,c]</tspan>
 </text>
 <text x="56" y="680" class="meta">Note: semantics apply to the valid region unless stated otherwise.</text>
 </svg>

--- a/docs/isa/manifest.yaml
+++ b/docs/isa/manifest.yaml
@@ -1512,8 +1512,8 @@
     {
       "instruction": "TSCATTER",
       "category": "Complex",
-      "summary_en": "Scatter rows of a source tile into a destination tile using per-element row indices.",
-      "summary_zh": "使用逐元素行索引将源 Tile 的行散播到目标 Tile 中。",
+      "summary_en": "Scatter source elements into a destination tile using per-element flattened offsets.",
+      "summary_zh": "使用逐元素扁平偏移将源 Tile 元素散播到目标 Tile 中。",
       "diagram_template": "complex",
       "operands": [
         "dst",

--- a/docs/tools/gen_isa_svgs.py
+++ b/docs/tools/gen_isa_svgs.py
@@ -1456,20 +1456,20 @@ def _render_complex(instr: str, summary: str, accent: str, bg: str) -> str:
         return _end_svg(out)
 
     if instr == "TSCATTER":
-        expr = "dst[ idx[r,c], c ] = src[r,c]"
+        expr = "dst_flat[ idx[r,c] ] = src[r,c]"
         proc = [
             "for r,c in valid(src):",
-            "  rr = idx[r,c]",
-            "  dst[rr, c] = src[r,c]",
+            "  k = idx[r,c]",
+            "  dst_flat[k] = src[r,c]",
         ]
         out.append(
             f'<text x="{CANVAS_W // 2}" y="{EXPR_Y}" class="subtitle" text-anchor="middle" fill="{_esc(accent)}">{_esc(expr)}</text>'
         )
         xs = _layout_row_lefts(CANVAS_W // 2, [tile_w, tile_w], 120)
         x_src, x_idx = xs[0], xs[1]
-        idx_text = {(EX_R, EX_C): "rr"}
+        idx_text = {(EX_R, EX_C): "k"}
         _draw_tile_grid(out, x=x_src, y=y_src, label="src", prefix="a", highlight_cells=[(EX_R, EX_C)], accent=accent)
-        _draw_tile_grid(out, x=x_idx, y=y_src, label="row idx", prefix="i", highlight_cells=[(EX_R, EX_C)], text_override=idx_text, accent=accent)
+        _draw_tile_grid(out, x=x_idx, y=y_src, label="flat idx", prefix="i", highlight_cells=[(EX_R, EX_C)], text_override=idx_text, accent=accent)
 
         x_dst = (CANVAS_W - tile_w) // 2
         dst_r = min(TILE_ROWS - 2, EX_R + 1) if TILE_ROWS > 2 else EX_R

--- a/include/pto/cpu/NPUMemoryModel.hpp
+++ b/include/pto/cpu/NPUMemoryModel.hpp
@@ -31,6 +31,7 @@
 #include <cstddef>
 #include <algorithm>
 #include <cstdint>
+#include <cstdio>
 #include <cstdlib>
 #include <vector>
 #include <pto/common/pto_tile.hpp>
@@ -60,6 +61,8 @@ public:
     using ArchMemorySizes = std::size_t[MemoryRegion::_MAX_REGIONS];
 
 private:
+    static inline constexpr std::size_t kDefaultCpuSimUBScratchSize = 512 * 1024;
+
     // Memory sizes by architecture
     // A2/A3:
     // https://www.hiascend.com/doc_center/source/zh/canncommercial/80RC3/devguide/appdevg/sdpdevg/atlasprogramming_12_0003.html
@@ -95,7 +98,8 @@ private:
 
     void ApplySizeOverrides()
     {
-        sizes_[MemoryRegion::UB] = ReadSizeOverride("PTO_CPU_SIM_UB_BYTES", sizes_[MemoryRegion::UB]);
+        sizes_[MemoryRegion::UB] =
+            ReadSizeOverride("PTO_CPU_SIM_UB_BYTES", std::max(sizes_[MemoryRegion::UB], kDefaultCpuSimUBScratchSize));
         sizes_[MemoryRegion::L1] = ReadSizeOverride("PTO_CPU_SIM_L1_BYTES", sizes_[MemoryRegion::L1]);
         sizes_[MemoryRegion::L0A] = ReadSizeOverride("PTO_CPU_SIM_L0A_BYTES", sizes_[MemoryRegion::L0A]);
         sizes_[MemoryRegion::L0B] = ReadSizeOverride("PTO_CPU_SIM_L0B_BYTES", sizes_[MemoryRegion::L0B]);
@@ -324,7 +328,12 @@ private:
     {
         EnsureInitialized();
 
-        assert(byteOffset + numel * sizeof(T) <= sizes_[region]);
+        if (byteOffset > sizes_[region] || numel > (sizes_[region] - byteOffset) / sizeof(T)) {
+            std::fprintf(stderr,
+                         "PTO CPU sim TASSIGN out of range: region=%d offset=%zu numel=%zu elem_size=%zu size=%zu\n",
+                         static_cast<int>(region), byteOffset, numel, sizeof(T), sizes_[region]);
+            std::abort();
+        }
         return reinterpret_cast<T *>(buffers_[region].data() + byteOffset);
     }
 

--- a/include/pto/cpu/TCmps.hpp
+++ b/include/pto/cpu/TCmps.hpp
@@ -12,6 +12,7 @@ See LICENSE in the root of the software repository for the full text of the Lice
 #define TCMPS_HPP
 #include <pto/common/pto_tile.hpp>
 #include "pto/cpu/tile_offsets.hpp"
+#include <algorithm>
 #include <cmath>
 #include <vector>
 
@@ -61,7 +62,7 @@ AICORE void TCmps(typename TileDataDst::TileDType __out__ dst, typename TileData
 
     for (size_t i = 0; i < srcValidRow; i++) {
         for (size_t j = 0; j < srcValidCol; j++) {
-            T a = src0[i * srcStride + j];
+            T a = src0[GetTileElementOffset<TileDataSrc>(i, j)];
             golden[i * W + j] = CmpCall<T>(a, src1, mode);
         }
     }
@@ -81,11 +82,16 @@ AICORE void TCmps(typename TileDataDst::TileDType __out__ dst, typename TileData
         }
     }
 
-    int c = 0;
-    for (size_t i = 0; i < dstValidRow && c < out_uint8.size(); i++) {
-        for (size_t j = 0; j < dstValidCol && c < out_uint8.size(); j++) {
-            dst[i * W + j] = out_uint8[c++];
-            uint8_t b = dst[i * W + j];
+    std::fill(dst, dst + TileDataDst::Numel, static_cast<typename TileDataDst::DType>(0));
+    const size_t dstPackedCols = static_cast<size_t>(dstValidCol);
+    if (dstPackedCols == 0) {
+        return;
+    }
+    for (size_t c = 0; c < out_uint8.size() && c < TileDataDst::Numel; ++c) {
+        const size_t i = c / dstPackedCols;
+        const size_t j = c % dstPackedCols;
+        if (i < dstValidRow && j < dstValidCol) {
+            dst[GetTileElementOffset<TileDataDst>(i, j)] = static_cast<typename TileDataDst::DType>(out_uint8[c]);
         }
     }
 }
@@ -132,8 +138,8 @@ PTO_INTERNAL void TCMPS_IMPL(TileDataDst &dst, TileDataSrc0 &src0, TileDataSrc1 
 
     for (size_t i = 0; i < srcValidRow; i++) {
         for (size_t j = 0; j < srcValidCol; j++) {
-            T a = src0.data()[i * srcStride + j];
-            T b = src1.data()[i * src1Stride + j];
+            T a = src0.data()[GetTileElementOffset<TileDataSrc0>(i, j)];
+            T b = src1.data()[GetTileElementOffset<TileDataSrc1>(i, j)];
             golden[i * W + j] = CmpCall<T>(a, b, cmpMode);
         }
     }
@@ -152,10 +158,17 @@ PTO_INTERNAL void TCMPS_IMPL(TileDataDst &dst, TileDataSrc0 &src0, TileDataSrc1 
         }
     }
 
-    int c = 0;
-    for (size_t i = 0; i < dstValidRow && c < out_uint8.size(); i++) {
-        for (size_t j = 0; j < dstValidCol && c < out_uint8.size(); j++) {
-            dst.data()[GetTileElementOffset<TileDataDst>(i, j)] = out_uint8[c++];
+    std::fill(dst.data(), dst.data() + TileDataDst::Numel, static_cast<typename TileDataDst::DType>(0));
+    const size_t dstPackedCols = static_cast<size_t>(dstValidCol);
+    if (dstPackedCols == 0) {
+        return;
+    }
+    for (size_t c = 0; c < out_uint8.size() && c < TileDataDst::Numel; ++c) {
+        const size_t i = c / dstPackedCols;
+        const size_t j = c % dstPackedCols;
+        if (i < dstValidRow && j < dstValidCol) {
+            dst.data()[GetTileElementOffset<TileDataDst>(i, j)] =
+                static_cast<typename TileDataDst::DType>(out_uint8[c]);
         }
     }
 }

--- a/include/pto/cpu/TRowExpandOp.hpp
+++ b/include/pto/cpu/TRowExpandOp.hpp
@@ -32,16 +32,21 @@ PTO_INTERNAL typename TileVec::DType load_row_scalar(TileVec &src1, std::size_t 
     }
     return static_cast<typename TileVec::DType>(src1.data()[rowIndex % static_cast<std::size_t>(TileVec::Numel)]);
 }
+
+template <ElementOp Op, typename T>
+inline constexpr bool IsSupportedRowExpandOpType =
+    std::is_same_v<T, float> || std::is_same_v<T, half> ||
+    (Op == ElementOp::OP_ADD && (std::is_same_v<T, int32_t> || std::is_same_v<T, int> || std::is_same_v<T, int16_t>));
 } // namespace
 
-template <typename TileDst, typename TileSrc0, typename TileSrc1>
+template <typename TileDst, typename TileSrc0, typename TileSrc1, ElementOp TileOperation>
 PTO_INTERNAL void CheckRowExtendTiles()
 {
     using T = typename TileDst::DType;
     static_assert(std::is_same_v<T, typename TileSrc0::DType> && std::is_same_v<T, typename TileSrc1::DType>,
                   "TRowExpandOp: The data type of dst must be consistent with src0, src1.");
-    static_assert(std::is_same_v<T, float> || std::is_same_v<T, half>,
-                  "TRowExpandOp: The data type of dst, src0, src1 must be one of: `half`, `float`");
+    static_assert(IsSupportedRowExpandOpType<TileOperation, T>,
+                  "TRowExpandOp: Unsupported data type for this row expand operation.");
 
     static_assert(TileDst::isRowMajor, "TRowExpandOp: TileType of dst tile must be Row Major.");
 }
@@ -75,7 +80,7 @@ PTO_INTERNAL void TRowExpandOp(TileDst &dst, TileSrc0 &src0, TileSrc1 &src1, std
 template <typename TileDst, typename TileSrc0, typename TileSrc1, ElementOp TileOperation>
 PTO_INTERNAL void TRowExpandOp(TileDst &dst, TileSrc0 &src0, TileSrc1 &src1)
 {
-    CheckRowExtendTiles<TileDst, TileSrc0, TileSrc1>();
+    CheckRowExtendTiles<TileDst, TileSrc0, TileSrc1, TileOperation>();
     const std::size_t rows = static_cast<std::size_t>(dst.GetValidRow());
     const std::size_t cols = static_cast<std::size_t>(dst.GetValidCol());
     if (rows == 0 || cols == 0) {

--- a/include/pto/cpu/TScatter.hpp
+++ b/include/pto/cpu/TScatter.hpp
@@ -31,13 +31,18 @@ PTO_INTERNAL void TSCATTER_IMPL(TileDataDst &dst, TileDataSrc &src, TileInd &ind
         return;
     }
 
+    constexpr std::size_t dstNumel =
+        static_cast<std::size_t>(TileDataDst::Rows) * static_cast<std::size_t>(TileDataDst::Cols);
+
     for (unsigned i = 0; i < validRow; ++i) {
         for (unsigned j = 0; j < validCol; ++j) {
             const size_t srcOff = GetTileElementOffset<TileDataSrc>(i, j);
             const size_t idxOff = GetTileElementOffset<TileInd>(i, j);
-            const auto dstRow = static_cast<unsigned>(indexes.data()[idxOff]);
-            const size_t dstOff = GetTileElementOffset<TileDataDst>(dstRow, j);
-            dst.data()[dstOff] = src.data()[srcOff];
+            const auto rawIndex = indexes.data()[idxOff];
+            if (!IndexInBounds(rawIndex, dstNumel)) {
+                continue;
+            }
+            dst.data()[static_cast<std::size_t>(rawIndex)] = src.data()[srcOff];
         }
     }
 }

--- a/include/pto/cpu/trace.hpp
+++ b/include/pto/cpu/trace.hpp
@@ -14,6 +14,7 @@ See LICENSE in the root of the software repository for the full text of the Lice
 #include <cstdint>
 #include <functional>
 #include <iomanip>
+#include <mutex>
 #include <ostream>
 #include <sstream>
 #include <string>
@@ -57,23 +58,76 @@ struct InstructionTraceRecord {
 struct InstructionTraceState {
     uint64_t next_sequence_id = 0;
     std::vector<InstructionTraceRecord> records;
+    mutable std::mutex mutex;
 };
 
 inline thread_local InstructionTraceState g_instruction_trace_state;
+inline thread_local InstructionTraceState *g_instruction_trace_override = nullptr;
+
+inline InstructionTraceState &CurrentInstructionTraceState()
+{
+    return g_instruction_trace_override == nullptr ? g_instruction_trace_state : *g_instruction_trace_override;
+}
 
 inline void ResetInstructionTrace()
 {
-    g_instruction_trace_state = {};
+    auto &trace = CurrentInstructionTraceState();
+    std::scoped_lock lock(trace.mutex);
+    trace.next_sequence_id = 0;
+    trace.records.clear();
 }
 
 inline InstructionTraceState &GetMutableInstructionTrace()
 {
-    return g_instruction_trace_state;
+    return CurrentInstructionTraceState();
 }
 
+// Returns the active trace state for advanced consumers that need direct access
+// to the state object. Callers must lock InstructionTraceState::mutex before
+// reading records or mutating shared members.
 inline const InstructionTraceState &GetInstructionTrace()
 {
-    return g_instruction_trace_state;
+    return CurrentInstructionTraceState();
+}
+
+inline std::vector<InstructionTraceRecord> CopyInstructionTraceRecords()
+{
+    const auto &trace = GetInstructionTrace();
+    std::scoped_lock lock(trace.mutex);
+    return trace.records;
+}
+
+class ScopedInstructionTraceState {
+public:
+    explicit ScopedInstructionTraceState(InstructionTraceState &state) : saved_(g_instruction_trace_override)
+    {
+        g_instruction_trace_override = &state;
+    }
+
+    ~ScopedInstructionTraceState()
+    {
+        g_instruction_trace_override = saved_;
+    }
+
+    ScopedInstructionTraceState(const ScopedInstructionTraceState &) = delete;
+    ScopedInstructionTraceState &operator=(const ScopedInstructionTraceState &) = delete;
+
+private:
+    InstructionTraceState *saved_ = nullptr;
+};
+
+inline uint64_t ReserveInstructionTraceSequenceId()
+{
+    auto &trace = GetMutableInstructionTrace();
+    std::scoped_lock lock(trace.mutex);
+    return trace.next_sequence_id++;
+}
+
+inline void AppendInstructionTraceRecord(InstructionTraceRecord record)
+{
+    auto &trace = GetMutableInstructionTrace();
+    std::scoped_lock lock(trace.mutex);
+    trace.records.push_back(std::move(record));
 }
 
 inline const char *LayoutToString(Layout layout)
@@ -355,8 +409,8 @@ inline std::string HexAddress(std::uintptr_t address)
 
 inline void DumpInstructionTraceJson(std::ostream &os)
 {
-    const auto &trace = GetInstructionTrace();
-    for (const auto &record : trace.records) {
+    const auto records = CopyInstructionTraceRecords();
+    for (const auto &record : records) {
         os << "{\"block_idx\":" << record.block_idx << ",\"sequence_id\":" << record.sequence_id << ",\"opcode\":\""
            << JsonEscape(record.opcode) << "\",\"input_tiles\":[";
         for (std::size_t i = 0; i < record.input_tiles.size(); ++i) {
@@ -441,7 +495,7 @@ public:
             for (const auto &capture : output_tile_captures_) {
                 capture(record_);
             }
-            GetMutableInstructionTrace().records.push_back(std::move(record_));
+            AppendInstructionTraceRecord(std::move(record_));
         }
     }
 
@@ -453,7 +507,7 @@ private:
     {
         active_ = true;
         record_.block_idx = ::get_block_idx();
-        record_.sequence_id = GetMutableInstructionTrace().next_sequence_id++;
+        record_.sequence_id = ReserveInstructionTraceSequenceId();
         record_.opcode = std::string(opcode);
     }
 

--- a/tests/cpu/st/testcase/tscatter/gen_data.py
+++ b/tests/cpu/st/testcase/tscatter/gen_data.py
@@ -57,12 +57,13 @@ def gen_case(case_dir: str, rows: int, cols: int):
     os.chdir(case_dir)
 
     src = np.random.uniform(low=-4, high=4, size=[rows, cols]).astype(np.float32)
-    idx = np.random.randint(0, rows, size=[rows, cols]).astype(np.uint16)
+    idx = np.random.randint(0, rows, size=[rows, cols]).astype(np.uint32)
+    idx = idx * cols + np.arange(cols, dtype=np.uint32)
 
     dst = np.zeros([rows, cols], dtype=np.float32)
     for i in range(rows):
         for j in range(cols):
-            dst[idx[i, j], j] = src[i, j]
+            dst.flat[idx[i, j]] = src[i, j]
 
     src.tofile("input1.bin")
     idx.tofile("input2.bin")

--- a/tests/cpu/st/testcase/tscatter/main.cpp
+++ b/tests/cpu/st/testcase/tscatter/main.cpp
@@ -33,13 +33,13 @@ std::string GetGoldenDir()
 }
 
 template <int kTRows_, int kTCols_>
-void LaunchTScatter(float *out, float *src, uint16_t *idx, void *stream);
+void LaunchTScatter(float *out, float *src, uint32_t *idx, void *stream);
 
 template <int kTRows_, int kTCols_>
 void test_tscatter()
 {
     const size_t tileBytes = kTRows_ * kTCols_ * sizeof(float);
-    const size_t idxBytes = kTRows_ * kTCols_ * sizeof(uint16_t);
+    const size_t idxBytes = kTRows_ * kTCols_ * sizeof(uint32_t);
 
     aclInit(nullptr);
     aclrtSetDevice(0);
@@ -47,9 +47,9 @@ void test_tscatter()
     aclrtCreateStream(&stream);
 
     float *dstHost, *srcHost;
-    uint16_t *idxHost;
+    uint32_t *idxHost;
     float *dstDevice, *srcDevice;
-    uint16_t *idxDevice;
+    uint32_t *idxDevice;
 
     aclrtMallocHost((void **)(&dstHost), tileBytes);
     aclrtMallocHost((void **)(&srcHost), tileBytes);

--- a/tests/cpu/st/testcase/tscatter/tscatter_kernel.cpp
+++ b/tests/cpu/st/testcase/tscatter/tscatter_kernel.cpp
@@ -15,15 +15,15 @@ See LICENSE in the root of the software repository for the full text of the Lice
 using namespace pto;
 
 template <int kTRows_, int kTCols_>
-AICORE void runTScatter(__gm__ float __out__ *out, __gm__ float __in__ *src, __gm__ uint16_t __in__ *idx)
+AICORE void runTScatter(__gm__ float __out__ *out, __gm__ float __in__ *src, __gm__ uint32_t __in__ *idx)
 {
     using TileT = Tile<TileType::Vec, float, kTRows_, kTCols_, BLayout::RowMajor, -1, -1>;
-    using IdxT = Tile<TileType::Vec, uint16_t, kTRows_, kTCols_, BLayout::RowMajor, -1, -1>;
+    using IdxT = Tile<TileType::Vec, uint32_t, kTRows_, kTCols_, BLayout::RowMajor, -1, -1>;
 
     using SrcShape = Shape<1, 1, 1, kTRows_, kTCols_>;
     using SrcStride = Stride<1, 1, 1, kTCols_, 1>;
     using GTf = GlobalTensor<float, SrcShape, SrcStride>;
-    using GTi = GlobalTensor<uint16_t, SrcShape, SrcStride>;
+    using GTi = GlobalTensor<uint32_t, SrcShape, SrcStride>;
 
     TileT srcTile(kTRows_, kTCols_);
     TileT dstTile(kTRows_, kTCols_);
@@ -46,12 +46,12 @@ AICORE void runTScatter(__gm__ float __out__ *out, __gm__ float __in__ *src, __g
 }
 
 template <int kTRows_, int kTCols_>
-void LaunchTScatter(float *out, float *src, uint16_t *idx, void *stream)
+void LaunchTScatter(float *out, float *src, uint32_t *idx, void *stream)
 {
     runTScatter<kTRows_, kTCols_>(out, src, idx);
 }
 
-template void LaunchTScatter<16, 16>(float *out, float *src, uint16_t *idx, void *stream);
+template void LaunchTScatter<16, 16>(float *out, float *src, uint32_t *idx, void *stream);
 
 // --- Mask-pattern TSCATTER ---
 

--- a/tests/cpu/st/testcase/ttrace/main.cpp
+++ b/tests/cpu/st/testcase/ttrace/main.cpp
@@ -64,29 +64,29 @@ TEST_F(TTraceTest, CapturesZeroOperandAndBasicTileInstructions)
     pto::TADD(dst, src0, src1);
     pto::TDIV(dst, src0, src1);
 
-    const auto &trace = pto::cpu_sim::GetInstructionTrace();
-    ASSERT_EQ(trace.records.size(), 3u);
+    const auto trace = pto::cpu_sim::CopyInstructionTraceRecords();
+    ASSERT_EQ(trace.size(), 3u);
 
-    EXPECT_EQ(trace.records[0].opcode, "TSYNC");
-    EXPECT_EQ(trace.records[0].block_idx, 7u);
-    EXPECT_EQ(trace.records[0].sequence_id, 0u);
-    EXPECT_TRUE(trace.records[0].input_tiles.empty());
-    EXPECT_TRUE(trace.records[0].scalar_inputs.empty());
-    EXPECT_TRUE(trace.records[0].output_tiles.empty());
+    EXPECT_EQ(trace[0].opcode, "TSYNC");
+    EXPECT_EQ(trace[0].block_idx, 7u);
+    EXPECT_EQ(trace[0].sequence_id, 0u);
+    EXPECT_TRUE(trace[0].input_tiles.empty());
+    EXPECT_TRUE(trace[0].scalar_inputs.empty());
+    EXPECT_TRUE(trace[0].output_tiles.empty());
 
-    EXPECT_EQ(trace.records[1].opcode, "TADD");
-    EXPECT_EQ(trace.records[1].sequence_id, 1u);
-    ASSERT_EQ(trace.records[1].input_tiles.size(), 2u);
-    ASSERT_EQ(trace.records[1].output_tiles.size(), 1u);
-    EXPECT_EQ(trace.records[1].input_tiles[0].address, src0.GetAssignedAddress());
-    EXPECT_EQ(trace.records[1].input_tiles[1].address, src1.GetAssignedAddress());
-    EXPECT_EQ(trace.records[1].output_tiles[0].address, dst.GetAssignedAddress());
-    EXPECT_EQ(trace.records[1].output_tiles[0].shape, (std::vector<int64_t>{2, 32}));
+    EXPECT_EQ(trace[1].opcode, "TADD");
+    EXPECT_EQ(trace[1].sequence_id, 1u);
+    ASSERT_EQ(trace[1].input_tiles.size(), 2u);
+    ASSERT_EQ(trace[1].output_tiles.size(), 1u);
+    EXPECT_EQ(trace[1].input_tiles[0].address, src0.GetAssignedAddress());
+    EXPECT_EQ(trace[1].input_tiles[1].address, src1.GetAssignedAddress());
+    EXPECT_EQ(trace[1].output_tiles[0].address, dst.GetAssignedAddress());
+    EXPECT_EQ(trace[1].output_tiles[0].shape, (std::vector<int64_t>{2, 32}));
 
-    EXPECT_EQ(trace.records[2].opcode, "TDIV");
-    EXPECT_EQ(trace.records[2].sequence_id, 2u);
-    ASSERT_EQ(trace.records[2].input_tiles.size(), 2u);
-    ASSERT_EQ(trace.records[2].output_tiles.size(), 1u);
+    EXPECT_EQ(trace[2].opcode, "TDIV");
+    EXPECT_EQ(trace[2].sequence_id, 2u);
+    ASSERT_EQ(trace[2].input_tiles.size(), 2u);
+    ASSERT_EQ(trace[2].output_tiles.size(), 1u);
 
     std::ostringstream json;
     pto::cpu_sim::DumpInstructionTraceJson(json);
@@ -116,15 +116,15 @@ TEST_F(TTraceTest, CapturesInterleavedAndMultiOutputOperands)
 
     pto::TROWARGMAX(dstVal, dstIdx, src, tmp);
 
-    const auto &trace = pto::cpu_sim::GetInstructionTrace();
-    ASSERT_EQ(trace.records.size(), 1u);
-    EXPECT_EQ(trace.records[0].opcode, "TROWARGMAX");
-    ASSERT_EQ(trace.records[0].output_tiles.size(), 2u);
-    ASSERT_EQ(trace.records[0].input_tiles.size(), 2u);
-    EXPECT_EQ(trace.records[0].output_tiles[0].address, dstVal.GetAssignedAddress());
-    EXPECT_EQ(trace.records[0].output_tiles[1].address, dstIdx.GetAssignedAddress());
-    EXPECT_EQ(trace.records[0].input_tiles[0].address, src.GetAssignedAddress());
-    EXPECT_EQ(trace.records[0].input_tiles[1].address, tmp.GetAssignedAddress());
+    const auto trace = pto::cpu_sim::CopyInstructionTraceRecords();
+    ASSERT_EQ(trace.size(), 1u);
+    EXPECT_EQ(trace[0].opcode, "TROWARGMAX");
+    ASSERT_EQ(trace[0].output_tiles.size(), 2u);
+    ASSERT_EQ(trace[0].input_tiles.size(), 2u);
+    EXPECT_EQ(trace[0].output_tiles[0].address, dstVal.GetAssignedAddress());
+    EXPECT_EQ(trace[0].output_tiles[1].address, dstIdx.GetAssignedAddress());
+    EXPECT_EQ(trace[0].input_tiles[0].address, src.GetAssignedAddress());
+    EXPECT_EQ(trace[0].input_tiles[1].address, tmp.GetAssignedAddress());
 }
 
 TEST_F(TTraceTest, CapturesPointerOutputsForMxQuant)
@@ -157,22 +157,22 @@ TEST_F(TTraceTest, CapturesPointerOutputsForMxQuant)
     pto::TQUANT<pto::QuantType::MXFP8>(dst, src, &exp, &max, &scaling);
     pto::TQUANT<pto::QuantType::MXFP8, pto::VecStoreMode::NZ>(dst, src, &exp, &max, &scaling, &expZz);
 
-    const auto &trace = pto::cpu_sim::GetInstructionTrace();
-    ASSERT_EQ(trace.records.size(), 2u);
+    const auto trace = pto::cpu_sim::CopyInstructionTraceRecords();
+    ASSERT_EQ(trace.size(), 2u);
 
-    EXPECT_EQ(trace.records[0].opcode, "TQUANT");
-    ASSERT_EQ(trace.records[0].input_tiles.size(), 1u);
-    ASSERT_EQ(trace.records[0].output_tiles.size(), 4u);
-    EXPECT_EQ(trace.records[0].input_tiles[0].address, src.GetAssignedAddress());
-    EXPECT_EQ(trace.records[0].output_tiles[0].address, dst.GetAssignedAddress());
-    EXPECT_EQ(trace.records[0].output_tiles[1].address, exp.GetAssignedAddress());
-    EXPECT_EQ(trace.records[0].output_tiles[2].address, max.GetAssignedAddress());
-    EXPECT_EQ(trace.records[0].output_tiles[3].address, scaling.GetAssignedAddress());
+    EXPECT_EQ(trace[0].opcode, "TQUANT");
+    ASSERT_EQ(trace[0].input_tiles.size(), 1u);
+    ASSERT_EQ(trace[0].output_tiles.size(), 4u);
+    EXPECT_EQ(trace[0].input_tiles[0].address, src.GetAssignedAddress());
+    EXPECT_EQ(trace[0].output_tiles[0].address, dst.GetAssignedAddress());
+    EXPECT_EQ(trace[0].output_tiles[1].address, exp.GetAssignedAddress());
+    EXPECT_EQ(trace[0].output_tiles[2].address, max.GetAssignedAddress());
+    EXPECT_EQ(trace[0].output_tiles[3].address, scaling.GetAssignedAddress());
 
-    EXPECT_EQ(trace.records[1].opcode, "TQUANT");
-    ASSERT_EQ(trace.records[1].input_tiles.size(), 1u);
-    ASSERT_EQ(trace.records[1].output_tiles.size(), 5u);
-    EXPECT_EQ(trace.records[1].output_tiles[4].address, expZz.GetAssignedAddress());
+    EXPECT_EQ(trace[1].opcode, "TQUANT");
+    ASSERT_EQ(trace[1].input_tiles.size(), 1u);
+    ASSERT_EQ(trace[1].output_tiles.size(), 5u);
+    EXPECT_EQ(trace[1].output_tiles[4].address, expZz.GetAssignedAddress());
 }
 
 TEST_F(TTraceTest, WritesKernelTraceFile)


### PR DESCRIPTION
## Summary
- Add a shared instruction trace override with mutex protection and a locked
  trace-record snapshot reader (`CopyInstructionTraceRecords`,
  `ScopedInstructionTraceState`, `ReserveInstructionTraceSequenceId`,
  `AppendInstructionTraceRecord`) so mixed AIC/AIV CPU-sim threads can record
  into one trace state instead of each thread exposing only its own
  thread-local records, allowing DavinciOO to update the submodule pointer and
  merge wrapper traces correctly
- Fix CPU-sim TCMPS to read tile elements via layout-aware
  `GetTileElementOffset`, clear the destination mask tile, and pack mask
  bytes using the runtime valid column count consumed by TSEL
- Fix TSCATTER indexed form to use the backend-defined flat destination
  element offset semantics with `IndexInBounds` checks, and update the CPU
  ST golden generator (uint16 row index -> uint32 flat offset), kernel
  signatures, ISA docs (`PTOISA.md`, `PTOISA_zh.md`, `manifest.yaml`),
  TSCATTER SVG, and `gen_isa_svgs.py` away from the old row-index
  interpretation
- Allow TROWEXPANDADD on integer tile types (`int32_t`, `int`, `int16_t`)
  needed by generated CPU-sim kernels via a new `IsSupportedRowExpandOpType`
  trait, while keeping other row-expand ops restricted to `half`/`float`
- Replace release-build TASSIGN silent local-memory overflow with an
  explicit CPU-sim bounds check and `std::abort` diagnostic, and raise the
  default CPU-sim UB scratch floor (`kDefaultCpuSimUBScratchSize = 512 KiB`)
  to keep enough UB scratch space for legacy CPU ST offsets

## Testing
- [x] Pre-commit checks
- [x] Docs build
- [x] CPU SIM smoke tests
- [x] `pypto-lib/models/deepseek/v4/decode_compressor_ratio4.py --platform a2a3sim`
  passes on device 12 with PTO2 ring settings
- [x] Confirmed `kv`, `compress_state`, and `cmp_kv_cache` validation outputs
  all pass
