### PR TITLE
fix(backend): Correct V2C split FIFO slot reuse in the CPU simulator

### DIFF
--- a/include/pto/cpu/TPush.hpp
+++ b/include/pto/cpu/TPush.hpp
@@ -599,9 +599,6 @@ struct TPipe {
             {
                 std::lock_guard<std::mutex> lock(shared_state.mutex);
                 const auto slotIdx = static_cast<std::size_t>(tileIndex % RingFiFo::SLOT_NUM);
-                shared_state.transfer_dirs[slotIdx] = cpu_pipe::GetProducerTransferDir<TPipe, TileProd>();
-                shared_state.remaining_consumers[slotIdx] =
-                    cpu_pipe::GetRequiredConsumerCount<TPipe, TileProd, Split>();
                 if constexpr (TPipe::is_v2c && cpu_pipe::IsV2CProducerTile<TileProd>() &&
                               Split != TileSplitAxis::TILE_NO_SPLIT) {
                     const uint32_t laneMask = cpu_pipe::GetSplitLaneMask<Split>(static_cast<uint32_t>(subTileIndex));
@@ -612,6 +609,12 @@ struct TPipe {
                     shared_state.producers_allocated[slotIdx] = 0;
                     shared_state.producers_done[slotIdx] = 0;
                 }
+                // Mark the slot consumable only once fully committed: for a split V2C producer
+                // that is after both AIV lanes have written, so the consumer never reads a
+                // half-written slot.
+                shared_state.transfer_dirs[slotIdx] = cpu_pipe::GetProducerTransferDir<TPipe, TileProd>();
+                shared_state.remaining_consumers[slotIdx] =
+                    cpu_pipe::GetRequiredConsumerCount<TPipe, TileProd, Split>();
                 shared_state.next_producer_slot = (tileIndex + 1) % RingFiFo::SLOT_NUM;
                 ++shared_state.occupied;
             }
@@ -692,7 +695,10 @@ struct TPipe {
                 subTileIndex = static_cast<int>(laneId);
                 return;
             }
-            if constexpr (Split == TileSplitAxis::TILE_NO_SPLIT) {
+            // A pure V2C consumer (the cube) pops one full combined tile regardless of how the
+            // producers split it, so it uses the same pending-slot tracking as no-split mode to
+            // keep overlapping pops on distinct slots when the ring is reused.
+            if constexpr (Split == TileSplitAxis::TILE_NO_SPLIT || (TPipe::is_v2c && !TPipe::is_c2v)) {
                 if constexpr (cpu_pipe::ShouldNoSplitC2VConsumerLaneParticipate<TPipe, TileCons, Split>()) {
                     const uint32_t laneId = cpu_pipe::GetSplitLaneId<TileSplitAxis::TILE_UP_DOWN>();
                     const uint32_t laneMask = cpu_pipe::GetSplitLaneMask<TileSplitAxis::TILE_UP_DOWN>(laneId);
@@ -751,7 +757,8 @@ struct TPipe {
             {
                 std::lock_guard<std::mutex> lock(shared_state.mutex);
                 int freeTileIndex = tileIndex;
-                if constexpr (Split == TileSplitAxis::TILE_NO_SPLIT) {
+                // A pure V2C consumer uses pending-slot tracking in split mode too.
+                if constexpr (Split == TileSplitAxis::TILE_NO_SPLIT || (TPipe::is_v2c && !TPipe::is_c2v)) {
                     if constexpr (cpu_pipe::ShouldNoSplitC2VConsumerLaneFree<TPipe, Split>()) {
                         const uint32_t laneId = cpu_pipe::GetSplitLaneId<TileSplitAxis::TILE_UP_DOWN>();
                         auto &lanePopped = shared_state.popped_not_freed_by_lane[laneId];
@@ -777,8 +784,9 @@ struct TPipe {
                     remaining = 0;
                     shared_state.consumers_claimed[slotIndex] = 0;
                     shared_state.transfer_dirs[slotIndex] = cpu_pipe::TransferDir::None;
-                    if constexpr (Split != TileSplitAxis::TILE_NO_SPLIT) {
-                        shared_state.next_consumer_slot = (tileIndex + 1) % RingFiFo::SLOT_NUM;
+                    // Only c2v split advances the consumer cursor here (V2C does it in wait()).
+                    if constexpr (Split != TileSplitAxis::TILE_NO_SPLIT && !(TPipe::is_v2c && !TPipe::is_c2v)) {
+                        shared_state.next_consumer_slot = (freeTileIndex + 1) % RingFiFo::SLOT_NUM;
                     }
                     --shared_state.occupied;
                 }

--- a/tests/cpu/st/testcase/CMakeLists.txt
+++ b/tests/cpu/st/testcase/CMakeLists.txt
@@ -161,6 +161,7 @@ txors
 tpushpop_cv_nosplit
 tpushpop_cv
 tpushpop_vc_nosplit
+tpushpop_vc
 )
 
 foreach(TESTCASE ${ALL_TESTCASES})

--- a/tests/cpu/st/testcase/tpushpop_vc/CMakeLists.txt
+++ b/tests/cpu/st/testcase/tpushpop_vc/CMakeLists.txt
@@ -1,0 +1,1 @@
+pto_cpu_sim_st(tpushpop_vc)

--- a/tests/cpu/st/testcase/tpushpop_vc/main.cpp
+++ b/tests/cpu/st/testcase/tpushpop_vc/main.cpp
@@ -1,0 +1,221 @@
+/**
+Copyright (c) 2026 Huawei Technologies Co., Ltd.
+This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+CANN Open Software License Agreement Version 2.0 (the "License").
+Please refer to the License for details. You may not use this file except in compliance with the License.
+THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE.
+See LICENSE in the root of the software repository for the full text of the License.
+*/
+
+// V2C (vector -> cube) split TPUSH/TPOP coverage.
+//
+// Two AIV sub-cores each push a half of a tile (TILE_UP_DOWN splits the rows,
+// TILE_LEFT_RIGHT splits the columns); the single AIC pops the full combined
+// tile. This is the reverse of the C2V split case (1 producer / 2 consumers)
+// and was previously untested in CPU-sim -- the sibling testcase only covers
+// tpushpop_vc_nosplit. The wraparound variants drive more iterations than the
+// ring has slots (NB > SLOT_NUM) so that slots are reused; that reuse path is
+// exactly where the V2C split consumer used to hand the same slot to two
+// overlapping pops and return corrupted data.
+
+#include <algorithm>
+#include <gtest/gtest.h>
+#include <pto/pto-inst.hpp>
+#include <vector>
+#include "test_common.h"
+
+using namespace pto;
+using namespace PtoTestCommon;
+
+namespace {
+constexpr uint32_t kMatConsumerBase = 0x20000;
+constexpr uint8_t kPipeFlagId = 12;
+
+// Per-(iter, lane, element) distinct values so any slot mix-up shows up.
+template <typename T>
+T cellValue(int iter, int lane, int elem)
+{
+    return static_cast<T>(iter * 100000 + lane * 1000 + elem + 1);
+}
+
+template <typename TileData>
+void fillHalfTile(TileData &tile, int iter, int lane)
+{
+    using T = typename TileData::DType;
+    for (int i = 0; i < tile.Numel; ++i) {
+        tile.data()[i] = cellValue<T>(iter, lane, i);
+    }
+}
+
+// Expected full [rows, cols] combined tile.
+template <typename T, int rows, int cols, TileSplitAxis Split>
+std::vector<T> makeExpected(int iter)
+{
+    std::vector<T> expected(static_cast<std::size_t>(rows) * cols);
+    for (int r = 0; r < rows; ++r) {
+        for (int c = 0; c < cols; ++c) {
+            int lane;
+            int localElem;
+            if constexpr (Split == TileSplitAxis::TILE_UP_DOWN) {
+                constexpr int halfRows = rows / 2;
+                lane = r / halfRows;
+                localElem = (r % halfRows) * cols + c; // producer tile is [rows/2, cols]
+            } else {                                   // TILE_LEFT_RIGHT
+                constexpr int halfCols = cols / 2;
+                lane = c / halfCols;
+                localElem = r * halfCols + (c % halfCols); // producer tile is [rows, cols/2]
+            }
+            expected[static_cast<std::size_t>(r) * cols + c] = cellValue<T>(iter, lane, localElem);
+        }
+    }
+    return expected;
+}
+
+// One AIV lane pushes its half tile into the shared slot.
+template <typename T, int rows, int cols, TileSplitAxis Split, typename Pipe>
+void pushLane(Pipe &pipe, int iter, int lane)
+{
+    constexpr int prodRows = (Split == TileSplitAxis::TILE_UP_DOWN) ? rows / 2 : rows;
+    constexpr int prodCols = (Split == TileSplitAxis::TILE_LEFT_RIGHT) ? cols / 2 : cols;
+    using VecTile = Tile<TileType::Vec, T, prodRows, prodCols>;
+    cpu_sim::ScopedExecutionContext vecCtx(0, lane, 2); // (blockIdx, subblockId, subblockDim)
+    VecTile vecTile;
+    TASSIGN(vecTile, 0x0);
+    fillHalfTile(vecTile, iter, lane);
+    TPUSH<Pipe, VecTile, Split>(pipe, vecTile);
+}
+
+template <typename T, int rows, int cols, TileSplitAxis Split, typename Pipe>
+void popTile(Pipe &pipe, std::vector<T> &out)
+{
+    using MatTile = Tile<TileType::Mat, T, rows, cols>;
+    cpu_sim::ScopedExecutionContext cubeCtx(0, 0, 1);
+    MatTile matTile;
+    TASSIGN(matTile, 0x4000);
+    TPOP<Pipe, MatTile, Split>(pipe, matTile);
+    out.assign(matTile.data(), matTile.data() + matTile.Numel);
+    TFREE<Pipe, Split>(pipe);
+}
+
+// TPOP without the matching TFREE, so multiple tiles can be in flight at once
+// (the cube pipelines: it pops tile k+1 before freeing tile k). Reading the
+// wrong slot here is exactly the V2C-split-reuse bug.
+template <typename T, int rows, int cols, TileSplitAxis Split, typename Pipe>
+void popOnly(Pipe &pipe, std::vector<T> &out)
+{
+    using MatTile = Tile<TileType::Mat, T, rows, cols>;
+    cpu_sim::ScopedExecutionContext cubeCtx(0, 0, 1);
+    MatTile matTile;
+    TASSIGN(matTile, 0x4000);
+    TPOP<Pipe, MatTile, Split>(pipe, matTile);
+    out.assign(matTile.data(), matTile.data() + matTile.Numel);
+}
+
+template <TileSplitAxis Split, typename Pipe>
+void freeOne(Pipe &pipe)
+{
+    cpu_sim::ScopedExecutionContext cubeCtx(0, 0, 1);
+    TFREE<Pipe, Split>(pipe);
+}
+
+template <typename T, int rows, int cols, TileSplitAxis Split>
+void runSplitSingleTile()
+{
+    constexpr int kFifoDepth = 2;
+    using MatTile = Tile<TileType::Mat, T, rows, cols>;
+    using Pipe = TPipe<kPipeFlagId, Direction::DIR_V2C, sizeof(T) * MatTile::Numel, kFifoDepth>;
+
+    NPU_MEMORY_CLEAR();
+    Pipe::reset_for_cpu_sim();
+    Pipe pipe((__gm__ void *)nullptr, 0x0, kMatConsumerBase);
+
+    pushLane<T, rows, cols, Split>(pipe, 0, 0);
+    pushLane<T, rows, cols, Split>(pipe, 0, 1);
+    std::vector<T> actual;
+    popTile<T, rows, cols, Split>(pipe, actual);
+
+    const auto expected = makeExpected<T, rows, cols, Split>(0);
+    EXPECT_TRUE(ResultCmp(expected, actual, 0));
+}
+
+// Drive kIterations > kFifoDepth so the ring wraps and slots get reused.
+template <typename T, int rows, int cols, TileSplitAxis Split>
+void runSplitWraparound()
+{
+    constexpr int kFifoDepth = 2;
+    constexpr int kIterations = 5;
+    using MatTile = Tile<TileType::Mat, T, rows, cols>;
+    using Pipe = TPipe<kPipeFlagId + 1, Direction::DIR_V2C, sizeof(T) * MatTile::Numel, kFifoDepth>;
+
+    NPU_MEMORY_CLEAR();
+    Pipe::reset_for_cpu_sim();
+    Pipe pipe((__gm__ void *)nullptr, 0x0, kMatConsumerBase);
+
+    std::vector<std::vector<T>> actual(kIterations);
+
+    auto pushBoth = [&](int iter) {
+        pushLane<T, rows, cols, Split>(pipe, iter, 0);
+        pushLane<T, rows, cols, Split>(pipe, iter, 1);
+    };
+
+    // Keep the FIFO full and pop with depth-2 in flight: TPOP(k+1) is issued
+    // before TFREE(k), so two slots are outstanding at once -- the pipelined
+    // cube behaviour that exposes V2C-split slot reuse.
+    for (int iter = 0; iter < std::min(kFifoDepth, kIterations); ++iter) {
+        pushBoth(iter);
+    }
+    popOnly<T, rows, cols, Split>(pipe, actual[0]); // first tile in flight
+    for (int iter = 0; iter < kIterations; ++iter) {
+        const int nextIter = iter + 1;
+        if (nextIter < kIterations) {
+            popOnly<T, rows, cols, Split>(pipe, actual[nextIter]); // 2 in flight
+        }
+        freeOne<Split>(pipe);                                      // retire tile `iter`
+        const int producerIter = iter + kFifoDepth;
+        if (producerIter < kIterations) {
+            pushBoth(producerIter);
+        }
+    }
+
+    for (int iter = 0; iter < kIterations; ++iter) {
+        const auto expected = makeExpected<T, rows, cols, Split>(iter);
+        EXPECT_TRUE(ResultCmp(expected, actual[iter], 0));
+    }
+}
+} // namespace
+
+class TPushPopVCSplitTest : public testing::Test {
+protected:
+    void SetUp() override
+    {
+        NPU_MEMORY_INIT(NPUArch::A5);
+        NPU_MEMORY_CLEAR();
+    }
+
+    void TearDown() override
+    {
+        cpu_sim::reset_execution_context();
+        NPU_MEMORY_CLEAR();
+    }
+};
+
+TEST_F(TPushPopVCSplitTest, up_down_single_tile_float_16x32)
+{
+    runSplitSingleTile<float, 16, 32, TileSplitAxis::TILE_UP_DOWN>();
+}
+
+TEST_F(TPushPopVCSplitTest, up_down_fifo_wraparound_float_16x32)
+{
+    runSplitWraparound<float, 16, 32, TileSplitAxis::TILE_UP_DOWN>();
+}
+
+TEST_F(TPushPopVCSplitTest, left_right_single_tile_float_16x32)
+{
+    runSplitSingleTile<float, 16, 32, TileSplitAxis::TILE_LEFT_RIGHT>();
+}
+
+TEST_F(TPushPopVCSplitTest, left_right_fifo_wraparound_float_16x32)
+{
+    runSplitWraparound<float, 16, 32, TileSplitAxis::TILE_LEFT_RIGHT>();
+}


### PR DESCRIPTION
## Summary
- Consumer wait()/free(): a pure V2C consumer (is_v2c && !is_c2v) now uses the same pending-slot tracking as no-split mode (popped_slots + FindNextTransferSlot, with the cursor advanced in wait()), so overlapping pops under pipelining no longer alias a reused slot (iterations > SLOT_NUM)
- Producer record(): publish transfer_dirs / remaining_consumers only after the split both-lanes commit, so the consumer's readiness check never sees a half-written slot
- Add cpu ST tests/cpu/st/testcase/tpushpop_vc covering V2C TILE_UP_DOWN and TILE_LEFT_RIGHT, single-tile and depth-2 pipelined wraparound, closing the gap left by tpushpop_vc_nosplit

## Testing
- [x] New tpushpop_vc cpu ST (4 cases) passes; both wraparound cases fail without the fix, confirming the regression is caught
- [x] Existing cpu STs still pass: tpushpop, tpushpop_cv, tpushpop_cv_nosplit, tpushpop_vc_nosplit
- [x] dsv4 prefill_hc_pre passes end-to-end on a2a3sim with the kernel unchanged (UP_DOWN split retained)