### PR TITLE
test: sync PR920 A5 simple trim on upstream main

### DIFF
--- a/tests/run_st.sh
+++ b/tests/run_st.sh
@@ -529,8 +529,9 @@ if [ "$ENABLE_A5" = "true" ]; then
     python3 tests/script/run_st.py $ARGS -v a5 -t mgather -g MGATHERTest.case_half_16x128_8x64
     python3 tests/script/run_st.py $ARGS -v a5 -t mscatter -g MSCATTERTest.case_uint8_16x64_2048
     python3 tests/script/run_st.py $ARGS -v a5 -t mscatter -g MSCATTERTest.case_int32_clamp_8x16_256
-    python3 tests/script/run_st.py $ARGS -v a5 -t mscatter -g MSCATTERTest.case_elem2d_float_3072x8_default_24576size
-    python3 tests/script/run_st.py $ARGS -v a5 -t mscatter -g MSCATTERTest.case_elem2d_float_3072x8_last_256size
+    # Synced from cann/pto-isa PR920: trim these two A5 simple mscatter cases.
+    # python3 tests/script/run_st.py $ARGS -v a5 -t mscatter -g MSCATTERTest.case_elem2d_float_3072x8_default_24576size
+    # python3 tests/script/run_st.py $ARGS -v a5 -t mscatter -g MSCATTERTest.case_elem2d_float_3072x8_last_256size
     python3 tests/script/run_st.py $ARGS -v a5 -t tquant -g TQUANTTEST.case_int8_sym_fp32_128x128_nd
     python3 tests/script/run_st.py $ARGS -v a5 -t tquant -g TQUANTTEST.case_int8_asym_fp32_128x128_nd
     python3 tests/script/run_st.py $ARGS -v a5 -t tquant -g TQUANTTEST.case_int8_sym_fp32_128x128_nd


### PR DESCRIPTION
## Summary
- sync the remaining A5 simple trim from cann/pto-isa PR920 onto upstream main
- comment out the two extra mscatter A5 simple cases still present on hw-native-sys/main
- keep the change scoped to the A5 simple block in 	ests/run_st.sh

## Validation
- based on hw-native-sys/pto-isa main
- change is limited to 	ests/run_st.sh
- no extra business code changes included