### PR TITLE
feat(ci): Mirror GitHub PRs to GitCode after checks pass

### DIFF
--- a/.github/workflows/github-pr-to-gitcode-pr.yml
+++ b/.github/workflows/github-pr-to-gitcode-pr.yml
@@ -1,0 +1,120 @@
+name: Mirror GitHub PR to GitCode PR
+
+on:
+  workflow_run:
+    workflows: ["CI", "A5 Smoke"]
+    types: [completed]
+
+permissions:
+  actions: read
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: github-pr-to-gitcode-pr-${{ github.event.workflow_run.head_sha }}
+  cancel-in-progress: true
+
+jobs:
+  mirror:
+    if: ${{ github.event.workflow_run.event == 'pull_request' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Check required GitHub workflows
+        id: gate
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const requiredWorkflows = ["CI", "A5 Smoke"];
+            const run = context.payload.workflow_run;
+            const prs = run.pull_requests || [];
+
+            if (prs.length === 0) {
+              core.info("No pull request is associated with this workflow_run; skipping mirror.");
+              core.setOutput("ready", "false");
+              return;
+            }
+
+            const prNumber = prs[0].number;
+            const headSha = run.head_sha;
+            const runs = await github.paginate(github.rest.actions.listWorkflowRunsForRepo, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              event: "pull_request",
+              head_sha: headSha,
+              per_page: 100,
+            });
+
+            const missing = [];
+            const notSuccessful = [];
+            for (const workflowName of requiredWorkflows) {
+              const workflowRuns = runs
+                .filter((candidate) => candidate.name === workflowName)
+                .filter((candidate) => (candidate.pull_requests || []).some((pr) => pr.number === prNumber))
+                .sort((a, b) => new Date(b.created_at) - new Date(a.created_at));
+
+              const latest = workflowRuns[0];
+              if (!latest) {
+                missing.push(workflowName);
+                continue;
+              }
+
+              core.info(`${workflowName}: status=${latest.status}, conclusion=${latest.conclusion}, url=${latest.html_url}`);
+              if (latest.status !== "completed" || latest.conclusion !== "success") {
+                notSuccessful.push(`${workflowName} (${latest.status}/${latest.conclusion || "none"})`);
+              }
+            }
+
+            if (missing.length > 0 || notSuccessful.length > 0) {
+              if (missing.length > 0) {
+                core.info(`Waiting for workflow(s): ${missing.join(", ")}`);
+              }
+              if (notSuccessful.length > 0) {
+                core.info(`Workflow(s) not successful yet: ${notSuccessful.join(", ")}`);
+              }
+              core.setOutput("ready", "false");
+              return;
+            }
+
+            core.info(`All required workflows passed for PR #${prNumber} at ${headSha}.`);
+            core.setOutput("ready", "true");
+            core.setOutput("pr_number", String(prNumber));
+
+      - name: Checkout trusted base repository
+        if: ${{ steps.gate.outputs.ready == 'true' }}
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.repository.default_branch }}
+
+      - name: Write pull request event payload
+        if: ${{ steps.gate.outputs.ready == 'true' }}
+        id: pr-event
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require("fs");
+            const path = require("path");
+            const pull_number = Number("${{ steps.gate.outputs.pr_number }}");
+            const { data: pull_request } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number,
+            });
+            const eventPath = path.join(process.env.RUNNER_TEMP, "github-pr-event.json");
+            fs.writeFileSync(eventPath, JSON.stringify({ pull_request }, null, 2));
+            core.setOutput("path", eventPath);
+
+      - name: Mirror PR branch and create GitCode PR
+        if: ${{ steps.gate.outputs.ready == 'true' }}
+        run: |
+          bash scripts/github_pr_to_gitcode_pr.sh
+        env:
+          GITHUB_EVENT_PATH: ${{ steps.pr-event.outputs.path }}
+          GITCODE_TOKEN: ${{ secrets.GITCODE_TOKEN }}
+          GITCODE_PUSH_URL: ${{ secrets.GITCODE_PUSH_URL }}
+          GITCODE_OWNER: cann
+          GITCODE_REPO: pto-isa
+          GITCODE_BASE_BRANCH: master
+          GITCODE_HEAD_OWNER: zhhywang

