### PR TITLE
fix(cpu): Route DIR_BOTH V2C consumers through the pending-slot FIFO

### DIFF
--- a/include/pto/cpu/TPush.hpp
+++ b/include/pto/cpu/TPush.hpp
@@ -645,6 +645,11 @@ struct TPipe {
         bool isWait = true;
         bool isFree = true;
         int entryOffset = 0;
+        // CPU-sim only: set by wait() when this pop is serviced through the pending-slot
+        // FIFO (overlapping pops kept on distinct slots). free() reads it to choose the
+        // matching release path on a DIR_BOTH pipe, where the Split-only template cannot
+        // tell a V2C-direction release (cube popping Mat) from a C2V one (vector popping Vec).
+        bool pendingSlotTracked = false;
 
         PTO_INTERNAL Consumer() = default;
 
@@ -695,7 +700,9 @@ struct TPipe {
             (void)Split;
             auto &shared_state = TPipe::GetSharedState();
             std::unique_lock<std::mutex> lock(shared_state.mutex);
+            pendingSlotTracked = false;
             constexpr auto expectedDir = cpu_pipe::GetConsumerTransferDir<TPipe, TileCons>();
+            constexpr bool kBothDir = TPipe::is_c2v && TPipe::is_v2c;
             if constexpr (TPipe::is_c2v && cpu_pipe::IsC2VConsumerTile<TileCons>() &&
                           Split != TileSplitAxis::TILE_NO_SPLIT) {
                 const uint32_t laneId = cpu_pipe::GetSplitLaneId<Split>();
@@ -715,7 +722,8 @@ struct TPipe {
             // A pure V2C consumer (the cube) pops one full combined tile regardless of how the
             // producers split it, so it uses the same pending-slot tracking as no-split mode to
             // keep overlapping pops on distinct slots when the ring is reused.
-            if constexpr (Split == TileSplitAxis::TILE_NO_SPLIT || (TPipe::is_v2c && !TPipe::is_c2v)) {
+            if constexpr (Split == TileSplitAxis::TILE_NO_SPLIT || (TPipe::is_v2c && !TPipe::is_c2v) ||
+                          (kBothDir && expectedDir == cpu_pipe::TransferDir::V2C)) {
                 if constexpr (cpu_pipe::ShouldNoSplitC2VConsumerLaneParticipate<TPipe, TileCons, Split>()) {
                     const uint32_t laneId = cpu_pipe::GetSplitLaneId<TileSplitAxis::TILE_UP_DOWN>();
                     const uint32_t laneMask = cpu_pipe::GetSplitLaneMask<TileSplitAxis::TILE_UP_DOWN>(laneId);
@@ -755,6 +763,7 @@ struct TPipe {
                 subTileIndex = static_cast<int>(get_subblockid());
                 shared_state.next_consumer_slot = (tileIndex + 1) % RingFiFo::SLOT_NUM;
                 cpu_pipe::PushPendingSlot(shared_state.popped_slots, shared_state.popped_not_freed, tileIndex);
+                pendingSlotTracked = true;
                 return;
             }
             shared_state.cv.wait(lock, [&shared_state, expectedDir]() {
@@ -774,6 +783,7 @@ struct TPipe {
             {
                 std::lock_guard<std::mutex> lock(shared_state.mutex);
                 int freeTileIndex = tileIndex;
+                constexpr bool kBothDir = TPipe::is_c2v && TPipe::is_v2c;
                 // A pure V2C consumer uses pending-slot tracking in split mode too.
                 if constexpr (Split == TileSplitAxis::TILE_NO_SPLIT || (TPipe::is_v2c && !TPipe::is_c2v)) {
                     if constexpr (cpu_pipe::ShouldNoSplitC2VConsumerLaneFree<TPipe, Split>()) {
@@ -792,6 +802,17 @@ struct TPipe {
                             return;
                         }
                     }
+                } else if constexpr (kBothDir) {
+                    // DIR_BOTH split: the V2C consumer (cube popping Mat) tracked overlapping
+                    // pops through the pending FIFO in wait(); release the oldest such slot here
+                    // so back-to-back pops free distinct slots. The C2V split consumer (vector
+                    // popping Vec) is not pending-tracked and falls through to the lane logic.
+                    if (pendingSlotTracked) {
+                        if (!cpu_pipe::PopPendingSlot(shared_state.popped_slots, shared_state.popped_not_freed,
+                                                      freeTileIndex)) {
+                            return;
+                        }
+                    }
                 }
                 const auto slotIndex = static_cast<std::size_t>(freeTileIndex % RingFiFo::SLOT_NUM);
                 auto &remaining = shared_state.remaining_consumers[slotIndex];
@@ -802,8 +823,17 @@ struct TPipe {
                     shared_state.consumers_claimed[slotIndex] = 0;
                     shared_state.transfer_dirs[slotIndex] = cpu_pipe::TransferDir::None;
                     shared_state.slot_busy[slotIndex] = 0;
-                    // Only c2v split advances the consumer cursor here (V2C does it in wait()).
-                    if constexpr (Split != TileSplitAxis::TILE_NO_SPLIT && !(TPipe::is_v2c && !TPipe::is_c2v)) {
+                    // Only a split consumer that advances the shared cursor in free() does so here;
+                    // a pending-tracked V2C consumer already advanced it in wait(), and a NO_SPLIT
+                    // consumer advances its own per-lane/search cursor in wait() and must not touch
+                    // the shared next_consumer_slot here (it is shared with the other direction).
+                    bool advanceConsumerCursor = false;
+                    if constexpr (kBothDir) {
+                        advanceConsumerCursor = (Split != TileSplitAxis::TILE_NO_SPLIT) && !pendingSlotTracked;
+                    } else if constexpr (Split != TileSplitAxis::TILE_NO_SPLIT && !(TPipe::is_v2c && !TPipe::is_c2v)) {
+                        advanceConsumerCursor = true;
+                    }
+                    if (advanceConsumerCursor) {
                         shared_state.next_consumer_slot = (freeTileIndex + 1) % RingFiFo::SLOT_NUM;
                     }
                     --shared_state.occupied;

--- a/tests/cpu/st/testcase/tpushpop_vc/main.cpp
+++ b/tests/cpu/st/testcase/tpushpop_vc/main.cpp
@@ -183,6 +183,59 @@ void runSplitWraparound()
         EXPECT_TRUE(ResultCmp(expected, actual[iter], 0));
     }
 }
+
+// Same depth-2-in-flight pop pattern, but on a DIR_BOTH pipe. A bidirectional pipe
+// carries V2C (vector->cube) and C2V (cube->vector) traffic on one ring, so the
+// cube's V2C consumer is NOT "is_v2c && !is_c2v" and, before the fix, fell back to
+// a naive consumer that did not advance the slot cursor per pop -- two outstanding
+// pops then aliased the same slot and the two frees corrupted the ring accounting.
+// This is the hc_head linear-kernel deadlock in miniature (cube finishes, both
+// vector lanes hang at TPOP). The fix routes DIR_BOTH V2C consumers through the
+// pending-slot FIFO just like the pure-V2C path, so the pops read distinct slots.
+template <typename T, int rows, int cols, TileSplitAxis Split>
+void runSplitWraparoundBothDir()
+{
+    constexpr int kFifoDepth = 4;
+    constexpr int kIterations = 6;
+    using MatTile = Tile<TileType::Mat, T, rows, cols>;
+    using Pipe = TPipe<kPipeFlagId + 2, Direction::DIR_BOTH, sizeof(T) * MatTile::Numel, kFifoDepth, kFifoDepth, false>;
+
+    NPU_MEMORY_CLEAR();
+    Pipe::reset_for_cpu_sim();
+    Pipe pipe((__gm__ void *)nullptr, 0x0, kMatConsumerBase);
+
+    std::vector<std::vector<T>> actual(kIterations);
+
+    auto pushBoth = [&](int iter) {
+        pushLane<T, rows, cols, Split>(pipe, iter, 0);
+        pushLane<T, rows, cols, Split>(pipe, iter, 1);
+    };
+
+    for (int iter = 0; iter < std::min(kFifoDepth, kIterations); ++iter) {
+        pushBoth(iter);
+    }
+    popOnly<T, rows, cols, Split>(pipe, actual[0]); // first tile in flight
+    for (int iter = 0; iter < kIterations; ++iter) {
+        const int nextIter = iter + 1;
+        if (nextIter < kIterations) {
+            popOnly<T, rows, cols, Split>(pipe, actual[nextIter]); // 2 in flight
+        }
+        freeOne<Split>(pipe);                                      // retire tile `iter`
+        const int producerIter = iter + kFifoDepth;
+        if (producerIter < kIterations) {
+            pushBoth(producerIter);
+        }
+    }
+
+    for (int iter = 0; iter < kIterations; ++iter) {
+        const auto expected = makeExpected<T, rows, cols, Split>(iter);
+        EXPECT_TRUE(ResultCmp(expected, actual[iter], 0));
+    }
+
+    auto &sharedState = Pipe::GetSharedState();
+    std::lock_guard<std::mutex> lock(sharedState.mutex);
+    EXPECT_EQ(sharedState.occupied, 0);
+}
 } // namespace
 
 class TPushPopVCSplitTest : public testing::Test {
@@ -218,4 +271,14 @@ TEST_F(TPushPopVCSplitTest, left_right_single_tile_float_16x32)
 TEST_F(TPushPopVCSplitTest, left_right_fifo_wraparound_float_16x32)
 {
     runSplitWraparound<float, 16, 32, TileSplitAxis::TILE_LEFT_RIGHT>();
+}
+
+TEST_F(TPushPopVCSplitTest, both_dir_up_down_overlapping_pops_read_distinct_slots_float_16x32)
+{
+    runSplitWraparoundBothDir<float, 16, 32, TileSplitAxis::TILE_UP_DOWN>();
+}
+
+TEST_F(TPushPopVCSplitTest, both_dir_left_right_overlapping_pops_read_distinct_slots_float_16x32)
+{
+    runSplitWraparoundBothDir<float, 16, 32, TileSplitAxis::TILE_LEFT_RIGHT>();
 }


### PR DESCRIPTION
## Summary
- Extend the consumer wait() pending-slot branch with `(kBothDir && expectedDir == V2C)` so DIR_BOTH V2C consumers advance the cursor per pop and keep overlapping pops on distinct slots
- Add a runtime `pendingSlotTracked` flag on Consumer (set in wait()) because free() is templated only on Split and cannot otherwise tell a DIR_BOTH V2C release (cube popping Mat) from a C2V one (vector popping Vec); free() uses it to PopPendingSlot the oldest slot and skip the in-free cursor advance, while the C2V split consumer keeps the remaining_consumers/lane logic
- Non-DIR_BOTH, pure-V2C, NO_SPLIT, and single-buffered paths are unchanged (compile-time branches do not enter the new kBothDir path; a single pop-free is equivalent to the previous naive path)
- Add tpushpop_vc regression tests both_dir_{up_down,left_right}_overlapping_ pops_read_distinct_slots: depth-2 in-flight pops on a DIR_BOTH split pipe, asserting each tile reads its own slot and the ring ends with occupied == 0

## Testing
- [x] hc_head.py PASS on a2a3sim (y validate PASS, runtime 5.63s, no stall)
- [x] All 6 tpushpop_vc ST tests pass; the 2 new tests fail on the reverted code (duplicate data at ResultCmp), confirming they guard the bug
- [x] tpushpop_cv_nosplit / tpushpop_vc_nosplit / tpushpop_cv / tpushpop ST suites pass (no regression); built with g++ 15.2.0