### PR TITLE
fix(cpu): Align no-split C2V FIFO protocol in CPU sim

### DIFF
--- a/include/pto/cpu/TPop.hpp
+++ b/include/pto/cpu/TPop.hpp
@@ -18,7 +18,8 @@ namespace pto {
 template <typename Pipe, typename TileCons, TileSplitAxis Split, std::enable_if_t<!is_global_data_v<TileCons>, int> = 0>
 PTO_INTERNAL void TPOP_IMPL(Pipe &pipe, TileCons &tile)
 {
-    if (cpu_pipe::IsInactiveNoSplitVecLane<TileCons, Split>()) {
+    constexpr bool participateNoSplitC2V = cpu_pipe::ShouldNoSplitC2VConsumerLaneParticipate<Pipe, TileCons, Split>();
+    if (!participateNoSplitC2V && cpu_pipe::IsInactiveNoSplitVecLane<TileCons, Split>()) {
         cpu_pipe::EnsureTileStorage(tile);
         cpu_pipe::FillTile(tile, typename TileCons::DType{});
         return;
@@ -30,6 +31,11 @@ PTO_INTERNAL void TPOP_IMPL(Pipe &pipe, TileCons &tile)
 
     // 2. Address calculation + TASSIGN + data transfer
     pipe.cons.template pop<TileCons, Split>(pipe.fifo, tile);
+    if constexpr (participateNoSplitC2V) {
+        if (get_subblockid() != 0) {
+            cpu_pipe::FillTile(tile, typename TileCons::DType{});
+        }
+    }
 }
 
 template <
@@ -58,7 +64,8 @@ PTO_INTERNAL void TPOP_GLOBAL_IMPL(Pipe &pipe, GlobalData &gmTensor)
 template <typename Pipe, TileSplitAxis Split>
 PTO_INTERNAL void TFREE_IMPL(Pipe &pipe)
 {
-    if (cpu_pipe::IsInactiveNoSplitVecConsumerLane<Pipe, Split>()) {
+    if (!cpu_pipe::ShouldNoSplitC2VConsumerLaneFree<Pipe, Split>() &&
+        cpu_pipe::IsInactiveNoSplitVecConsumerLane<Pipe, Split>()) {
         return;
     }
     if (pipe.cons.getFreeStatus()) {
@@ -76,7 +83,8 @@ template <typename Pipe, typename GlobalData, TileSplitAxis Split,
           std::enable_if_t<is_global_data_v<GlobalData>, int> = 0>
 PTO_INTERNAL void TFREE_GLOBAL_IMPL(Pipe &pipe, GlobalData &)
 {
-    if (cpu_pipe::IsInactiveNoSplitVecConsumerLane<Pipe, Split>()) {
+    if (!cpu_pipe::ShouldNoSplitC2VConsumerLaneFree<Pipe, Split>() &&
+        cpu_pipe::IsInactiveNoSplitVecConsumerLane<Pipe, Split>()) {
         return;
     }
     if (pipe.cons.getFreeStatus()) {

--- a/include/pto/cpu/TPush.hpp
+++ b/include/pto/cpu/TPush.hpp
@@ -202,6 +202,76 @@ PTO_INTERNAL bool IsInactiveNoSplitVecConsumerLane()
     return get_subblockid() != 0;
 }
 
+template <typename Pipe, typename TileCons, TileSplitAxis Split>
+PTO_INTERNAL constexpr bool ShouldNoSplitC2VConsumerLaneParticipate()
+{
+    return Split == TileSplitAxis::TILE_NO_SPLIT && Pipe::is_c2v && Pipe::is_no_split && IsC2VConsumerTile<TileCons>();
+}
+
+template <typename Pipe, TileSplitAxis Split>
+PTO_INTERNAL constexpr bool ShouldNoSplitC2VConsumerLaneFree()
+{
+    return Split == TileSplitAxis::TILE_NO_SPLIT && Pipe::is_c2v && Pipe::is_no_split;
+}
+
+template <typename Pipe, typename TileProd, TileSplitAxis Split>
+PTO_INTERNAL constexpr uint32_t GetRequiredConsumerCount()
+{
+    if constexpr (Pipe::is_c2v && Pipe::is_no_split && IsC2VProducerTile<TileProd>() &&
+                  Split == TileSplitAxis::TILE_NO_SPLIT) {
+        return 2u;
+    } else if constexpr (Pipe::is_c2v && IsC2VProducerTile<TileProd>()) {
+        return GetSplitCount<Split>();
+    } else {
+        return 1u;
+    }
+}
+
+template <std::size_t SlotNum, typename RejectSlotFn>
+PTO_INTERNAL bool FindNextTransferSlot(const std::array<TransferDir, SlotNum> &transferDirs, int start,
+                                       TransferDir expectedDir, int &slotIndex, RejectSlotFn rejectSlot)
+{
+    for (std::size_t offset = 0; offset < SlotNum; ++offset) {
+        const int candidate = static_cast<int>((static_cast<std::size_t>(start) + offset) % SlotNum);
+        if (transferDirs[static_cast<std::size_t>(candidate)] == expectedDir && !rejectSlot(candidate)) {
+            slotIndex = candidate;
+            return true;
+        }
+    }
+    return false;
+}
+
+template <std::size_t SlotNum>
+PTO_INTERNAL bool FindNextTransferSlot(const std::array<TransferDir, SlotNum> &transferDirs, int start,
+                                       TransferDir expectedDir, int &slotIndex)
+{
+    return FindNextTransferSlot(transferDirs, start, expectedDir, slotIndex, [](int) { return false; });
+}
+
+template <std::size_t SlotNum>
+PTO_INTERNAL void PushPendingSlot(std::array<int, SlotNum> &slots, int &count, int slotIndex)
+{
+    if (count < 0 || static_cast<std::size_t>(count) >= SlotNum) {
+        return;
+    }
+    slots[static_cast<std::size_t>(count)] = slotIndex;
+    ++count;
+}
+
+template <std::size_t SlotNum>
+PTO_INTERNAL bool PopPendingSlot(std::array<int, SlotNum> &slots, int &count, int &slotIndex)
+{
+    if (count <= 0 || static_cast<std::size_t>(count) > SlotNum) {
+        return false;
+    }
+    slotIndex = slots[0];
+    for (int i = 1; i < count; ++i) {
+        slots[static_cast<std::size_t>(i - 1)] = slots[static_cast<std::size_t>(i)];
+    }
+    --count;
+    return true;
+}
+
 template <typename TileData>
 PTO_INTERNAL void FillTile(TileData &tile, typename TileData::DType value)
 {
@@ -252,6 +322,16 @@ PTO_INTERNAL void InsertTileWindowToLinear(T *dst, uint32_t dstCols, SrcTileData
     for (int r = 0; r < src.GetValidRow(); ++r) {
         for (int c = 0; c < src.GetValidCol(); ++c) {
             dst[(r + rowOffset) * dstCols + (c + colOffset)] = src.data()[GetTileElementOffset<SrcTileData>(r, c)];
+        }
+    }
+}
+
+template <typename T, typename SrcTileData>
+PTO_INTERNAL void StoreValidTileToLinear(T *dst, uint32_t dstCols, SrcTileData &src)
+{
+    for (int r = 0; r < src.GetValidRow(); ++r) {
+        for (int c = 0; c < src.GetValidCol(); ++c) {
+            dst[r * dstCols + c] = src.data()[GetTileElementOffset<SrcTileData>(r, c)];
         }
     }
 }
@@ -331,6 +411,7 @@ struct TPipe {
     static constexpr bool is_c2v = ((DIR_TYPE & Direction::DIR_C2V) == Direction::DIR_C2V);
     static constexpr bool is_v2c = ((DIR_TYPE & Direction::DIR_V2C) == Direction::DIR_V2C);
     static constexpr bool is_v2c_ctrl = ((DIR_TYPE & Direction::DIR_V2C_CTRL) == Direction::DIR_V2C_CTRL);
+    static constexpr bool is_no_split = IsNoSplit;
     static constexpr uint8_t VEC_CORE_ID_OFFSET = 16;
     using RingFiFo = RingFIFO<SlotSize, SlotNum, LocalSlotNum>;
     static constexpr uint32_t LOCAL_SPLIT_COPIES = is_c2v ? 2u : 1u;
@@ -341,7 +422,12 @@ struct TPipe {
         std::condition_variable cv;
         int next_producer_slot = 0;
         int next_consumer_slot = 0;
+        std::array<int, 2> next_consumer_slots_by_lane{};
         int occupied = 0;
+        int popped_not_freed = 0;
+        std::array<int, 2> popped_not_freed_by_lane{};
+        std::array<std::array<int, SlotNum>, 2> popped_slots_by_lane{};
+        std::array<int, SlotNum> popped_slots{};
         std::array<std::array<uint8_t, LOCAL_SLOT_STORAGE_SIZE>, SlotNum> local_slot_storage{};
         std::array<cpu_pipe::TransferDir, SlotNum> transfer_dirs{};
         std::array<uint32_t, SlotNum> remaining_consumers{};
@@ -409,7 +495,14 @@ struct TPipe {
         std::lock_guard<std::mutex> lock(shared_state.mutex);
         shared_state.next_producer_slot = 0;
         shared_state.next_consumer_slot = 0;
+        shared_state.next_consumer_slots_by_lane.fill(0);
         shared_state.occupied = 0;
+        shared_state.popped_not_freed = 0;
+        shared_state.popped_not_freed_by_lane.fill(0);
+        for (auto &lanePoppedSlots : shared_state.popped_slots_by_lane) {
+            lanePoppedSlots.fill(0);
+        }
+        shared_state.popped_slots.fill(0);
         for (auto &slot : shared_state.local_slot_storage) {
             slot.fill(0);
         }
@@ -507,12 +600,8 @@ struct TPipe {
                 std::lock_guard<std::mutex> lock(shared_state.mutex);
                 const auto slotIdx = static_cast<std::size_t>(tileIndex % RingFiFo::SLOT_NUM);
                 shared_state.transfer_dirs[slotIdx] = cpu_pipe::GetProducerTransferDir<TPipe, TileProd>();
-                if constexpr (TPipe::is_c2v && cpu_pipe::IsC2VProducerTile<TileProd>() &&
-                              Split != TileSplitAxis::TILE_NO_SPLIT) {
-                    shared_state.remaining_consumers[slotIdx] = cpu_pipe::GetSplitCount<Split>();
-                } else {
-                    shared_state.remaining_consumers[slotIdx] = 1;
-                }
+                shared_state.remaining_consumers[slotIdx] =
+                    cpu_pipe::GetRequiredConsumerCount<TPipe, TileProd, Split>();
                 if constexpr (TPipe::is_v2c && cpu_pipe::IsV2CProducerTile<TileProd>() &&
                               Split != TileSplitAxis::TILE_NO_SPLIT) {
                     const uint32_t laneMask = cpu_pipe::GetSplitLaneMask<Split>(static_cast<uint32_t>(subTileIndex));
@@ -603,6 +692,48 @@ struct TPipe {
                 subTileIndex = static_cast<int>(laneId);
                 return;
             }
+            if constexpr (Split == TileSplitAxis::TILE_NO_SPLIT) {
+                if constexpr (cpu_pipe::ShouldNoSplitC2VConsumerLaneParticipate<TPipe, TileCons, Split>()) {
+                    const uint32_t laneId = cpu_pipe::GetSplitLaneId<TileSplitAxis::TILE_UP_DOWN>();
+                    const uint32_t laneMask = cpu_pipe::GetSplitLaneMask<TileSplitAxis::TILE_UP_DOWN>(laneId);
+                    auto &laneNext = shared_state.next_consumer_slots_by_lane[laneId];
+                    auto &lanePopped = shared_state.popped_not_freed_by_lane[laneId];
+                    int foundSlot = 0;
+                    shared_state.cv.wait(lock, [&shared_state, &laneNext, laneMask, expectedDir, &foundSlot]() {
+                        return cpu_pipe::FindNextTransferSlot(
+                            shared_state.transfer_dirs, laneNext, expectedDir, foundSlot,
+                            [&shared_state, laneMask](int candidate) {
+                                return (shared_state.consumers_claimed[static_cast<std::size_t>(candidate)] &
+                                        laneMask) != 0;
+                            });
+                    });
+                    tileIndex = foundSlot;
+                    shared_state.consumers_claimed[static_cast<std::size_t>(tileIndex % RingFiFo::SLOT_NUM)] |=
+                        laneMask;
+                    subTileIndex = static_cast<int>(laneId);
+                    laneNext = (tileIndex + 1) % RingFiFo::SLOT_NUM;
+                    cpu_pipe::PushPendingSlot(shared_state.popped_slots_by_lane[laneId], lanePopped, tileIndex);
+                    return;
+                }
+                int foundSlot = 0;
+                shared_state.cv.wait(lock, [&shared_state, expectedDir, &foundSlot]() {
+                    return cpu_pipe::FindNextTransferSlot(
+                        shared_state.transfer_dirs, shared_state.next_consumer_slot, expectedDir, foundSlot,
+                        [&shared_state](int candidate) {
+                            for (int i = 0; i < shared_state.popped_not_freed; ++i) {
+                                if (shared_state.popped_slots[static_cast<std::size_t>(i)] == candidate) {
+                                    return true;
+                                }
+                            }
+                            return false;
+                        });
+                });
+                tileIndex = foundSlot;
+                subTileIndex = static_cast<int>(get_subblockid());
+                shared_state.next_consumer_slot = (tileIndex + 1) % RingFiFo::SLOT_NUM;
+                cpu_pipe::PushPendingSlot(shared_state.popped_slots, shared_state.popped_not_freed, tileIndex);
+                return;
+            }
             shared_state.cv.wait(lock, [&shared_state, expectedDir]() {
                 return shared_state.occupied > 0 &&
                        shared_state.transfer_dirs[static_cast<std::size_t>(shared_state.next_consumer_slot)] ==
@@ -619,7 +750,26 @@ struct TPipe {
             auto &shared_state = TPipe::GetSharedState();
             {
                 std::lock_guard<std::mutex> lock(shared_state.mutex);
-                const auto slotIndex = static_cast<std::size_t>(tileIndex % RingFiFo::SLOT_NUM);
+                int freeTileIndex = tileIndex;
+                if constexpr (Split == TileSplitAxis::TILE_NO_SPLIT) {
+                    if constexpr (cpu_pipe::ShouldNoSplitC2VConsumerLaneFree<TPipe, Split>()) {
+                        const uint32_t laneId = cpu_pipe::GetSplitLaneId<TileSplitAxis::TILE_UP_DOWN>();
+                        auto &lanePopped = shared_state.popped_not_freed_by_lane[laneId];
+                        if (!cpu_pipe::PopPendingSlot(shared_state.popped_slots_by_lane[laneId], lanePopped,
+                                                      freeTileIndex)) {
+                            if (!cpu_pipe::PopPendingSlot(shared_state.popped_slots, shared_state.popped_not_freed,
+                                                          freeTileIndex)) {
+                                return;
+                            }
+                        }
+                    } else {
+                        if (!cpu_pipe::PopPendingSlot(shared_state.popped_slots, shared_state.popped_not_freed,
+                                                      freeTileIndex)) {
+                            return;
+                        }
+                    }
+                }
+                const auto slotIndex = static_cast<std::size_t>(freeTileIndex % RingFiFo::SLOT_NUM);
                 auto &remaining = shared_state.remaining_consumers[slotIndex];
                 if (remaining > 1) {
                     --remaining;
@@ -627,7 +777,9 @@ struct TPipe {
                     remaining = 0;
                     shared_state.consumers_claimed[slotIndex] = 0;
                     shared_state.transfer_dirs[slotIndex] = cpu_pipe::TransferDir::None;
-                    shared_state.next_consumer_slot = (tileIndex + 1) % RingFiFo::SLOT_NUM;
+                    if constexpr (Split != TileSplitAxis::TILE_NO_SPLIT) {
+                        shared_state.next_consumer_slot = (tileIndex + 1) % RingFiFo::SLOT_NUM;
+                    }
                     --shared_state.occupied;
                 }
             }
@@ -817,7 +969,11 @@ PTO_INTERNAL void TPUSH_IMPL(Pipe &pipe, TileProd &tile)
         using T = typename TileProd::DType;
         constexpr int rows = TileProd::Rows;
         constexpr int cols = TileProd::Cols;
-        if constexpr (Pipe::is_v2c && TileProd::Loc == TileType::Vec) {
+        if constexpr (Pipe::is_c2v && cpu_pipe::IsC2VProducerTile<TileProd>()) {
+            auto *addr =
+                reinterpret_cast<__gm__ T *>(reinterpret_cast<std::uintptr_t>(pipe.fifo.GM_SLOT_BUFFER) + entryBase);
+            cpu_pipe::StoreValidTileToLinear(addr, static_cast<uint32_t>(cols), tile);
+        } else if constexpr (Pipe::is_v2c && TileProd::Loc == TileType::Vec) {
             constexpr int gmStrideR = (Split == TileSplitAxis::TILE_LEFT_RIGHT) ? (cols * 2) : cols;
             std::size_t subOffset = 0;
             if constexpr (Split == TileSplitAxis::TILE_UP_DOWN) {

--- a/tests/cpu/st/testcase/tpushpop_cv_nosplit/main.cpp
+++ b/tests/cpu/st/testcase/tpushpop_cv_nosplit/main.cpp
@@ -9,9 +9,12 @@ See LICENSE in the root of the software repository for the full text of the Lice
 */
 
 #include <algorithm>
+#include <atomic>
+#include <chrono>
 #include <gtest/gtest.h>
 #include <mutex>
 #include <pto/pto-inst.hpp>
+#include <thread>
 #include <vector>
 #include "test_common.h"
 
@@ -115,12 +118,54 @@ void runCubeToVectorNoSplitWraparound()
 }
 
 template <typename T, int rows, int cols>
-void runCubeToVectorNoSplitInactiveLaneNoOp()
+void runCubeToVectorNoSplitDelayedFree()
 {
     constexpr int kFifoDepth = 2;
     using CubeTile = Tile<TileType::Mat, T, rows, cols>;
     using VecTile = Tile<TileType::Vec, T, rows, cols>;
     using Pipe = TPipe<kPipeFlagId + 2, Direction::DIR_C2V, sizeof(T) * VecTile::Numel, kFifoDepth>;
+
+    NPU_MEMORY_CLEAR();
+    Pipe::reset_for_cpu_sim();
+    Pipe pipe((__gm__ void *)nullptr, kVecConsumerBase, 0x0);
+    std::vector<std::vector<T>> actual(kFifoDepth);
+
+    cpu_sim::ScopedExecutionContext ctx(0, 0, 1);
+    for (int iter = 0; iter < kFifoDepth; ++iter) {
+        CubeTile cubeTile;
+        TASSIGN(cubeTile, 0x0);
+        fillCubeTile<T, rows, cols>(cubeTile, iter);
+        TPUSH<Pipe, CubeTile, TileSplitAxis::TILE_NO_SPLIT>(pipe, cubeTile);
+    }
+
+    for (int iter = 0; iter < kFifoDepth; ++iter) {
+        VecTile vecTile;
+        TASSIGN(vecTile, 0x4000);
+        TPOP<Pipe, VecTile, TileSplitAxis::TILE_NO_SPLIT>(pipe, vecTile);
+        actual[iter].assign(vecTile.data(), vecTile.data() + vecTile.Numel);
+    }
+    for (int iter = 0; iter < kFifoDepth; ++iter) {
+        TFREE<Pipe, TileSplitAxis::TILE_NO_SPLIT>(pipe);
+    }
+
+    for (int iter = 0; iter < kFifoDepth; ++iter) {
+        const auto expected = makeExpected<T, rows, cols>(iter);
+        EXPECT_TRUE(ResultCmp(expected, actual[iter], 0));
+    }
+
+    auto &sharedState = Pipe::GetSharedState();
+    std::lock_guard<std::mutex> lock(sharedState.mutex);
+    EXPECT_EQ(sharedState.occupied, 0);
+    EXPECT_EQ(sharedState.popped_not_freed, 0);
+}
+
+template <typename T, int rows, int cols>
+void runCubeToVectorNoSplitInactiveLaneSkipsProtocol()
+{
+    constexpr int kFifoDepth = 2;
+    using CubeTile = Tile<TileType::Mat, T, rows, cols>;
+    using VecTile = Tile<TileType::Vec, T, rows, cols>;
+    using Pipe = TPipe<kPipeFlagId + 3, Direction::DIR_C2V, sizeof(T) * VecTile::Numel, kFifoDepth>;
 
     NPU_MEMORY_CLEAR();
     Pipe::reset_for_cpu_sim();
@@ -166,6 +211,387 @@ void runCubeToVectorNoSplitInactiveLaneNoOp()
         EXPECT_EQ(sharedState.occupied, 0);
     }
 }
+
+template <typename T, int rows, int cols>
+void runCubeToVectorNoSplitDualLaneDelayedFree()
+{
+    constexpr int kFifoDepth = 2;
+    using CubeTile = Tile<TileType::Mat, T, rows, cols>;
+    using VecTile = Tile<TileType::Vec, T, rows, cols>;
+    using Pipe = TPipe<kPipeFlagId + 4, Direction::DIR_C2V, sizeof(T) * VecTile::Numel, kFifoDepth, 2, true>;
+
+    NPU_MEMORY_CLEAR();
+    Pipe::reset_for_cpu_sim();
+    Pipe pipe((__gm__ void *)nullptr, kVecConsumerBase, 0x0);
+    std::vector<std::vector<T>> lane0Actual(kFifoDepth);
+    std::vector<std::vector<T>> lane1Actual(kFifoDepth);
+
+    {
+        cpu_sim::ScopedExecutionContext producerCtx(0, 0, 1);
+        for (int iter = 0; iter < kFifoDepth; ++iter) {
+            CubeTile cubeTile;
+            TASSIGN(cubeTile, 0x0);
+            fillCubeTile<T, rows, cols>(cubeTile, iter);
+            TPUSH<Pipe, CubeTile, TileSplitAxis::TILE_NO_SPLIT>(pipe, cubeTile);
+        }
+    }
+
+    {
+        cpu_sim::ScopedExecutionContext lane0Ctx(0, 0, 2);
+        for (int iter = 0; iter < kFifoDepth; ++iter) {
+            VecTile vecTile;
+            TASSIGN(vecTile, 0x4000);
+            TPOP<Pipe, VecTile, TileSplitAxis::TILE_NO_SPLIT>(pipe, vecTile);
+            lane0Actual[iter].assign(vecTile.data(), vecTile.data() + vecTile.Numel);
+        }
+        for (int iter = 0; iter < kFifoDepth; ++iter) {
+            TFREE<Pipe, TileSplitAxis::TILE_NO_SPLIT>(pipe);
+        }
+    }
+
+    {
+        auto &sharedState = Pipe::GetSharedState();
+        std::lock_guard<std::mutex> lock(sharedState.mutex);
+        EXPECT_EQ(sharedState.occupied, kFifoDepth);
+    }
+
+    {
+        cpu_sim::ScopedExecutionContext lane1Ctx(0, 1, 2);
+        for (int iter = 0; iter < kFifoDepth; ++iter) {
+            VecTile vecTile;
+            TASSIGN(vecTile, 0x8000);
+            TPOP<Pipe, VecTile, TileSplitAxis::TILE_NO_SPLIT>(pipe, vecTile);
+            lane1Actual[iter].assign(vecTile.data(), vecTile.data() + vecTile.Numel);
+        }
+        for (int iter = 0; iter < kFifoDepth; ++iter) {
+            TFREE<Pipe, TileSplitAxis::TILE_NO_SPLIT>(pipe);
+        }
+    }
+
+    for (int iter = 0; iter < kFifoDepth; ++iter) {
+        const auto expected = makeExpected<T, rows, cols>(iter);
+        EXPECT_TRUE(ResultCmp(expected, lane0Actual[iter], 0));
+        EXPECT_TRUE(std::all_of(lane1Actual[iter].begin(), lane1Actual[iter].end(),
+                                [](T value) { return value == static_cast<T>(0); }));
+    }
+
+    auto &sharedState = Pipe::GetSharedState();
+    std::lock_guard<std::mutex> lock(sharedState.mutex);
+    EXPECT_EQ(sharedState.occupied, 0);
+    EXPECT_EQ(sharedState.popped_not_freed_by_lane[0], 0);
+    EXPECT_EQ(sharedState.popped_not_freed_by_lane[1], 0);
+}
+
+template <typename T, int rows, int cols>
+void runCubeToVectorNoSplitDualLaneFastLaneWrapWaits()
+{
+    constexpr int kFifoDepth = 2;
+    using CubeTile = Tile<TileType::Mat, T, rows, cols>;
+    using VecTile = Tile<TileType::Vec, T, rows, cols>;
+    using Pipe = TPipe<kPipeFlagId + 5, Direction::DIR_C2V, sizeof(T) * VecTile::Numel, kFifoDepth, 2, true>;
+
+    NPU_MEMORY_CLEAR();
+    Pipe::reset_for_cpu_sim();
+    Pipe pipe((__gm__ void *)nullptr, kVecConsumerBase, 0x0);
+    std::vector<std::vector<T>> lane0Actual(kFifoDepth + 1);
+    std::vector<std::vector<T>> lane1Actual(kFifoDepth);
+
+    {
+        cpu_sim::ScopedExecutionContext producerCtx(0, 0, 1);
+        for (int iter = 0; iter < kFifoDepth; ++iter) {
+            CubeTile cubeTile;
+            TASSIGN(cubeTile, 0x0);
+            fillCubeTile<T, rows, cols>(cubeTile, iter);
+            TPUSH<Pipe, CubeTile, TileSplitAxis::TILE_NO_SPLIT>(pipe, cubeTile);
+        }
+    }
+
+    {
+        cpu_sim::ScopedExecutionContext lane0Ctx(0, 0, 2);
+        for (int iter = 0; iter < kFifoDepth; ++iter) {
+            VecTile vecTile;
+            TASSIGN(vecTile, 0x4000);
+            TPOP<Pipe, VecTile, TileSplitAxis::TILE_NO_SPLIT>(pipe, vecTile);
+            lane0Actual[iter].assign(vecTile.data(), vecTile.data() + vecTile.Numel);
+        }
+        for (int iter = 0; iter < kFifoDepth; ++iter) {
+            TFREE<Pipe, TileSplitAxis::TILE_NO_SPLIT>(pipe);
+        }
+    }
+
+    std::atomic<bool> lane0ThirdPopDone{false};
+    std::thread lane0ThirdPop([&]() {
+        cpu_sim::ScopedExecutionContext lane0Ctx(0, 0, 2);
+        VecTile vecTile;
+        TASSIGN(vecTile, 0x4000);
+        TPOP<Pipe, VecTile, TileSplitAxis::TILE_NO_SPLIT>(pipe, vecTile);
+        lane0Actual[kFifoDepth].assign(vecTile.data(), vecTile.data() + vecTile.Numel);
+        TFREE<Pipe, TileSplitAxis::TILE_NO_SPLIT>(pipe);
+        lane0ThirdPopDone.store(true, std::memory_order_release);
+    });
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    EXPECT_FALSE(lane0ThirdPopDone.load(std::memory_order_acquire));
+
+    {
+        cpu_sim::ScopedExecutionContext lane1Ctx(0, 1, 2);
+        for (int iter = 0; iter < kFifoDepth; ++iter) {
+            VecTile vecTile;
+            TASSIGN(vecTile, 0x8000);
+            TPOP<Pipe, VecTile, TileSplitAxis::TILE_NO_SPLIT>(pipe, vecTile);
+            lane1Actual[iter].assign(vecTile.data(), vecTile.data() + vecTile.Numel);
+            TFREE<Pipe, TileSplitAxis::TILE_NO_SPLIT>(pipe);
+        }
+    }
+
+    {
+        cpu_sim::ScopedExecutionContext producerCtx(0, 0, 1);
+        CubeTile cubeTile;
+        TASSIGN(cubeTile, 0x0);
+        fillCubeTile<T, rows, cols>(cubeTile, kFifoDepth);
+        TPUSH<Pipe, CubeTile, TileSplitAxis::TILE_NO_SPLIT>(pipe, cubeTile);
+    }
+
+    lane0ThirdPop.join();
+    EXPECT_TRUE(lane0ThirdPopDone.load(std::memory_order_acquire));
+
+    for (int iter = 0; iter < kFifoDepth + 1; ++iter) {
+        const auto expected = makeExpected<T, rows, cols>(iter);
+        EXPECT_TRUE(ResultCmp(expected, lane0Actual[iter], 0));
+    }
+    for (int iter = 0; iter < kFifoDepth; ++iter) {
+        EXPECT_TRUE(std::all_of(lane1Actual[iter].begin(), lane1Actual[iter].end(),
+                                [](T value) { return value == static_cast<T>(0); }));
+    }
+
+    auto &sharedState = Pipe::GetSharedState();
+    std::lock_guard<std::mutex> lock(sharedState.mutex);
+    EXPECT_EQ(sharedState.occupied, 1);
+    EXPECT_EQ(sharedState.popped_not_freed_by_lane[0], 0);
+    EXPECT_EQ(sharedState.popped_not_freed_by_lane[1], 0);
+}
+
+template <typename T, int rows, int cols, int validRows>
+void runCubeToVectorNoSplitGmSlotUsesValidShape()
+{
+    constexpr int kFifoDepth = 2;
+    using CubeTile = Tile<TileType::Acc, T, rows, cols, BLayout::ColMajor, validRows, cols, SLayout::RowMajor, 1024>;
+    using VecTile = Tile<TileType::Vec, T, validRows, cols>;
+    using Pipe = TPipe<kPipeFlagId + 6, Direction::DIR_C2V, sizeof(T) * VecTile::Numel, kFifoDepth, 2, true>;
+
+    NPU_MEMORY_CLEAR();
+    Pipe::reset_for_cpu_sim();
+    std::vector<uint8_t> gmSlotStorage(Pipe::RingFiFo::SLOT_SIZE * Pipe::RingFiFo::SLOT_NUM);
+    auto *gmSlotBuffer = reinterpret_cast<__gm__ void *>(gmSlotStorage.data());
+    Pipe pipe(gmSlotBuffer, kVecConsumerBase, 0x0);
+    std::vector<T> actual(VecTile::Numel);
+
+    {
+        cpu_sim::ScopedExecutionContext producerCtx(0, 0, 1);
+        CubeTile cubeTile;
+        TASSIGN(cubeTile, 0x0);
+        for (int r = 0; r < rows; ++r) {
+            for (int c = 0; c < cols; ++c) {
+                cubeTile.data()[GetTileElementOffset<CubeTile>(r, c)] = static_cast<T>(r * cols + c + 1);
+            }
+        }
+        TPUSH<Pipe, CubeTile, TileSplitAxis::TILE_NO_SPLIT>(pipe, cubeTile);
+    }
+
+    {
+        cpu_sim::ScopedExecutionContext lane0Ctx(0, 0, 2);
+        VecTile vecTile;
+        TASSIGN(vecTile, 0x4000);
+        TPOP<Pipe, VecTile, TileSplitAxis::TILE_NO_SPLIT>(pipe, vecTile);
+        actual.assign(vecTile.data(), vecTile.data() + vecTile.Numel);
+        TFREE<Pipe, TileSplitAxis::TILE_NO_SPLIT>(pipe);
+    }
+
+    {
+        cpu_sim::ScopedExecutionContext lane1Ctx(0, 1, 2);
+        VecTile vecTile;
+        TASSIGN(vecTile, 0x8000);
+        TPOP<Pipe, VecTile, TileSplitAxis::TILE_NO_SPLIT>(pipe, vecTile);
+        TFREE<Pipe, TileSplitAxis::TILE_NO_SPLIT>(pipe);
+    }
+
+    std::vector<T> expected(VecTile::Numel);
+    for (int r = 0; r < validRows; ++r) {
+        for (int c = 0; c < cols; ++c) {
+            expected[r * cols + c] = static_cast<T>(r * cols + c + 1);
+        }
+    }
+    EXPECT_TRUE(ResultCmp(expected, actual, 0));
+
+    auto &sharedState = Pipe::GetSharedState();
+    std::lock_guard<std::mutex> lock(sharedState.mutex);
+    EXPECT_EQ(sharedState.occupied, 0);
+}
+
+template <typename T, int rows, int cols, int validRows, int validCols>
+void runCubeToVectorNoSplitGmSlotUsesDynamicValidShape()
+{
+    constexpr int kFifoDepth = 2;
+    using CubeTile = Tile<TileType::Acc, T, rows, cols, BLayout::ColMajor, -1, -1, SLayout::RowMajor, 1024>;
+    using VecTile = Tile<TileType::Vec, T, validRows, validCols>;
+    using Pipe = TPipe<kPipeFlagId + 7, Direction::DIR_BOTH, sizeof(T) * VecTile::Numel, kFifoDepth, 2, true>;
+
+    NPU_MEMORY_CLEAR();
+    Pipe::reset_for_cpu_sim();
+    std::vector<uint8_t> gmSlotStorage(Pipe::RingFiFo::SLOT_SIZE * Pipe::RingFiFo::SLOT_NUM);
+    auto *gmSlotBuffer = reinterpret_cast<__gm__ void *>(gmSlotStorage.data());
+    Pipe pipe(gmSlotBuffer, kVecConsumerBase, 0x0);
+    std::vector<T> actual(VecTile::Numel);
+
+    {
+        cpu_sim::ScopedExecutionContext producerCtx(0, 0, 1);
+        CubeTile cubeTile(validRows, validCols);
+        TASSIGN(cubeTile, 0x0);
+        for (int r = 0; r < rows; ++r) {
+            for (int c = 0; c < cols; ++c) {
+                cubeTile.data()[GetTileElementOffset<CubeTile>(r, c)] = static_cast<T>(r * cols + c + 1);
+            }
+        }
+        TPUSH<Pipe, CubeTile, TileSplitAxis::TILE_NO_SPLIT>(pipe, cubeTile);
+    }
+
+    {
+        cpu_sim::ScopedExecutionContext lane0Ctx(0, 0, 2);
+        VecTile vecTile;
+        TASSIGN(vecTile, 0x4000);
+        TPOP<Pipe, VecTile, TileSplitAxis::TILE_NO_SPLIT>(pipe, vecTile);
+        actual.assign(vecTile.data(), vecTile.data() + vecTile.Numel);
+        TFREE<Pipe, TileSplitAxis::TILE_NO_SPLIT>(pipe);
+    }
+
+    {
+        cpu_sim::ScopedExecutionContext lane1Ctx(0, 1, 2);
+        VecTile vecTile;
+        TASSIGN(vecTile, 0x8000);
+        TPOP<Pipe, VecTile, TileSplitAxis::TILE_NO_SPLIT>(pipe, vecTile);
+        TFREE<Pipe, TileSplitAxis::TILE_NO_SPLIT>(pipe);
+    }
+
+    std::vector<T> expected(VecTile::Numel);
+    for (int r = 0; r < validRows; ++r) {
+        for (int c = 0; c < validCols; ++c) {
+            expected[r * validCols + c] = static_cast<T>(r * cols + c + 1);
+        }
+    }
+    EXPECT_TRUE(ResultCmp(expected, actual, 0));
+
+    auto &sharedState = Pipe::GetSharedState();
+    std::lock_guard<std::mutex> lock(sharedState.mutex);
+    EXPECT_EQ(sharedState.occupied, 0);
+}
+
+template <typename T, int rows, int cols>
+void runBothDirectionNoSplitC2VThenV2C()
+{
+    constexpr int kFifoDepth = 4;
+    using CubeProdTile = Tile<TileType::Acc, T, rows, cols, BLayout::ColMajor, -1, -1, SLayout::RowMajor, 1024>;
+    using VecConsTile = Tile<TileType::Vec, T, rows, cols>;
+    using VecProdTile = Tile<TileType::Vec, T, rows, cols>;
+    using CubeConsTile = Tile<TileType::Mat, T, rows, cols, BLayout::ColMajor, -1, -1, SLayout::RowMajor, 512>;
+    using Pipe = TPipe<kPipeFlagId + 8, Direction::DIR_BOTH, sizeof(T) * VecConsTile::Numel, kFifoDepth, 2, true>;
+
+    NPU_MEMORY_CLEAR();
+    Pipe::reset_for_cpu_sim();
+    std::vector<uint8_t> gmSlotStorage(Pipe::RingFiFo::SLOT_SIZE * Pipe::RingFiFo::SLOT_NUM);
+    auto *gmSlotBuffer = reinterpret_cast<__gm__ void *>(gmSlotStorage.data());
+    Pipe pipe(gmSlotBuffer, kVecConsumerBase, kVecConsumerBase + 0x4000);
+    std::vector<T> c2vActual(VecConsTile::Numel);
+    std::vector<T> secondC2vActual(VecConsTile::Numel);
+    std::vector<T> v2cActual(CubeConsTile::Numel);
+
+    auto pushCube = [&](int iter) {
+        cpu_sim::ScopedExecutionContext cubeCtx(0, 0, 1);
+        CubeProdTile cubeTile(rows, cols);
+        TASSIGN(cubeTile, 0x0);
+        for (int r = 0; r < rows; ++r) {
+            for (int c = 0; c < cols; ++c) {
+                cubeTile.data()[GetTileElementOffset<CubeProdTile>(r, c)] =
+                    static_cast<T>(iter * 1000 + r * cols + c + 1);
+            }
+        }
+        TPUSH<Pipe, CubeProdTile, TileSplitAxis::TILE_NO_SPLIT>(pipe, cubeTile);
+    };
+
+    pushCube(0);
+    {
+        cpu_sim::ScopedExecutionContext lane0Ctx(0, 0, 2);
+        VecConsTile vecTile;
+        TASSIGN(vecTile, 0x4000);
+        TPOP<Pipe, VecConsTile, TileSplitAxis::TILE_NO_SPLIT>(pipe, vecTile);
+        c2vActual.assign(vecTile.data(), vecTile.data() + vecTile.Numel);
+        TFREE<Pipe, TileSplitAxis::TILE_NO_SPLIT>(pipe);
+    }
+
+    {
+        cpu_sim::ScopedExecutionContext lane1Ctx(0, 1, 2);
+        VecConsTile vecTile;
+        TASSIGN(vecTile, 0x8000);
+        TPOP<Pipe, VecConsTile, TileSplitAxis::TILE_NO_SPLIT>(pipe, vecTile);
+        TFREE<Pipe, TileSplitAxis::TILE_NO_SPLIT>(pipe);
+    }
+
+    {
+        cpu_sim::ScopedExecutionContext vecCtx(0, 0, 2);
+        VecProdTile vecTile;
+        TASSIGN(vecTile, 0x4000);
+        for (int r = 0; r < rows; ++r) {
+            for (int c = 0; c < cols; ++c) {
+                vecTile.data()[GetTileElementOffset<VecProdTile>(r, c)] = static_cast<T>(1000 + r * cols + c + 1);
+            }
+        }
+        TPUSH<Pipe, VecProdTile, TileSplitAxis::TILE_NO_SPLIT>(pipe, vecTile);
+    }
+
+    pushCube(1);
+    {
+        cpu_sim::ScopedExecutionContext lane0Ctx(0, 0, 2);
+        VecConsTile vecTile;
+        TASSIGN(vecTile, 0x4000);
+        TPOP<Pipe, VecConsTile, TileSplitAxis::TILE_NO_SPLIT>(pipe, vecTile);
+        secondC2vActual.assign(vecTile.data(), vecTile.data() + vecTile.Numel);
+        TFREE<Pipe, TileSplitAxis::TILE_NO_SPLIT>(pipe);
+    }
+
+    {
+        cpu_sim::ScopedExecutionContext lane1Ctx(0, 1, 2);
+        VecConsTile vecTile;
+        TASSIGN(vecTile, 0x8000);
+        TPOP<Pipe, VecConsTile, TileSplitAxis::TILE_NO_SPLIT>(pipe, vecTile);
+        TFREE<Pipe, TileSplitAxis::TILE_NO_SPLIT>(pipe);
+    }
+
+    {
+        cpu_sim::ScopedExecutionContext cubeCtx(0, 0, 1);
+        CubeConsTile cubeTile(rows, cols);
+        TASSIGN(cubeTile, 0x0);
+        TPOP<Pipe, CubeConsTile, TileSplitAxis::TILE_NO_SPLIT>(pipe, cubeTile);
+        v2cActual.assign(cubeTile.data(), cubeTile.data() + cubeTile.Numel);
+        TFREE<Pipe, TileSplitAxis::TILE_NO_SPLIT>(pipe);
+    }
+
+    std::vector<T> c2vExpected(VecConsTile::Numel);
+    std::vector<T> secondC2vExpected(VecConsTile::Numel);
+    std::vector<T> v2cExpected(CubeConsTile::Numel);
+    for (int r = 0; r < rows; ++r) {
+        for (int c = 0; c < cols; ++c) {
+            c2vExpected[r * cols + c] = static_cast<T>(r * cols + c + 1);
+            secondC2vExpected[r * cols + c] = static_cast<T>(1000 + r * cols + c + 1);
+            v2cExpected[GetTileElementOffset<CubeConsTile>(r, c)] = static_cast<T>(1000 + r * cols + c + 1);
+        }
+    }
+    EXPECT_TRUE(ResultCmp(c2vExpected, c2vActual, 0));
+    EXPECT_TRUE(ResultCmp(secondC2vExpected, secondC2vActual, 0));
+    EXPECT_TRUE(ResultCmp(v2cExpected, v2cActual, 0));
+
+    auto &sharedState = Pipe::GetSharedState();
+    std::lock_guard<std::mutex> lock(sharedState.mutex);
+    EXPECT_EQ(sharedState.occupied, 0);
+}
 } // namespace
 
 class TPushPopCVNoSplitTest : public testing::Test {
@@ -193,7 +619,37 @@ TEST_F(TPushPopCVNoSplitTest, cube_to_vector_fifo_wraparound_float_16x32)
     runCubeToVectorNoSplitWraparound<float, 16, 32>();
 }
 
-TEST_F(TPushPopCVNoSplitTest, cube_to_vector_inactive_aiv1_is_noop_in_no_split_mode)
+TEST_F(TPushPopCVNoSplitTest, cube_to_vector_delayed_free_float_16x32)
 {
-    runCubeToVectorNoSplitInactiveLaneNoOp<float, 16, 32>();
+    runCubeToVectorNoSplitDelayedFree<float, 16, 32>();
+}
+
+TEST_F(TPushPopCVNoSplitTest, cube_to_vector_inactive_lane_skips_protocol_when_pipe_is_not_no_split)
+{
+    runCubeToVectorNoSplitInactiveLaneSkipsProtocol<float, 16, 32>();
+}
+
+TEST_F(TPushPopCVNoSplitTest, cube_to_vector_no_split_dual_lane_delayed_free_float_16x32)
+{
+    runCubeToVectorNoSplitDualLaneDelayedFree<float, 16, 32>();
+}
+
+TEST_F(TPushPopCVNoSplitTest, cube_to_vector_no_split_dual_lane_fast_lane_wrap_waits_float_16x32)
+{
+    runCubeToVectorNoSplitDualLaneFastLaneWrapWaits<float, 16, 32>();
+}
+
+TEST_F(TPushPopCVNoSplitTest, cube_to_vector_no_split_gm_slot_uses_valid_shape_int32_128x128)
+{
+    runCubeToVectorNoSplitGmSlotUsesValidShape<int32_t, 128, 128, 16>();
+}
+
+TEST_F(TPushPopCVNoSplitTest, cube_to_vector_no_split_gm_slot_uses_dynamic_valid_shape_float_16x32)
+{
+    runCubeToVectorNoSplitGmSlotUsesDynamicValidShape<float, 16, 32, 16, 32>();
+}
+
+TEST_F(TPushPopCVNoSplitTest, both_direction_no_split_c2v_then_v2c_float_16x32)
+{
+    runBothDirectionNoSplitC2VThenV2C<float, 16, 32>();
 }


### PR DESCRIPTION
## Summary
- Make no-split C2V consumers participate per vector lane, so inactive lanes still advance FIFO protocol while receiving zeroed tile data
- Track no-split delayed TPOP/TFREE slots explicitly and release C2V slots only after both vector lanes have freed them
- Let DIR_BOTH no-split consumers select slots by transfer direction, so C2V and V2C traffic can coexist without blocking on the wrong FIFO head
- Store CPU sim tile data using runtime valid shapes to avoid overwriting inactive rows or columns in GM-backed FIFO slots
- Extend tpushpop_cv_nosplit ST coverage for delayed-free, dual-lane no-split, fast-lane wraparound, valid-shape GM storage, and DIR_BOTH C2V/V2C interleaving

## Testing
- [x] tpushpop_cv_nosplit passes with Release build
- [x] decode_sparse_attn.py --platform a2a3sim passes attn_out validation
- [x] decode_qkv_proj_rope.py --platform a2a3sim passes q, kv, qr, and qr_scale validation