--- a/scripts/github_pr_to_gitcode_pr.sh
+++ b/scripts/github_pr_to_gitcode_pr.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+GITHUB_EVENT_PATH="${GITHUB_EVENT_PATH:?GITHUB_EVENT_PATH is required}"
+GITCODE_TOKEN="${GITCODE_TOKEN:?GITCODE_TOKEN is required}"
+GITCODE_OWNER="${GITCODE_OWNER:-cann}"
+GITCODE_REPO="${GITCODE_REPO:-pto-isa}"
+GITCODE_BASE_BRANCH="${GITCODE_BASE_BRANCH:-master}"
+GITCODE_HEAD_OWNER="${GITCODE_HEAD_OWNER:-zhhywang}"
+GITCODE_REMOTE_NAME="${GITCODE_REMOTE_NAME:-gitcode}"
+GITCODE_PUSH_URL="${GITCODE_PUSH_URL:?GITCODE_PUSH_URL is required}"
+GITCODE_API_BASE="${GITCODE_API_BASE:-https://api.gitcode.com/api/v5}"
+BRANCH_PREFIX="${BRANCH_PREFIX:-github-pr}"
+DRY_RUN="${DRY_RUN:-0}"
+
+log() {
+  printf '[%s] %s\n' "$(date -Is)" "$*"
+}
+
+die() {
+  log "ERROR: $*"
+  exit 1
+}
+
+json_get() {
+  local expr="$1"
+  jq -r "${expr}" "${GITHUB_EVENT_PATH}"
+}
+
+json_payload() {
+  jq -n \
+    --arg title "$1" \
+    --arg head "$2" \
+    --arg base "$3" \
+    --arg body "$4" \
+    '{"title": $title, "head": $head, "base": $base, "body": $body}'
+}
+
+print_pr_url() {
+  local response_file="$1"
+  local pr_url=""
+  local pr_number=""
+
+  pr_url="$(jq -r '.html_url // .web_url // .url // .links.html.href // empty' "${response_file}")"
+  if [[ -n "${pr_url}" ]]; then
+    log "GitCode PR URL: ${pr_url}"
+    return 0
+  fi
+
+  pr_number="$(jq -r '.number // .iid // .id // empty' "${response_file}")"
+  if [[ -n "${pr_number}" ]]; then
+    log "GitCode PR URL: https://gitcode.com/${GITCODE_OWNER}/${GITCODE_REPO}/pulls/${pr_number}"
+    return 0
+  fi
+
+  log "GitCode PR URL not found in API response"
+}
+
+command -v jq >/dev/null 2>&1 || die "jq is required"
+
+pr_number="$(json_get '.pull_request.number')"
+pr_title="$(json_get '.pull_request.title')"
+pr_body="$(json_get '.pull_request.body // ""')"
+pr_html_url="$(json_get '.pull_request.html_url')"
+head_sha="$(json_get '.pull_request.head.sha')"
+head_repo_full_name="$(json_get '.pull_request.head.repo.full_name')"
+head_ref="$(json_get '.pull_request.head.ref')"
+base_ref="$(json_get '.pull_request.base.ref')"
+
+[[ -n "${pr_number}" ]] || die "cannot read pull request number"
+[[ -n "${head_sha}" ]] || die "cannot read pull request head SHA"
+
+gitcode_branch="${BRANCH_PREFIX}/${pr_number}"
+gitcode_head="${GITCODE_HEAD_OWNER}:${gitcode_branch}"
+gitcode_title="[GitHub PR #${pr_number}] ${pr_title}"
+gitcode_body="$(cat <<EOF
+Mirrored from GitHub PR #${pr_number}: ${pr_html_url}
+
+GitHub source branch: ${head_repo_full_name}:${head_ref}
+GitHub base branch: ${base_ref}
+GitHub head SHA: ${head_sha}
+
+---
+
+${pr_body}
+EOF
+)"
+
+github_pr_ref="refs/remotes/github-pr/${pr_number}"
+
+log "mirroring GitHub PR #${pr_number} (${head_sha}) to GitCode branch ${gitcode_branch}"
+
+if git remote get-url "${GITCODE_REMOTE_NAME}" >/dev/null 2>&1; then
+  git remote set-url "${GITCODE_REMOTE_NAME}" "${GITCODE_PUSH_URL}"
+else
+  git remote add "${GITCODE_REMOTE_NAME}" "${GITCODE_PUSH_URL}"
+fi
+
+git fetch origin "pull/${pr_number}/head:${github_pr_ref}"
+fetched_sha="$(git rev-parse "${github_pr_ref}")"
+[[ "${fetched_sha}" == "${head_sha}" ]] || die "fetched PR ref ${fetched_sha} does not match event head ${head_sha}"
+
+if [[ "${DRY_RUN}" == "1" ]]; then
+  log "DRY_RUN=1; would push ${github_pr_ref} to ${GITCODE_REMOTE_NAME}/${gitcode_branch}"
+  log "DRY_RUN=1; would create GitCode PR '${gitcode_title}' from ${gitcode_head} to ${GITCODE_BASE_BRANCH}"
+  exit 0
+fi
+
+git push "${GITCODE_REMOTE_NAME}" "${github_pr_ref}:refs/heads/${gitcode_branch}" --force
+
+payload="$(json_payload "${gitcode_title}" "${gitcode_head}" "${GITCODE_BASE_BRANCH}" "${gitcode_body}")"
+api_url="${GITCODE_API_BASE}/repos/${GITCODE_OWNER}/${GITCODE_REPO}/pulls"
+
+log "creating GitCode PR from ${gitcode_head} to ${GITCODE_OWNER}/${GITCODE_REPO}:${GITCODE_BASE_BRANCH}"
+response_file="$(mktemp)"
+trap 'rm -f "${response_file}"' EXIT
+status_code="$(
+  curl -sS -o "${response_file}" -w '%{http_code}' \
+    -X POST "${api_url}" \
+    -H "Content-Type: application/json" \
+    -H "PRIVATE-TOKEN: ${GITCODE_TOKEN}" \
+    --data "${payload}"
+)"
+
+case "${status_code}" in
+  200|201)
+    log "GitCode PR created"
+    print_pr_url "${response_file}"
+    cat "${response_file}"
+    ;;
+  409|422)
+    log "GitCode PR may already exist or request was rejected as duplicate"
+    print_pr_url "${response_file}"
+    cat "${response_file}"
+    ;;
+  *)
+    cat "${response_file}" >&2
+    die "GitCode API returned HTTP ${status_code}"
+    ;;
+esac


### PR DESCRIPTION
## Summary
- Add a workflow_run-based GitHub Action that waits for both CI and A5 Smoke
  to pass on the same pull request head SHA before mirroring
- Add a helper script that pushes the GitHub PR commit to the zhhywang GitCode
  fork and opens a PR against cann/pto-isa master
- Use jq-based event parsing, PRIVATE-TOKEN authentication, temporary response
  cleanup, and GitCode PR URL logging in the mirror helper

## Testing
- [x] Verified bash syntax with bash -n scripts/github_pr_to_gitcode_pr.sh
- [x] Verified jq payload construction for nullable and multiline PR bodies
