### PR TITLE
test(mscatter_indirect_call_repro): add opt-in regression test for SIMT-via-LongCALL

### DIFF
--- a/tests/npu/a5/src/st/testcase/CMakeLists.txt
+++ b/tests/npu/a5/src/st/testcase/CMakeLists.txt
@@ -253,6 +253,12 @@ set(ALL_TESTCASES
 set(OPT_IN_TESTCASES
 # Device-side async L2 prefetch: correctness + focused perf comparison
 tprefetch_async
+# Standalone repro for the runtime-dispatch limitation described in
+# mgather/MGATHER.md §"Runtime Dispatch Requirement" — expected to hang on
+# current toolchain. Acts as a regression detector once SIMT-aware lowering
+# is added to HiIPUISD::LongCALL (or an equivalent builtin is exposed).
+# See testcase/mscatter_indirect_call_repro/README.md.
+mscatter_indirect_call_repro
 )
 
 if (AUTO_MODE)

--- a/tests/npu/a5/src/st/testcase/mscatter_indirect_call_repro/CMakeLists.txt
+++ b/tests/npu/a5/src/st/testcase/mscatter_indirect_call_repro/CMakeLists.txt
@@ -1,0 +1,11 @@
+# --------------------------------------------------------------------------------
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# --------------------------------------------------------------------------------
+
+pto_vec_st(mscatter_indirect_call_repro)

--- a/tests/npu/a5/src/st/testcase/mscatter_indirect_call_repro/README.md
+++ b/tests/npu/a5/src/st/testcase/mscatter_indirect_call_repro/README.md
@@ -1,0 +1,98 @@
+# MSCATTER indirect-call repro (expected-fail regression test)
+
+Standalone reproducer for the runtime-dispatch limitation documented in
+[`tests/npu/a5/src/st/testcase/mgather/MGATHER.md`][mgather-doc]
+§"Runtime Dispatch Requirement".
+
+This test is **expected to fail / hang** on the current toolchain
+(bisheng 15.0.5, dav-c310-vec, CANN 9.1.T500). It is **opt-in** — built
+only when `TEST_CASE=mscatter_indirect_call_repro` is explicitly
+supplied, so it does not slow down the default CI matrix.
+
+When the toolchain / firmware learns to install SIMT-aware lowering for
+indirect calls into SIMT-bearing functions, this test will start passing
+without any test-side change — that is the regression-detector value.
+
+[mgather-doc]: ../mgather/MGATHER.md
+
+## What it tests
+
+A single ELEM2D case (`float, 8 × 32 → 256-slot table, random idx`),
+identical in shape, data, and golden to the corresponding case in
+`tests/npu/a5/src/st/testcase/mscatter`:
+
+```
+MSCATTERTest.case_elem2d_float_8x32_random_256size  →  PASS (~5s)
+MSCATTERIndirectCallReproTest
+  .case_indirect_call_elem2d_float_8x32_random_256size  →  hang
+```
+
+The only difference between the two is the **call form** that reaches
+the MSCATTER body:
+
+```cpp
+// In the original mscatter test (PASS):
+extern "C" __global__ AICORE void runMSCATTER_NAME(...) {
+    runElem2D<...>(out, src, indices);          // bisheng → HiIPUISD::CALL
+}
+
+// In this repro (hang):
+extern "C" __global__ AICORE void runMSCATTER_indirect_call_NAME(...) {
+    using FnT = void (*)(__gm__ float *, __gm__ float *, __gm__ int32_t *);
+    volatile FnT fn = &simt_body_NAME;          // volatile → must roundtrip through memory
+    fn(out, src, indices);                        // bisheng → HiIPUISD::LongCALL (BLR)
+}
+```
+
+Both kernels:
+
+- Are launched by host via standard `<<<1, nullptr, stream>>>`
+  (`rtKernelLaunchWithHandleV2`).
+- Carry identical `.ascend.meta.<func>` TLV records (firmware installs
+  the same SIMT context at kernel entry).
+- Reach the same `MSCATTER<...>(outGlobal, srcTile, idxTile)` with the
+  same operands.
+- Use the same input data and golden.
+
+Empirically, byte-level diff of bisheng's `.aicore_binary` for the two
+kernels shows that the short-branch `HiIPUISD::CALL` lowering emits a
+pair of `0x1c..` LD-class instructions immediately before the BL that
+the `HiIPUISD::LongCALL` lowering does not emit. Those two extra
+instructions appear to install state the SIMT scheduler needs before
+the first `cce::async_invoke` inside MSCATTER; the long-form lowering
+skips them because the call target is not statically resolvable.
+
+## How to build and run
+
+```bash
+# Build the opt-in case
+bash build.sh --build --npu --a5 -- -DTEST_CASE=mscatter_indirect_call_repro
+
+# Generate data and run
+cd build_out/.../tests/npu/a5/src/st/testcase/mscatter_indirect_call_repro
+python3 ../testcase/mscatter_indirect_call_repro/gen_data.py
+./bin/mscatter_indirect_call_repro
+# → expected: hang on aclrtSynchronizeStream (kill after ~200s)
+```
+
+## When does this start passing
+
+Any of the following would let this test go green:
+
+1. bisheng emits SIMT-aware setup on `HiIPUISD::LongCALL` lowering paths
+   too (currently only the short-branch lowering emits it).
+2. bisheng exposes a user-callable builtin (e.g.
+   `__builtin_cce_simt_call_prelude(target_pc)`) so dispatcher code can
+   manually install the setup before each indirect call.
+3. Firmware gains a SIMT scheduler restore path triggerable from
+   AICore-side intrinsics, so the runtime cost moves out of bisheng.
+
+## Related
+
+- Upstream description of the limitation:
+  [`tests/npu/a5/src/st/testcase/mgather/MGATHER.md`][mgather-doc]
+  §"Runtime Dispatch Requirement" (lines 377–403).
+- Downstream blocker (uses this exact pattern):
+  [hw-native-sys/simpler#970][simpler-970].
+
+[simpler-970]: https://github.com/hw-native-sys/simpler/issues/970

--- a/tests/npu/a5/src/st/testcase/mscatter_indirect_call_repro/gen_data.py
+++ b/tests/npu/a5/src/st/testcase/mscatter_indirect_call_repro/gen_data.py
@@ -1,0 +1,85 @@
+#!/usr/bin/python3
+# coding=utf-8
+# --------------------------------------------------------------------------------
+# Copyright (c) 2026 Huawei Technologies Co., Ltd.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# --------------------------------------------------------------------------------
+"""
+Generates the single test case for the indirect-call SIMT repro.
+
+Mirrors `case_elem2d(np.float32, 8, 32, 256)` from
+tests/npu/a5/src/st/testcase/mscatter/gen_data.py — identical input layout
+and identical golden (SIMT semantics are unchanged; only the call form
+that reaches MSCATTER differs).
+"""
+
+import os
+import numpy as np
+
+np.random.seed(42)
+
+
+def make_src(dtype, count, start=1):
+    if np.issubdtype(dtype, np.integer):
+        info = np.iinfo(dtype)
+        mod = min(info.max - info.min + 1, 251)
+    else:
+        mod = 251
+    arr = (np.arange(start, start + count) % mod) + 1
+    return arr.astype(dtype)
+
+
+def make_idx_random(rng, shape, low, high):
+    return rng.integers(low, high, size=shape).astype(np.int32)
+
+
+def case_elem2d(name, dtype, rows, cols, table_size):
+    src = make_src(dtype, rows * cols)
+    src = src.reshape(rows, cols)
+
+    rng = np.random.default_rng(42)
+    idx = make_idx_random(rng, (rows, cols), 0, table_size)
+
+    table = np.zeros(table_size, dtype=dtype)
+    for r in range(rows):
+        for c in range(cols):
+            table[int(idx[r, c])] = src[r, c]
+
+    return src.flatten(), idx.flatten(), table
+
+
+def write_case(name, src, idx, golden):
+    if not os.path.exists(name):
+        os.makedirs(name)
+    cwd = os.getcwd()
+    os.chdir(name)
+    src.tofile("src.bin")
+    idx.tofile("indices.bin")
+    golden.tofile("golden.bin")
+    os.chdir(cwd)
+    print(f"Generated {name}")
+
+
+CASES = []
+
+
+def add(name, gen):
+    CASES.append((name, gen))
+
+
+add(
+    "MSCATTERIndirectCallReproTest.case_indirect_call_elem2d_float_8x32_random_256size",
+    lambda n: case_elem2d(n, np.float32, 8, 32, 256),
+)
+
+
+if __name__ == "__main__":
+    for name, gen in CASES:
+        src, idx, golden = gen(name)
+        write_case(name, src, idx, golden)
+    print("All MSCATTER indirect-call repro test data generated successfully")

--- a/tests/npu/a5/src/st/testcase/mscatter_indirect_call_repro/main.cpp
+++ b/tests/npu/a5/src/st/testcase/mscatter_indirect_call_repro/main.cpp
@@ -1,0 +1,113 @@
+/**
+Copyright (c) 2026 Huawei Technologies Co., Ltd.
+This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+CANN Open Software License Agreement Version 2.0 (the "License").
+Please refer to the License for details. You may not use this file except in compliance with the License.
+THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+See LICENSE in the root of the software repository for the full text of the License.
+*/
+
+#include "test_common.h"
+#include <gtest/gtest.h>
+#include <functional>
+#include "acl/acl.h"
+#include "mscatter_indirect_call_repro_common.h"
+
+using namespace std;
+using namespace PtoTestCommon;
+
+class MSCATTERIndirectCallReproTest : public testing::Test {
+protected:
+    void SetUp() override {}
+    void TearDown() override {}
+};
+
+static std::string GetGoldenDir()
+{
+    const testing::TestInfo *testInfo = testing::UnitTest::GetInstance()->current_test_info();
+    return std::string("../") + testInfo->test_suite_name() + "." + testInfo->name();
+}
+
+template <typename T, typename TIdx, typename Launcher>
+void run_mscatter_repro_test(size_t srcCount, size_t idxCount, size_t outCount, Launcher launcher)
+{
+    size_t srcByteSize = srcCount * sizeof(T);
+    size_t idxByteSize = idxCount * sizeof(TIdx);
+    size_t outByteSize = outCount * sizeof(T);
+
+    aclInit(nullptr);
+    aclrtSetDevice(0);
+    aclrtStream stream;
+    aclrtCreateStream(&stream);
+
+    T *srcHost, *outHost;
+    TIdx *idxHost;
+    T *srcDevice, *outDevice;
+    TIdx *idxDevice;
+
+    aclrtMallocHost((void **)(&srcHost), srcByteSize);
+    aclrtMallocHost((void **)(&idxHost), idxByteSize);
+    aclrtMallocHost((void **)(&outHost), outByteSize);
+
+    aclrtMalloc((void **)&srcDevice, srcByteSize, ACL_MEM_MALLOC_HUGE_FIRST);
+    aclrtMalloc((void **)&idxDevice, idxByteSize, ACL_MEM_MALLOC_HUGE_FIRST);
+    aclrtMalloc((void **)&outDevice, outByteSize, ACL_MEM_MALLOC_HUGE_FIRST);
+
+    ReadFile(GetGoldenDir() + "/src.bin", srcByteSize, srcHost, srcByteSize);
+    ReadFile(GetGoldenDir() + "/indices.bin", idxByteSize, idxHost, idxByteSize);
+
+    aclrtMemcpy(srcDevice, srcByteSize, srcHost, srcByteSize, ACL_MEMCPY_HOST_TO_DEVICE);
+    aclrtMemcpy(idxDevice, idxByteSize, idxHost, idxByteSize, ACL_MEMCPY_HOST_TO_DEVICE);
+
+    aclrtMemset(outDevice, outByteSize, 0, outByteSize);
+
+    launcher(outDevice, srcDevice, idxDevice, stream);
+
+    aclrtSynchronizeStream(stream);   // EXPECTED to hang on current toolchain; see kernel.cpp header.
+    aclrtMemcpy(outHost, outByteSize, outDevice, outByteSize, ACL_MEMCPY_DEVICE_TO_HOST);
+
+    WriteFile(GetGoldenDir() + "/output.bin", outHost, outByteSize);
+
+    aclrtFree(srcDevice);
+    aclrtFree(idxDevice);
+    aclrtFree(outDevice);
+
+    aclrtFreeHost(srcHost);
+    aclrtFreeHost(idxHost);
+    aclrtFreeHost(outHost);
+    aclrtDestroyStream(stream);
+    aclrtResetDevice(0);
+    aclFinalize();
+
+    std::vector<T> golden(outCount);
+    std::vector<T> devFinal(outCount);
+    ReadFile(GetGoldenDir() + "/golden.bin", outByteSize, golden.data(), outByteSize);
+    ReadFile(GetGoldenDir() + "/output.bin", outByteSize, devFinal.data(), outByteSize);
+
+    bool ret = ResultCmp<T>(golden, devFinal, 0.0f);
+    EXPECT_TRUE(ret);
+}
+
+#define DECLARE_LAUNCH(NAME, THOST, TIDX) \
+    void Launch_##NAME(THOST *out, THOST *src, TIDX *indices, void *stream);
+
+DECLARE_LAUNCH(indirect_call_elem2d_float_8x32_random_256size, float, int32_t)
+
+// Mirrors MSCATTERTest.case_elem2d_float_8x32_random_256size from
+// tests/.../mscatter/main.cpp, but routed through a kernel that interposes one
+// volatile fn-pointer indirect call (BLR) before the MSCATTER body.
+//
+// Reference direct-call test: PASSes in ~5 seconds.
+// This indirect-call variant: chip hangs (no SIMT scheduler staged for BLR
+// target). When the toolchain learns to emit SIMT-aware indirect call
+// lowering, this test will start passing without code change.
+TEST_F(MSCATTERIndirectCallReproTest, case_indirect_call_elem2d_float_8x32_random_256size)
+{
+    constexpr size_t kSrcCount = 8 * 32;     // 256
+    constexpr size_t kIdxCount = 8 * 32;     // 256
+    constexpr size_t kOutCount = 256;
+    run_mscatter_repro_test<float, int32_t>(
+        kSrcCount, kIdxCount, kOutCount,
+        Launch_indirect_call_elem2d_float_8x32_random_256size);
+}

--- a/tests/npu/a5/src/st/testcase/mscatter_indirect_call_repro/mscatter_indirect_call_repro_common.h
+++ b/tests/npu/a5/src/st/testcase/mscatter_indirect_call_repro/mscatter_indirect_call_repro_common.h
@@ -1,0 +1,38 @@
+/**
+Copyright (c) 2026 Huawei Technologies Co., Ltd.
+This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+CANN Open Software License Agreement Version 2.0 (the "License").
+Please refer to the License for details. You may not use this file except in compliance with the License.
+THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+See LICENSE in the root of the software repository for the full text of the License.
+*/
+
+#ifndef MSCATTER_INDIRECT_CALL_REPRO_COMMON_H
+#define MSCATTER_INDIRECT_CALL_REPRO_COMMON_H
+
+#include <cstdint>
+
+enum class ScatterAtomicOp : uint8_t
+{
+    None = 0,
+    Add = 1,
+    Max = 2,
+    Min = 3
+};
+
+enum class ScatterOOB : uint8_t
+{
+    Undefined = 0,
+    Skip = 1,
+    Clamp = 2,
+    Wrap = 3
+};
+
+enum class ScatterConflict : uint8_t
+{
+    Last = 0,
+    Default = 1
+};
+
+#endif // MSCATTER_INDIRECT_CALL_REPRO_COMMON_H

--- a/tests/npu/a5/src/st/testcase/mscatter_indirect_call_repro/mscatter_indirect_call_repro_kernel.cpp
+++ b/tests/npu/a5/src/st/testcase/mscatter_indirect_call_repro/mscatter_indirect_call_repro_kernel.cpp
@@ -1,0 +1,146 @@
+/**
+Copyright (c) 2026 Huawei Technologies Co., Ltd.
+This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+CANN Open Software License Agreement Version 2.0 (the "License").
+Please refer to the License for details. You may not use this file except in compliance with the License.
+THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+See LICENSE in the root of the software repository for the full text of the License.
+*/
+
+// ============================================================================
+// Standalone regression / repro for the runtime-dispatch limitation documented
+// in tests/npu/a5/src/st/testcase/mgather/MGATHER.md
+// §"Runtime Dispatch Requirement".
+//
+// THIS TEST IS EXPECTED TO HANG OR PRODUCE INCORRECT RESULTS until the
+// toolchain / firmware gains support for SIMT-aware lowering of indirect
+// calls into SIMT-bearing functions. When that lands, this test should
+// start passing without any test-side change — it serves as a regression
+// detector for the fix.
+//
+// What it demonstrates
+// --------------------
+// Standard rtKernelLaunch launch path (host `<<<1, nullptr, stream>>>`,
+// identical to every other ST in this suite) — kernel entry is
+// `runMSCATTER_indirect_call_elem2d_float_8x32_random_256size`. Inside,
+// the SIMT body (one MSCATTER) is reached through ONE volatile fn-pointer
+// indirect call instead of a direct call:
+//
+//     volatile FnT fn = &simt_body;   // bisheng forced to emit HiIPUISD::LongCALL
+//     fn(out, src, indices);          // BLR — SIMT body runs after this
+//
+// Direct call (without the `volatile`) → MSCATTER PASSes, identical to the
+// MSCATTERTest case_elem2d_float_8x32_random_256size in
+// tests/npu/a5/src/st/testcase/mscatter/.
+//
+// Indirect call (the variant in this file) → chip hang. Confirmed on
+// dav-c310-vec (a5) with CANN 9.1.T500 / bisheng 15.0.5 / driver
+// 25.6.rc1.b108 — task-submit times out at 200s, no errcode raised.
+//
+// Why this is a meaningful regression test
+// ----------------------------------------
+// The standard CANN launch path installs TID / warp / vec-pipe scheduling
+// state correctly. The first `cce::async_invoke` inside MSCATTER is then
+// dispatched correctly. With an intervening BLR (HiIPUISD::LongCALL),
+// bisheng skips the SIMT-aware pre-call setup it emits for short BL —
+// the SIMT scheduler is not staged for the post-BLR target, and the
+// first `async_invoke` finds no warp scheduler to dispatch into.
+//
+// All custom AICore dispatchers that dispatch user kernels via runtime
+// function pointer (e.g. ringbuffer-based SU dispatchers like
+// hw-native-sys/simpler#970) hit the same issue.
+// ============================================================================
+
+#include <pto/pto-inst.hpp>
+#include <pto/common/constants.hpp>
+#include <pto/npu/a5/MScatter.hpp>
+#include "acl/acl.h"
+#include "mscatter_indirect_call_repro_common.h"
+
+using namespace std;
+using namespace pto;
+
+__global__ AICORE __attribute__((aiv)) void mscatter_indirect_warmup_kernel()
+{}
+
+AICORE PTO_INLINE void FlushScatterOutput()
+{
+    dcci(static_cast<__gm__ void *>(0), ENTIRE_DATA_CACHE);
+    dsb(DSB_DDR);
+}
+
+// ----------------------------------------------------------------------------
+// SIMT body — same as runElem2D in tests/.../mscatter/mscatter_kernel.cpp,
+// instantiated for the 8x32 → 256-slot float case.
+// noinline so the call boundary survives -O3.
+// ----------------------------------------------------------------------------
+AICORE __attribute__((noinline)) void simt_body_elem2d_float_8x32_random_256size(
+    __gm__ float __out__ *out, __gm__ float __in__ *src, __gm__ int32_t __in__ *indices)
+{
+    constexpr int kSrcRows = 8;
+    constexpr int kSrcCols = 32;
+    constexpr int kTableSize = 256;
+    using SrcShape  = pto::Shape <1, 1, 1, kSrcRows, kSrcCols>;
+    using SrcStride = pto::Stride<1, 1, 1, kSrcCols, 1>;
+    using IdxShape  = pto::Shape <1, 1, 1, kSrcRows, kSrcCols>;
+    using IdxStride = pto::Stride<1, 1, 1, kSrcCols, 1>;
+    using OutShape  = pto::Shape <1, 1, 1, 1, kTableSize>;
+    using OutStride = pto::Stride<1, 1, 1, kTableSize, 1>;
+
+    GlobalTensor<float,   SrcShape, SrcStride> srcGlobal(src);
+    GlobalTensor<int32_t, IdxShape, IdxStride> idxGlobal(indices);
+    GlobalTensor<float,   OutShape, OutStride> outGlobal(out);
+
+    using SrcTile = Tile<TileType::Vec, float,   kSrcRows, kSrcCols,
+                         BLayout::RowMajor, kSrcRows, kSrcCols>;
+    using IdxTile = Tile<TileType::Vec, int32_t, kSrcRows, kSrcCols,
+                         BLayout::RowMajor, kSrcRows, kSrcCols>;
+
+    SrcTile srcTile;
+    IdxTile idxTile;
+
+    constexpr int idxBytes = ((kSrcRows * kSrcCols * (int)sizeof(int32_t) + 31) / 32) * 32;
+    TASSIGN(idxTile, 0x0);
+    TASSIGN(srcTile, idxBytes);
+
+    TLOAD(idxTile, idxGlobal);
+    TLOAD(srcTile, srcGlobal);
+
+    set_flag (PIPE_MTE2, PIPE_V, EVENT_ID0);
+    wait_flag(PIPE_MTE2, PIPE_V, EVENT_ID0);
+
+    // ↓ The SIMT instruction — fails when reached via BLR.
+    MSCATTER<pto::Coalesce::Elem,
+             pto::ScatterAtomicOp::None,
+             pto::ScatterOOB::Undefined,
+             pto::ScatterConflict::Last>(outGlobal, srcTile, idxTile);
+
+    pipe_barrier(PIPE_ALL);
+    set_flag (PIPE_V, PIPE_MTE3, EVENT_ID0);
+    wait_flag(PIPE_V, PIPE_MTE3, EVENT_ID0);
+    FlushScatterOutput();
+}
+
+// ----------------------------------------------------------------------------
+// Kernel entry — launched by host via <<<1, nullptr, stream>>>.
+// `volatile FnT fn = &simt_body;` forces bisheng to lower the call as
+// HiIPUISD::LongCALL (4-word indirect call, target via linker reloc).
+// Same SIMT body code, same data, same launch path — only the call form
+// changes vs the corresponding case in tests/.../mscatter/mscatter_kernel.cpp.
+// ----------------------------------------------------------------------------
+extern "C" __global__ AICORE void runMSCATTER_indirect_call_elem2d_float_8x32_random_256size(
+    __gm__ float *out, __gm__ float *src, __gm__ int32_t *indices)
+{
+    using FnT = void (*)(__gm__ float *, __gm__ float *, __gm__ int32_t *);
+    volatile FnT fn = &simt_body_elem2d_float_8x32_random_256size;
+    fn(out, src, indices);   // <-- BLR; SIMT scheduler unprepared on this path
+}
+
+void Launch_indirect_call_elem2d_float_8x32_random_256size(
+    float *out, float *src, int32_t *indices, void *stream)
+{
+    mscatter_indirect_warmup_kernel<<<64, nullptr, stream>>>();
+    runMSCATTER_indirect_call_elem2d_float_8x32_random_256size<<<1, nullptr, stream>>>(
+        reinterpret_cast<float *>(out), reinterpret_cast<float *>(src), indices);
+}


### PR DESCRIPTION
## Summary

Adds an opt-in standalone reproducer for the runtime-dispatch limitation already described in [`tests/npu/a5/src/st/testcase/mgather/MGATHER.md`](tests/npu/a5/src/st/testcase/mgather/MGATHER.md) §"Runtime Dispatch Requirement".

The new testcase `mscatter_indirect_call_repro` is a near-clone of the existing `MSCATTERTest.case_elem2d_float_8x32_random_256size`:
- Same data, same golden, same `<<<1, nullptr, stream>>>` launch path
- Same `MSCATTER<...>(outGlobal, srcTile, idxTile)` body
- **Only difference**: one `volatile FnT fn = &target; fn(...)` interposed between the kernel entry and the SIMT body, which forces bisheng to emit `HiIPUISD::LongCALL` (4-word indirect form, target via linker reloc) instead of short-branch `HiIPUISD::CALL`

## Observed behavior

On `dav-c310-vec` with CANN 9.1.T500 / bisheng 15.0.5 / driver 25.6.rc1.b108:

| Test | Body reaches MSCATTER via | Result |
|---|---|---|
| `MSCATTERTest.case_elem2d_float_8x32_random_256size` (existing baseline) | direct call (`HiIPUISD::CALL`) | ✅ PASS ~5s |
| `MSCATTERIndirectCallReproTest.case_indirect_call_elem2d_float_8x32_random_256size` (this PR) | indirect call (`HiIPUISD::LongCALL`) | ❌ chip hang 220s (just verified on real a5) |

Same kernel source, same data, same launch ABI. Confirms the limitation is **specifically about indirect-call lowering on the SIMT path**, independent of the dispatcher / launch path.

## Why opt-in

Registered under `OPT_IN_TESTCASES` in `tests/npu/a5/src/st/testcase/CMakeLists.txt` — built only when `TEST_CASE=mscatter_indirect_call_repro` is explicitly supplied. CI default-build path is not affected.

Build & run:
\`\`\`bash
bash build.sh --build --npu --a5 -- -DTEST_CASE=mscatter_indirect_call_repro
# Then in the test's build dir: python3 gen_data.py && ./bin/mscatter_indirect_call_repro
# → expected hang on aclrtSynchronizeStream
\`\`\`

## Value

- **Standalone case** that any team member (bisheng, firmware, CANN runtime, downstream consumers like simpler/pypto) can clone-build-run to reproduce, without any external dispatcher context.
- **Regression detector**: when SIMT-aware lowering is added on the `LongCALL` path (or an equivalent user-callable builtin is exposed), this test starts passing automatically.

## Files

\`\`\`
tests/npu/a5/src/st/testcase/
  CMakeLists.txt                            (modified — registers as OPT_IN)
  mscatter_indirect_call_repro/
    CMakeLists.txt                          (one-line: pto_vec_st)
    README.md                               (explains setup + why it hangs)
    main.cpp                                (host launcher, 1 gtest case)
    mscatter_indirect_call_repro_kernel.cpp (kernel — direct-vs-indirect diff is one line)
    mscatter_indirect_call_repro_common.h   (shared enums, copied from mscatter_common.h)
    gen_data.py                             (generates the single case's bin files)
\`\`\`

## Test plan

- [x] Built locally with bisheng 15.0.5 + cmake 4.3.2 + \`--cce-aicore-arch=dav-c310-vec\` — compiles clean, no warnings beyond existing pto-isa baseline.
- [x] Ran on real a5 hardware via task-submit (lock device 2). Test entered \`[ RUN ]\`, then 220s timeout on \`aclrtSynchronizeStream\` — exact expected behavior.
- [ ] Run on a5 simulator (\`RUN_MODE=sim\`) — not blocking; sim doesn't model the SIMT scheduler init the same way.

## Related

- Upstream description of the limitation: [\`tests/npu/a5/src/st/testcase/mgather/MGATHER.md\`](tests/npu/a5/src/st/testcase/mgather/MGATHER.md) §"Runtime Dispatch Requirement" (line 377-403, already documents the problem)
- Downstream blocker that hits the exact same code path: [hw-native-sys/simpler#970](https://github.com/hw-native-sys/simpler/issues/970) — see the comment thread for full empirical analysis (byte-level disasm comparison, bisheng \`__builtin_cce_*\` exhaustive scan, SDAG node analysis).

🤖 Generated with [Claude Code](https://claude.com/claude-code)