### PR TITLE
fix(sim): Align non-templated MGATHER/MSCATTER default to hardware Row

### DIFF
--- a/docs/isa/tile/ops/memory-and-data-movement/mgather.md
+++ b/docs/isa/tile/ops/memory-and-data-movement/mgather.md
@@ -15,7 +15,7 @@ Out-of-bounds handling is selected through the `GatherOOB` template parameter. `
 
 Per-target dispatch summary:
 
-- **CPU Simulator** — pure C++ reference. The implementation walks `validRow * validCol` and reads `table[idx[i, j]]` (Elem semantics); the CPU sim does not have a separate Row coalesce path. Row iteration uses `pto::cpu::parallel_for_rows`, which by default runs sequentially in row-major order because `PTO_CPU_MAX_THREADS` defaults to `1u`. No destination collision is possible for gather, so the iteration order is observationally irrelevant.
+- **CPU Simulator** — pure C++ reference. Templates on the same `Coalesce` / `GatherOOB` parameters as A5, with the same `Coalesce::Row` default, so a non-templated `MGATHER(dst, src, idx)` means `Coalesce::Row` on sim exactly as on hardware. Row mode reads `table[idx[r], :]` into `dst[r, :]` (table row stride `Shape[4]`, `tableRows = Shape[3]`); Elem mode walks `validRow * validCol` and reads `table[idx[i, j]]`. `GatherOOB` is modeled (`Clamp` / `Wrap` remap the index, `Zero` writes a zero element on out-of-range; `Undefined` reads unchecked). Row iteration uses `pto::cpu::parallel_for_rows`, which by default runs sequentially because `PTO_CPU_MAX_THREADS` defaults to `1u`.
 - **A2/A3 VEC-CORE** — single-threaded scalar / MTE2 walk driven from the scalar pipe. Row mode issues one wide `copy_gm_to_ubuf_align_b*` DMA per row through `tablePtr + safeIdx * tableRowStride` (where `tableRowStride = table.GetStride(DIM_3)` and `tableRows = ∏ Shape[0..3]`); Elem mode performs a scalar GM→UB copy per element (DMA bursts cannot satisfy per-element UB-destination 32-byte alignment). Supports ND-GM with ND-UB **and** NZ-GM with NZ-UB tile pairs.
 - **A5 SIMT** — SIMT launch through `cce::async_invoke` with up to `dim3{32, 32}` (1024 threads). Row mode uses warp-parallel lane reads that the SIMT hardware coalesces into 128 B GM bursts when consecutive; Elem mode maps one lane to one element with per-lane scalar GM loads. The Row kernel computes `srcRow = table + safeIdx * validCols`, so the GM table is treated as **packed ND with row stride = `validCols`** — `MGatherCheck` enforces `GlobalTable::staticShape[4] == TileDst::ValidCol` at compile time, and `tableRows = Shape[3]`. NZ block-stride layouts are not implemented on A5. The `(1, 1)` Elem case bypasses the SIMT launch and runs `MGatherScalarImpl` on the AIV vector core.
 
@@ -52,7 +52,7 @@ enum class GatherOOB : uint8_t {
 - `Clamp`: `idx = min(idx, capacity - 1)` before access.
 - `Wrap`: `idx = idx % capacity` before access.
 - `Zero`: out-of-bounds destinations receive `static_cast<T>(0)`. In Row mode the OOB row is filled with `T(0)` (A2/A3 ND fills inline on the scalar pipe; A2/A3 NZ pre-zeros the whole tile once before the DMA loop; A5 SIMT does the substitution inline per lane). In Elem mode the OOB lane writes `T(0)` inline through the same store. All dtypes are supported under every `GatherOOB` value.
-- CPU simulator: bounds are **not** enforced regardless of the `Oob` parameter — out-of-range indices read whatever `table.data()[idx]` returns and are target-defined.
+- CPU simulator: models `GatherOOB` the same way as A5 — `Clamp`/`Wrap` remap the (uint32-cast) index, `Zero` writes `T(0)` for out-of-range, and only `Undefined` (the default) reads `table.data()[idx]` unchecked (target-defined).
 
 ## Assembly Syntax
 
@@ -98,11 +98,13 @@ Declared in `include/pto/common/pto_instr.hpp` (the shared dispatcher) and the p
 ### CPU Reference Form
 
 ```cpp
-template <typename TileDst, typename GlobalData, typename TileInd, typename... WaitEvents>
+template <Coalesce  Mode = Coalesce::Row,
+          GatherOOB Oob  = GatherOOB::Undefined,
+          typename TileDst, typename GlobalData, typename TileInd, typename... WaitEvents>
 PTO_INST RecordEvent MGATHER(TileDst &dst, GlobalData &src, TileInd &indexes, WaitEvents &... events);
 ```
 
-The CPU form has no `Coalesce` or `GatherOOB` template parameter. The implementation always walks `validRow × validCol` and reads `src.data()[indexes.data()[idxOff]]` — this matches `Coalesce::Elem` semantics regardless of the index tile shape. Bounds are not enforced. The signature exists so the same source builds without modification against the CPU simulator headers.
+The CPU form mirrors the A5 signature and defaults, so a non-templated `MGATHER(dst, src, idx)` resolves to `Coalesce::Row` on both sim and hardware and one kernel source validates against one golden. Row mode reads `src[idx[r], :]` into `dst[r, :]` with `tableRows = Shape[3]` and row stride `Shape[4]`; Elem mode walks `validRow × validCol` and reads `dst[i, j] = src[idx[i, j]]`. `GatherOOB` is modeled the same way as hardware: `Clamp`/`Wrap` remap the (uint32-cast) index, `Zero` writes a zero element for out-of-range, and `Undefined` reads unchecked.
 
 ### A2/A3 Form
 
@@ -183,9 +185,8 @@ The constraints below are split into target-specific sections so each backend li
 
 **Index interpretation:**
 
-- Index interpretation is target-defined. The CPU simulator treats indices as **linear element indices into `src.data()`** and writes `dst.data()[dstOff] = src.data()[idx]` for every `(r, c)` in the destination valid region — equivalent to `Coalesce::Elem` semantics, regardless of the index tile shape.
-- The CPU simulator does not enforce bounds checks on `indexes`. Out-of-range indices read whatever `src.data() + idx` returns and are target-defined.
-- The simulator does **not** model the `Coalesce` or `GatherOOB` template parameters at the CPU intrinsic surface; out-of-bounds handling is the caller's responsibility on CPU.
+- Index interpretation follows the `Coalesce` mode, with the same `Coalesce::Row` default as hardware. `Row` treats `idx[r]` as a logical row index into a `[TableRows, Shape[4]]` table; `Elem` treats `idx[i, j]` as a **linear element index into `src.data()`**.
+- The CPU simulator models `GatherOOB`: `Clamp`/`Wrap` remap the index, `Zero` writes `T(0)` for out-of-range, and `Undefined` (the default) reads `src.data()[idx]` unchecked (target-defined). Indices are cast to `uint32_t` first, so negative indices resolve as large values.
 
 **Header-level enforcement.** The CPU header (`include/pto/cpu/MGatherScatter.hpp`) static-asserts only the minimum closure rules: `std::is_integral_v<TileInd::DType>` for the index dtype and `sizeof(TileDst::DType) == sizeof(GlobalData::DType)` for byte-wise compatibility. The dtype / shape / layout constraints above are the **PTO ABI contract** — callers are expected to honor them so the same kernel source compiles and runs unmodified against the A2/A3 and A5 backends.
 
@@ -296,7 +297,7 @@ A5:
   Coalesce::Elem : (Idx.ValidRow == Dst.ValidRow) && (Idx.ValidCol == Dst.ValidCol)
 ```
 
-On the CPU reference path, no mode parameter exists; the implementation always walks element-wise.
+The CPU reference path enforces the same A5 Row rule (`[1, R]` or `[R, 1]` index valid shape) when valid shapes are statically known; Elem walks element-wise over the destination valid region.
 
 ## Layout Support
 
@@ -306,7 +307,7 @@ UB addressing is computed from each tile's `Rows` / `Cols` plus (on A2/A3 NZ) an
 |---------------|-----|-------|----|
 | `TileDst` (UB) — ND | `BLayout::RowMajor + SLayout::NoneBox` only | `BLayout::RowMajor + SLayout::NoneBox` | `BLayout::RowMajor` or `ColMajor`, `SLayout::NoneBox` (Elem mode walks both via `tile_offset_2d`) |
 | `TileDst` (UB) — NZ | not supported | `BLayout::ColMajor + SLayout::RowMajor + SFractalSize == 512` (paired with NZ GM table) | **not supported** |
-| `TileIdx` (UB) — Row | row-major (Cols must equal 1 to match CPU's elementwise indexing) | `[1, R]` `BLayout::RowMajor + SLayout::NoneBox` (always ND, regardless of table layout) | `[1, R]` `RowMajor` **or** `[R, 1]` `ColMajor` (independent of GM table layout) |
+| `TileIdx` (UB) — Row | `[1, R]` or `[R, 1]` row-major (same valid-shape rule as A5) | `[1, R]` `BLayout::RowMajor + SLayout::NoneBox` (always ND, regardless of table layout) | `[1, R]` `RowMajor` **or** `[R, 1]` `ColMajor` (independent of GM table layout) |
 | `TileIdx` (UB) — Elem | `BLayout::RowMajor + SLayout::NoneBox` | `[R, C]` `BLayout::RowMajor + SLayout::NoneBox` | any `BLayout`, independent of `TileDst` (kernel reads through `tile_offset_2d<TileIdx>`) |
 | `GlobalTable` (GM) — ND | `Layout::ND` only | `Layout::ND` (linear contiguous addressing); 5-D `Shape<…, R, C>`; kernel uses `tableRowStride = GetStride(DIM_3)`, so stride-padded ND tables are supported | `Layout::ND` only; Row mode hard-wires `tableRowStride = validCols` and requires `Shape[4] == validCols` |
 | `GlobalTable` (GM) — NZ | not supported | `Layout::NZ`; 5-D `Shape<B, BCols, BRows, 16, C0>` with `staticShape[3] == 16` and `staticShape[4] == 32 / sizeof(T)` (`B` may be > 1; the kernel loops `for i in 0..gShape0`) | **not supported** |

--- a/docs/isa/tile/ops/memory-and-data-movement/mscatter.md
+++ b/docs/isa/tile/ops/memory-and-data-movement/mscatter.md
@@ -19,7 +19,7 @@ Write behaviour is controlled by orthogonal template policies:
 
 Per-target dispatch summary:
 
-- **CPU Simulator** — pure C++ reference. The implementation walks `validRow * validCol` with a plain sequential `for` loop in row-major order and writes `table[idx[i, j]] = src[i, j]` (Elem semantics). When multiple sources map to the same destination, the last writer in row-major iteration order wins. No atomic mode is exposed at the intrinsic surface.
+- **CPU Simulator** — pure C++ reference. Templates on the same `Coalesce` / `ScatterAtomicOp` / `ScatterOOB` / `ScatterConflict` parameters as A5, with the same defaults (`Row`, `None`, `Undefined`, `Last`), so a non-templated `MSCATTER(dst, src, idx)` means `Coalesce::Row` on sim exactly as on hardware. Row mode walks rows sequentially and copies `src[r, :]` to `table[idx[r], :]`; Elem mode walks `validRow * validCol` in row-major order and writes `table[idx[i, j]] = src[i, j]`. Atomic modes run the equivalent sequential read-modify-write; the last writer in iteration order wins for `ScatterAtomicOp::None`.
 - **A2/A3 VEC-CORE** — single-threaded scalar / MTE3 walk driven from the scalar pipe. Row mode issues one wide `copy_ubuf_to_gm_align_b*` DMA per row through `tablePtr + safeIdx * tableRowStride` (where `tableRowStride = table.GetStride(DIM_3)` and `tableRows = ∏ Shape[0..3]`); Elem mode performs a scalar UB→GM store per element (DMA bursts cannot satisfy per-element UB-source 32-byte alignment). Supports ND-GM with ND-UB **and** NZ-GM with NZ-UB tile pairs. Always "last write wins" for `ScatterAtomicOp::None`.
 - **A5 SIMT** — SIMT launch through `cce::async_invoke` with up to `dim3{32, 32}` (1024 threads). Row mode uses warp-parallel lane writes that the SIMT hardware coalesces into 128 B GM bursts when consecutive; Elem mode maps one lane to one element with per-lane scalar GM stores. The Row kernel computes `dstRow = table + safeIdx * validCols`, so the GM table is treated as **packed ND with row stride = `validCols`** — `MScatterCheck` enforces `GlobalTable::staticShape[4] == TileSrc::ValidCol` at compile time, and `tableRows = Shape[3]`. `Conflict::Last` is implemented as a slot-centric reverse scan (`last_owner_find_*`) so the result is deterministic and race-free. NZ block-stride layouts are not implemented on A5. The `(1, 1)` Elem case bypasses the SIMT launch and runs `MScatterScalarImpl` on the AIV vector core.
 
@@ -120,11 +120,15 @@ Declared in `include/pto/common/pto_instr.hpp` (the shared dispatcher) and the p
 ### CPU Reference Form
 
 ```cpp
-template <typename GlobalData, typename TileSrc, typename TileInd, typename... WaitEvents>
+template <Coalesce         Mode     = Coalesce::Row,
+          ScatterAtomicOp  Atomic   = ScatterAtomicOp::None,
+          ScatterOOB       Oob      = ScatterOOB::Undefined,
+          ScatterConflict  Conflict = ScatterConflict::Last,
+          typename GlobalData, typename TileSrc, typename TileInd, typename... WaitEvents>
 PTO_INST RecordEvent MSCATTER(GlobalData &dst, TileSrc &src, TileInd &indexes, WaitEvents &... events);
 ```
 
-The CPU form has no `Coalesce`, `ScatterAtomicOp`, `ScatterOOB`, or `ScatterConflict` template parameter. The implementation always walks `validRow × validCol` and writes `dst.data()[indexes.data()[idxOff]] = src.data()[srcOff]` — Elem semantics regardless of the index tile shape. Atomic is always plain replace; the last writer in row-major iteration order wins. Bounds are not enforced.
+The CPU form mirrors the A5 signature and defaults, so a non-templated `MSCATTER(dst, src, idx)` resolves to `Coalesce::Row` on both sim and hardware and one kernel source validates against one golden. Row mode copies `src[r, :]` to `table[idx[r], :]` with `tableRows = Shape[3]` and row stride `Shape[4]`; Elem mode walks `validRow × validCol` and writes `dst.data()[idx[i, j]] = src[i, j]`. `ScatterAtomicOp` and `ScatterOOB` are modeled with the equivalent sequential read-modify-write and index-resolution rules; conflicts always resolve as last-writer-wins in row-major iteration order (matches `Conflict::Last`). With `ScatterOOB::Undefined`, bounds are not enforced.
 
 ### A2/A3 Form
 
@@ -202,7 +206,7 @@ enum class ScatterConflict : uint8_t {  // A5 only
 | `Max`  | ABI contract: `int32_t` or `float` (simulator runs plain replace) | unsupported (rejected at compile time by `MScatterCheck`) | `int32_t`, `uint32_t`, `float` (SIMT `atomicMax`) |
 | `Min`  | ABI contract: `int32_t` or `float` (simulator runs plain replace) | unsupported (rejected at compile time by `MScatterCheck`) | `int32_t`, `uint32_t`, `float` (SIMT `atomicMin`) |
 
-A2/A3 `Max` / `Min` would need a hardware atomic-max/min unit on the MTE3 path that the SoC does not provide; `MScatterCheck` static-asserts reject them. The CPU simulator's `MSCATTER` does not template on `ScatterAtomicOp` — the contract column above is what callers must honor at the source level so the same kernel still compiles and behaves correctly when the same source is built against A2/A3 or A5.
+A2/A3 `Max` / `Min` would need a hardware atomic-max/min unit on the MTE3 path that the SoC does not provide; `MScatterCheck` static-asserts reject them. The CPU simulator templates on `ScatterAtomicOp` and models `Add` / `Max` / `Min` with sequential read-modify-write for any arithmetic dtype — the contract column above is what callers must honor at the source level so the same kernel still compiles and behaves correctly when built against A2/A3 or A5.
 
 ## Constraints
 
@@ -239,9 +243,9 @@ The constraints below are split into target-specific sections so each backend li
 
 **Index interpretation:**
 
-- Index interpretation is target-defined. The CPU simulator treats indices as **linear element indices into `dst.data()`** and writes `dst.data()[idx] = src.data()[srcOff]` for every `(r, c)` in the source valid region — equivalent to `Coalesce::Elem` semantics, regardless of the index tile shape.
-- The CPU simulator does not enforce bounds checks on `indexes`. Out-of-range indices write to whatever GM address `dst.data() + idx` resolves to and are target-defined.
-- The simulator does **not** model `ScatterAtomicOp`, `ScatterOOB`, or `ScatterConflict` template parameters; the implementation always does plain replace, with "last writer in row-major iteration order wins" as the conflict policy.
+- Index interpretation follows the `Coalesce` mode, with the same `Coalesce::Row` default as hardware. `Row` treats `idx[r]` as a logical row index into a `[TableRows, Shape[4]]` table; `Elem` treats `idx[i, j]` as a **linear element index into `dst.data()`**.
+- With `ScatterOOB::Undefined` (the default) the simulator does not enforce bounds checks on `indexes`; out-of-range indices write to whatever GM address resolves and are target-defined. `Skip` / `Clamp` / `Wrap` are modeled the same way as hardware (indices are cast to `uint32_t` first, so negative indices resolve as large values).
+- `ScatterConflict` is accepted but conflicts always resolve as last-writer-wins in row-major iteration order (matches `Conflict::Last`).
 
 **Header-level enforcement.** The CPU header (`include/pto/cpu/MGatherScatter.hpp`) static-asserts only the minimum closure rules: `std::is_integral_v<TileInd::DType>` for the index dtype and `sizeof(TileSrc::DType) == sizeof(GlobalData::DType)` for byte-wise compatibility. The dtype / shape / atomic / layout constraints above are the **PTO ABI contract** — callers are expected to honor them so the same kernel source compiles and runs unmodified against the A2/A3 and A5 backends.
 
@@ -365,7 +369,7 @@ A5:
   Coalesce::Elem : (Idx.ValidRow == Src.ValidRow) && (Idx.ValidCol == Src.ValidCol)
 ```
 
-On the CPU reference path, no mode parameter exists; the implementation always walks element-wise.
+The CPU reference path enforces the same A5 Row rule (`[1, R]` or `[R, 1]` index valid shape) when valid shapes are statically known; Elem walks element-wise over the source valid region.
 
 ## Layout Support
 
@@ -375,7 +379,7 @@ UB addressing is computed from each tile's `Rows` / `Cols` plus (on A2/A3 NZ) an
 |---------------|-----|-------|----|
 | `TileSrc` (UB) — ND | `BLayout::RowMajor + SLayout::NoneBox` only | `BLayout::RowMajor + SLayout::NoneBox` | `BLayout::RowMajor` or `ColMajor`, `SLayout::NoneBox` (Elem mode walks both via `tile_offset_2d`) |
 | `TileSrc` (UB) — NZ | not supported | `BLayout::ColMajor + SLayout::RowMajor + SFractalSize == 512` (paired with NZ GM table) | **not supported** |
-| `TileIdx` (UB) — Row | row-major (Cols must equal 1 to match CPU's elementwise indexing) | `[1, R]` `BLayout::RowMajor + SLayout::NoneBox` (always ND, regardless of table layout) | `[1, R]` `RowMajor` **or** `[R, 1]` `ColMajor` (independent of GM table layout) |
+| `TileIdx` (UB) — Row | `[1, R]` or `[R, 1]` row-major (same valid-shape rule as A5) | `[1, R]` `BLayout::RowMajor + SLayout::NoneBox` (always ND, regardless of table layout) | `[1, R]` `RowMajor` **or** `[R, 1]` `ColMajor` (independent of GM table layout) |
 | `TileIdx` (UB) — Elem | `BLayout::RowMajor + SLayout::NoneBox` | `[R, C]` `BLayout::RowMajor + SLayout::NoneBox` | any `BLayout`, independent of `TileSrc` (kernel reads through `tile_offset_2d<TileIdx>`) |
 | `GlobalTable` (GM) — ND | `Layout::ND` only | `Layout::ND` (linear contiguous addressing); 5-D `Shape<…, R, C>`; kernel uses `tableRowStride = GetStride(DIM_3)`, so stride-padded ND tables are supported | `Layout::ND` only; Row mode hard-wires `tableRowStride = validCols` and requires `Shape[4] == validCols` |
 | `GlobalTable` (GM) — NZ | not supported | `Layout::NZ`; 5-D `Shape<B, BCols, BRows, 16, C0>` with `staticShape[3] == 16` and `staticShape[4] == 32 / sizeof(T)` (`B` may be > 1; the kernel loops `for i in 0..gShape0`) | **not supported** |

--- a/include/pto/common/pto_instr.hpp
+++ b/include/pto/common/pto_instr.hpp
@@ -1913,7 +1913,7 @@ PTO_INST RecordEvent MGATHER(TileDst &dst, GlobalData &src, TileInd &indexes, Wa
     return {};
 }
 
-#ifdef PTO_NPU_ARCH_A5
+#if defined(PTO_NPU_ARCH_A5) || defined(__CPU_SIM)
 template <Coalesce CMode, typename TileDst, typename GlobalData, typename TileInd, typename... WaitEvents>
 PTO_INST RecordEvent MGATHER(TileDst &dst, GlobalData &src, TileInd &indexes, WaitEvents &...events)
 {
@@ -1940,7 +1940,7 @@ PTO_INST RecordEvent MSCATTER(GlobalData &dst, TileSrc &src, TileInd &indexes, W
     return {};
 }
 
-#ifdef PTO_NPU_ARCH_A5
+#if defined(PTO_NPU_ARCH_A5) || defined(__CPU_SIM)
 template <Coalesce Mode, typename GlobalData, typename TileSrc, typename TileInd, typename... WaitEvents>
 PTO_INST RecordEvent MSCATTER(GlobalData &dst, TileSrc &src, TileInd &indexes, WaitEvents &...events)
 {

--- a/include/pto/cpu/MGatherScatter.hpp
+++ b/include/pto/cpu/MGatherScatter.hpp
@@ -18,7 +18,49 @@ See LICENSE in the root of the software repository for the full text of the Lice
 
 namespace pto {
 
-template <typename TileDst, typename GlobalData, typename TileInd>
+enum class GatherOOB : uint8_t
+{
+    Undefined = 0,
+    Clamp = 1,
+    Wrap = 2,
+    Zero = 3
+};
+
+#ifndef PTO_COALESCE_ENUM_DEFINED
+#define PTO_COALESCE_ENUM_DEFINED
+enum class Coalesce : uint8_t
+{
+    Row = 0,
+    Elem = 1
+};
+#endif
+
+// Resolve a gather index against the table capacity; returns false when the element must be zeroed
+// (out-of-range in Zero mode, or a degenerate empty table). `cap` mirrors the A5 uint32 surface.
+template <GatherOOB Oob>
+PTO_INTERNAL bool GatherResolveIdx(uint32_t raw, uint32_t cap, uint32_t &safe)
+{
+    if (cap == 0u) { // empty table: no element to read (% and cap-1 would be UB) -> caller writes zero
+        safe = 0u;
+        return false;
+    }
+    if constexpr (Oob == GatherOOB::Clamp) {
+        safe = (raw >= cap) ? (cap - 1u) : raw;
+        return true;
+    } else if constexpr (Oob == GatherOOB::Wrap) {
+        safe = raw % cap;
+        return true;
+    } else if constexpr (Oob == GatherOOB::Zero) {
+        safe = raw;
+        return raw < cap;
+    } else {
+        safe = raw;
+        return true;
+    }
+}
+
+template <Coalesce Mode = Coalesce::Row, GatherOOB Oob = GatherOOB::Undefined, typename TileDst, typename GlobalData,
+          typename TileInd>
 PTO_INTERNAL void MGATHER_IMPL(TileDst &dst, GlobalData &src, TileInd &indexes)
 {
     using IndexT = typename TileInd::DType;
@@ -33,17 +75,117 @@ PTO_INTERNAL void MGATHER_IMPL(TileDst &dst, GlobalData &src, TileInd &indexes)
     }
 
     auto *base = src.data();
-    cpu::parallel_for_rows(validRow, validCol, [&](std::size_t i) {
-        for (std::size_t j = 0; j < validCol; ++j) {
-            const size_t dstOff = GetTileElementOffset<TileDst>(i, j);
-            const size_t idxOff = GetTileElementOffset<TileInd>(i, j);
-            const auto idx = static_cast<size_t>(indexes.data()[idxOff]);
-            dst.data()[dstOff] = base[idx];
+    if constexpr (Mode == Coalesce::Row) {
+        constexpr int kIdxValidR = TileInd::ValidRow;
+        constexpr int kIdxValidC = TileInd::ValidCol;
+        if constexpr (TileDst::ValidRow > 0 && kIdxValidR > 0 && kIdxValidC > 0) {
+            static_assert((kIdxValidR == 1 && kIdxValidC == TileDst::ValidRow) ||
+                              (kIdxValidC == 1 && kIdxValidR == TileDst::ValidRow),
+                          "MGATHER Coalesce::Row requires index tile valid shape [1, R] or [R, 1] matching "
+                          "TileDst::ValidRow.");
         }
-    });
+        const bool idxColumn = (indexes.GetValidCol() == 1);
+        const uint32_t tableRows = static_cast<uint32_t>(src.GetShape(GlobalTensorDim::DIM_3));
+        const size_t tableCols = static_cast<size_t>(src.GetShape(GlobalTensorDim::DIM_4));
+        cpu::parallel_for_rows(validRow, validCol, [&](std::size_t i) {
+            const size_t idxOff = idxColumn ? GetTileElementOffset<TileInd>(i, 0) : GetTileElementOffset<TileInd>(0, i);
+            const auto raw = static_cast<uint32_t>(indexes.data()[idxOff]);
+            uint32_t safe;
+            const bool doRead = GatherResolveIdx<Oob>(raw, tableRows, safe);
+            for (std::size_t j = 0; j < validCol; ++j) {
+                const size_t dstOff = GetTileElementOffset<TileDst>(i, j);
+                dst.data()[dstOff] =
+                    doRead ? base[static_cast<size_t>(safe) * tableCols + j] : typename TileDst::DType{};
+            }
+        });
+    } else {
+        const uint32_t tableSize =
+            static_cast<uint32_t>(src.GetShape(GlobalTensorDim::DIM_0) * src.GetShape(GlobalTensorDim::DIM_1) *
+                                  src.GetShape(GlobalTensorDim::DIM_2) * src.GetShape(GlobalTensorDim::DIM_3) *
+                                  src.GetShape(GlobalTensorDim::DIM_4));
+        cpu::parallel_for_rows(validRow, validCol, [&](std::size_t i) {
+            for (std::size_t j = 0; j < validCol; ++j) {
+                const size_t dstOff = GetTileElementOffset<TileDst>(i, j);
+                const size_t idxOff = GetTileElementOffset<TileInd>(i, j);
+                const auto raw = static_cast<uint32_t>(indexes.data()[idxOff]);
+                uint32_t safe;
+                const bool doRead = GatherResolveIdx<Oob>(raw, tableSize, safe);
+                dst.data()[dstOff] = doRead ? base[safe] : typename TileDst::DType{};
+            }
+        });
+    }
 }
 
-template <typename GlobalData, typename TileSrc, typename TileInd>
+enum class ScatterAtomicOp : uint8_t
+{
+    None = 0,
+    Add = 1,
+    Max = 2,
+    Min = 3
+};
+
+enum class ScatterOOB : uint8_t
+{
+    Undefined = 0,
+    Skip = 1,
+    Clamp = 2,
+    Wrap = 3
+};
+
+enum class ScatterConflict : uint8_t
+{
+    Last = 0,
+    Default = 1
+};
+
+#ifndef PTO_COALESCE_ENUM_DEFINED
+#define PTO_COALESCE_ENUM_DEFINED
+enum class Coalesce : uint8_t
+{
+    Row = 0,
+    Elem = 1
+};
+#endif
+
+template <ScatterOOB Oob>
+PTO_INTERNAL bool ScatterResolveIdx(uint32_t raw, uint32_t limit, uint32_t &safe)
+{
+    if (limit == 0u) { // empty table: nothing addressable (% and limit-1 would be UB) -> caller skips the write
+        safe = 0u;
+        return false;
+    }
+    if constexpr (Oob == ScatterOOB::Skip) {
+        safe = raw;
+        return raw < limit;
+    } else if constexpr (Oob == ScatterOOB::Clamp) {
+        safe = (raw >= limit) ? (limit - 1u) : raw;
+        return true;
+    } else if constexpr (Oob == ScatterOOB::Wrap) {
+        safe = raw % limit;
+        return true;
+    } else {
+        safe = raw;
+        return true;
+    }
+}
+
+template <ScatterAtomicOp Atomic, typename T>
+PTO_INTERNAL void ScatterWrite(T &dst, T val)
+{
+    if constexpr (Atomic == ScatterAtomicOp::Add) {
+        dst = static_cast<T>(dst + val);
+    } else if constexpr (Atomic == ScatterAtomicOp::Max) {
+        dst = (dst < val) ? val : dst;
+    } else if constexpr (Atomic == ScatterAtomicOp::Min) {
+        dst = (val < dst) ? val : dst;
+    } else {
+        dst = val;
+    }
+}
+
+template <Coalesce Mode = Coalesce::Row, ScatterAtomicOp Atomic = ScatterAtomicOp::None,
+          ScatterOOB Oob = ScatterOOB::Undefined, ScatterConflict Conflict = ScatterConflict::Last, typename GlobalData,
+          typename TileSrc, typename TileInd>
 PTO_INTERNAL void MSCATTER_IMPL(GlobalData &dst, TileSrc &src, TileInd &indexes)
 {
     using IndexT = typename TileInd::DType;
@@ -58,12 +200,46 @@ PTO_INTERNAL void MSCATTER_IMPL(GlobalData &dst, TileSrc &src, TileInd &indexes)
     }
 
     auto *base = dst.data();
-    for (unsigned i = 0; i < validRow; ++i) {
-        for (unsigned j = 0; j < validCol; ++j) {
-            const size_t srcOff = GetTileElementOffset<TileSrc>(i, j);
-            const size_t idxOff = GetTileElementOffset<TileInd>(i, j);
-            const auto idx = static_cast<size_t>(indexes.data()[idxOff]);
-            base[idx] = src.data()[srcOff];
+    if constexpr (Mode == Coalesce::Row) {
+        constexpr int kIdxValidR = TileInd::ValidRow;
+        constexpr int kIdxValidC = TileInd::ValidCol;
+        if constexpr (TileSrc::ValidRow > 0 && kIdxValidR > 0 && kIdxValidC > 0) {
+            static_assert((kIdxValidR == 1 && kIdxValidC == TileSrc::ValidRow) ||
+                              (kIdxValidC == 1 && kIdxValidR == TileSrc::ValidRow),
+                          "MSCATTER Coalesce::Row requires index tile valid shape [1, R] or [R, 1] matching "
+                          "TileSrc::ValidRow.");
+        }
+        const bool idxColumn = (indexes.GetValidCol() == 1);
+        const uint32_t tableRows = static_cast<uint32_t>(dst.GetShape(GlobalTensorDim::DIM_3));
+        const size_t tableCols = static_cast<size_t>(dst.GetShape(GlobalTensorDim::DIM_4));
+        for (unsigned i = 0; i < validRow; ++i) {
+            const size_t idxOff = idxColumn ? GetTileElementOffset<TileInd>(i, 0) : GetTileElementOffset<TileInd>(0, i);
+            const auto raw = static_cast<uint32_t>(indexes.data()[idxOff]);
+            uint32_t safe;
+            if (!ScatterResolveIdx<Oob>(raw, tableRows, safe)) {
+                continue;
+            }
+            for (unsigned j = 0; j < validCol; ++j) {
+                const size_t srcOff = GetTileElementOffset<TileSrc>(i, j);
+                ScatterWrite<Atomic>(base[static_cast<size_t>(safe) * tableCols + j], src.data()[srcOff]);
+            }
+        }
+    } else {
+        const uint32_t tableSize =
+            static_cast<uint32_t>(dst.GetShape(GlobalTensorDim::DIM_0) * dst.GetShape(GlobalTensorDim::DIM_1) *
+                                  dst.GetShape(GlobalTensorDim::DIM_2) * dst.GetShape(GlobalTensorDim::DIM_3) *
+                                  dst.GetShape(GlobalTensorDim::DIM_4));
+        for (unsigned i = 0; i < validRow; ++i) {
+            for (unsigned j = 0; j < validCol; ++j) {
+                const size_t srcOff = GetTileElementOffset<TileSrc>(i, j);
+                const size_t idxOff = GetTileElementOffset<TileInd>(i, j);
+                const auto raw = static_cast<uint32_t>(indexes.data()[idxOff]);
+                uint32_t safe;
+                if (!ScatterResolveIdx<Oob>(raw, tableSize, safe)) {
+                    continue;
+                }
+                ScatterWrite<Atomic>(base[safe], src.data()[srcOff]);
+            }
         }
     }
 }

--- a/tests/cpu/st/testcase/hashfind/hashfind_kernel.cpp
+++ b/tests/cpu/st/testcase/hashfind/hashfind_kernel.cpp
@@ -103,8 +103,8 @@ AICORE void runHashFind(__gm__ int32_t __out__ *out, __gm__ int32_t __in__ *tabl
         TADDS(idxTile, idxTile, static_cast<uint32_t>(probe));
         TANDS(idxTile, idxTile, mask);
 
-        MGATHER(keyTile, keysGlobal, idxTile);
-        MGATHER(valTile, valsGlobal, idxTile);
+        MGATHER<Coalesce::Elem>(keyTile, keysGlobal, idxTile);
+        MGATHER<Coalesce::Elem>(valTile, valsGlobal, idxTile);
 
         // match = (key == query), empty = (key == empty_key)
         TCMP(matchTile, keyTile, qTile, CmpMode::EQ);

--- a/tests/cpu/st/testcase/mgather/gen_data.py
+++ b/tests/cpu/st/testcase/mgather/gen_data.py
@@ -30,6 +30,21 @@ def gen_case(case_dir: str, tile_rows: int, tile_cols: int, src_len: int):
     os.chdir("..")
 
 
+def gen_row_case(case_dir: str, tile_rows: int, tile_cols: int, table_rows: int):
+    os.makedirs(case_dir, exist_ok=True)
+    os.chdir(case_dir)
+
+    src = np.random.uniform(low=-8, high=8, size=[table_rows, tile_cols]).astype(np.float32)
+    idx = np.random.randint(0, table_rows, size=[tile_rows]).astype(np.uint32)
+    out = src[idx].astype(np.float32)  # dst[r, :] = src[idx[r], :]
+
+    src.tofile("input1.bin")
+    idx.tofile("input2.bin")
+    out.tofile("golden.bin")
+    os.chdir("..")
+
+
 if __name__ == "__main__":
     gen_case("MGATHERTest.case_float_16x16_src512", 16, 16, 512)
-
+    gen_row_case("MGATHERTest.case_float_row_default_table32x16_dst16x16", 16, 16, 32)
+    gen_row_case("MGATHERTest.case_float_row_explicit_table32x16_dst16x16", 16, 16, 32)

--- a/tests/cpu/st/testcase/mgather/main.cpp
+++ b/tests/cpu/st/testcase/mgather/main.cpp
@@ -34,11 +34,14 @@ std::string GetGoldenDir()
 template <int kTileRows, int kTileCols, int kSrcLen>
 void LaunchMGather(float *out, float *src, uint32_t *idx, void *stream);
 
-template <int kTileRows, int kTileCols, int kSrcLen>
-void test_mgather()
+template <int kTileRows, int kTileCols, int kTableRows, bool kExplicitRow>
+void LaunchMGatherRow(float *out, float *src, uint32_t *idx, void *stream);
+
+template <int kTileRows, int kTileCols, int kSrcElems, int kIdxCount>
+void test_mgather_common(void (*launch)(float *, float *, uint32_t *, void *))
 {
-    const size_t srcBytes = kSrcLen * sizeof(float);
-    const size_t idxBytes = kTileRows * kTileCols * sizeof(uint32_t);
+    const size_t srcBytes = kSrcElems * sizeof(float);
+    const size_t idxBytes = kIdxCount * sizeof(uint32_t);
     const size_t outBytes = kTileRows * kTileCols * sizeof(float);
 
     aclInit(nullptr);
@@ -67,7 +70,7 @@ void test_mgather()
     aclrtMemcpy(srcDevice, srcBytes, srcHost, srcBytes, ACL_MEMCPY_HOST_TO_DEVICE);
     aclrtMemcpy(idxDevice, idxBytes, idxHost, idxBytes, ACL_MEMCPY_HOST_TO_DEVICE);
 
-    LaunchMGather<kTileRows, kTileCols, kSrcLen>(outDevice, srcDevice, idxDevice, stream);
+    launch(outDevice, srcDevice, idxDevice, stream);
 
     aclrtSynchronizeStream(stream);
     aclrtMemcpy(outHost, outBytes, outDevice, outBytes, ACL_MEMCPY_DEVICE_TO_HOST);
@@ -94,5 +97,15 @@ void test_mgather()
 
 TEST_F(MGATHERTest, case_float_16x16_src512)
 {
-    test_mgather<16, 16, 512>();
+    test_mgather_common<16, 16, 512, 16 * 16>(LaunchMGather<16, 16, 512>);
+}
+
+TEST_F(MGATHERTest, case_float_row_default_table32x16_dst16x16)
+{
+    test_mgather_common<16, 16, 32 * 16, 16>(LaunchMGatherRow<16, 16, 32, false>);
+}
+
+TEST_F(MGATHERTest, case_float_row_explicit_table32x16_dst16x16)
+{
+    test_mgather_common<16, 16, 32 * 16, 16>(LaunchMGatherRow<16, 16, 32, true>);
 }

--- a/tests/cpu/st/testcase/mgather/mgather_kernel.cpp
+++ b/tests/cpu/st/testcase/mgather/mgather_kernel.cpp
@@ -37,7 +37,44 @@ AICORE void runMGather(__gm__ float __out__ *out, __gm__ float __in__ *src, __gm
     TASSIGN(idxTile, 0);
     TASSIGN(outTile, kTileRows * kTileCols * sizeof(typename IdxT::DType));
     TLOAD(idxTile, idxGlobal);
-    MGATHER(outTile, srcGlobal, idxTile);
+    MGATHER<Coalesce::Elem>(outTile, srcGlobal, idxTile);
+    TSTORE(outGlobal, outTile);
+    out = outGlobal.data();
+}
+
+template <int kTileRows, int kTileCols, int kTableRows, bool kExplicitRow>
+AICORE void runMGatherRow(__gm__ float __out__ *out, __gm__ float __in__ *src, __gm__ uint32_t __in__ *idx)
+{
+    using TileT = Tile<TileType::Vec, float, kTileRows, kTileCols, BLayout::RowMajor, -1, -1>;
+    using IdxT = Tile<TileType::Vec, uint32_t, 1, kTileRows, BLayout::RowMajor, -1, -1>;
+
+    using SrcShape = Shape<1, 1, 1, kTableRows, kTileCols>;
+    using SrcStride = Stride<1, 1, 1, kTileCols, 1>;
+    using SrcGT = GlobalTensor<float, SrcShape, SrcStride>;
+
+    using TileShape = Shape<1, 1, 1, kTileRows, kTileCols>;
+    using TileStride = Stride<1, 1, 1, kTileCols, 1>;
+    using TileGTf = GlobalTensor<float, TileShape, TileStride>;
+
+    using IdxShape = Shape<1, 1, 1, 1, kTileRows>;
+    using IdxStride = Stride<1, 1, 1, kTileRows, 1>;
+    using IdxGT = GlobalTensor<uint32_t, IdxShape, IdxStride>;
+
+    SrcGT srcGlobal(src);
+    TileGTf outGlobal(out);
+    IdxGT idxGlobal(idx);
+
+    TileT outTile(kTileRows, kTileCols);
+    IdxT idxTile(1, kTileRows);
+
+    TASSIGN(idxTile, 0);
+    TASSIGN(outTile, kTileRows * sizeof(typename IdxT::DType));
+    TLOAD(idxTile, idxGlobal);
+    if constexpr (kExplicitRow) {
+        MGATHER<Coalesce::Row>(outTile, srcGlobal, idxTile);
+    } else {
+        MGATHER(outTile, srcGlobal, idxTile); // non-templated default must match hardware: Coalesce::Row
+    }
     TSTORE(outGlobal, outTile);
     out = outGlobal.data();
 }
@@ -48,4 +85,12 @@ void LaunchMGather(float *out, float *src, uint32_t *idx, void *stream)
     runMGather<kTileRows, kTileCols, kSrcLen>(out, src, idx);
 }
 
+template <int kTileRows, int kTileCols, int kTableRows, bool kExplicitRow>
+void LaunchMGatherRow(float *out, float *src, uint32_t *idx, void *stream)
+{
+    runMGatherRow<kTileRows, kTileCols, kTableRows, kExplicitRow>(out, src, idx);
+}
+
 template void LaunchMGather<16, 16, 512>(float *out, float *src, uint32_t *idx, void *stream);
+template void LaunchMGatherRow<16, 16, 32, false>(float *out, float *src, uint32_t *idx, void *stream);
+template void LaunchMGatherRow<16, 16, 32, true>(float *out, float *src, uint32_t *idx, void *stream);

--- a/tests/cpu/st/testcase/mscatter/gen_data.py
+++ b/tests/cpu/st/testcase/mscatter/gen_data.py
@@ -36,6 +36,26 @@ def gen_case(case_dir: str, tile_rows: int, tile_cols: int, dst_len: int):
     os.chdir("..")
 
 
+def gen_row_case(case_dir: str, tile_rows: int, tile_cols: int, table_rows: int):
+    os.makedirs(case_dir, exist_ok=True)
+    os.chdir(case_dir)
+
+    dst_init = np.random.uniform(low=-2, high=2, size=[table_rows, tile_cols]).astype(np.float32)
+    src = np.random.uniform(low=-4, high=4, size=[tile_rows, tile_cols]).astype(np.float32)
+    idx = np.random.randint(0, table_rows, size=[tile_rows, 1]).astype(np.uint32)
+
+    golden = dst_init.copy()
+    for i in range(tile_rows):
+        golden[idx[i, 0], :] = src[i, :]
+
+    dst_init.tofile("input1.bin")
+    src.tofile("input2.bin")
+    idx.tofile("input3.bin")
+    golden.tofile("golden.bin")
+    os.chdir("..")
+
+
 if __name__ == "__main__":
     gen_case("MSCATTERTest.case_float_dst512_src16x16", 16, 16, 512)
-
+    gen_row_case("MSCATTERTest.case_float_row_default_table32x16_src16x16", 16, 16, 32)
+    gen_row_case("MSCATTERTest.case_float_row_explicit_table32x16_src16x16", 16, 16, 32)

--- a/tests/cpu/st/testcase/mscatter/main.cpp
+++ b/tests/cpu/st/testcase/mscatter/main.cpp
@@ -34,12 +34,15 @@ std::string GetGoldenDir()
 template <int kTileRows, int kTileCols, int kDstLen>
 void LaunchMScatter(float *out, float *srcTile, uint32_t *idx, void *stream);
 
-template <int kTileRows, int kTileCols, int kDstLen>
-void test_mscatter()
+template <int kTileRows, int kTileCols, int kTableRows, bool kExplicitRow>
+void LaunchMScatterRow(float *out, float *srcTile, uint32_t *idx, void *stream);
+
+template <int kTileRows, int kTileCols, int kDstLen, int kIdxCount>
+void test_mscatter_common(void (*launch)(float *, float *, uint32_t *, void *))
 {
     const size_t dstBytes = kDstLen * sizeof(float);
     const size_t srcBytes = kTileRows * kTileCols * sizeof(float);
-    const size_t idxBytes = kTileRows * kTileCols * sizeof(uint32_t);
+    const size_t idxBytes = kIdxCount * sizeof(uint32_t);
 
     aclInit(nullptr);
     aclrtSetDevice(0);
@@ -70,7 +73,7 @@ void test_mscatter()
     aclrtMemcpy(srcDevice, srcBytes, srcHost, srcBytes, ACL_MEMCPY_HOST_TO_DEVICE);
     aclrtMemcpy(idxDevice, idxBytes, idxHost, idxBytes, ACL_MEMCPY_HOST_TO_DEVICE);
 
-    LaunchMScatter<kTileRows, kTileCols, kDstLen>(dstDevice, srcDevice, idxDevice, stream);
+    launch(dstDevice, srcDevice, idxDevice, stream);
 
     aclrtSynchronizeStream(stream);
     aclrtMemcpy(dstHost, dstBytes, dstDevice, dstBytes, ACL_MEMCPY_DEVICE_TO_HOST);
@@ -97,5 +100,15 @@ void test_mscatter()
 
 TEST_F(MSCATTERTest, case_float_dst512_src16x16)
 {
-    test_mscatter<16, 16, 512>();
+    test_mscatter_common<16, 16, 512, 16 * 16>(LaunchMScatter<16, 16, 512>);
+}
+
+TEST_F(MSCATTERTest, case_float_row_default_table32x16_src16x16)
+{
+    test_mscatter_common<16, 16, 32 * 16, 16>(LaunchMScatterRow<16, 16, 32, false>);
+}
+
+TEST_F(MSCATTERTest, case_float_row_explicit_table32x16_src16x16)
+{
+    test_mscatter_common<16, 16, 32 * 16, 16>(LaunchMScatterRow<16, 16, 32, true>);
 }

--- a/tests/cpu/st/testcase/mscatter/mscatter_kernel.cpp
+++ b/tests/cpu/st/testcase/mscatter/mscatter_kernel.cpp
@@ -39,7 +39,45 @@ AICORE void runMScatter(__gm__ float __out__ *dst, __gm__ float __in__ *srcTile,
 
     TLOAD(src, srcGlobal);
     TLOAD(indexes, idxGlobal);
-    MSCATTER(dstGlobal, src, indexes);
+    MSCATTER<Coalesce::Elem>(dstGlobal, src, indexes);
+    dst = dstGlobal.data();
+}
+
+template <int kTileRows, int kTileCols, int kTableRows, bool kExplicitRow>
+AICORE void runMScatterRow(__gm__ float __out__ *dst, __gm__ float __in__ *srcTile, __gm__ uint32_t __in__ *idx)
+{
+    using TileT = Tile<TileType::Vec, float, kTileRows, kTileCols, BLayout::RowMajor, -1, -1>;
+    using IdxT = Tile<TileType::Vec, uint32_t, 1, kTileRows, BLayout::RowMajor, -1, -1>;
+
+    using DstShape = Shape<1, 1, 1, kTableRows, kTileCols>;
+    using DstStride = Stride<1, 1, 1, kTileCols, 1>;
+    using DstGT = GlobalTensor<float, DstShape, DstStride>;
+
+    using TileShape = Shape<1, 1, 1, kTileRows, kTileCols>;
+    using TileStride = Stride<1, 1, 1, kTileCols, 1>;
+    using TileGTf = GlobalTensor<float, TileShape, TileStride>;
+
+    using IdxShape = Shape<1, 1, 1, 1, kTileRows>;
+    using IdxStride = Stride<1, 1, 1, kTileRows, 1>;
+    using IdxGT = GlobalTensor<uint32_t, IdxShape, IdxStride>;
+
+    DstGT dstGlobal(dst);
+    TileGTf srcGlobal(srcTile);
+    IdxGT idxGlobal(idx);
+
+    TileT src(kTileRows, kTileCols);
+    IdxT indexes(1, kTileRows);
+
+    TASSIGN(src, 0);
+    TASSIGN(indexes, kTileRows * kTileCols * sizeof(typename TileT::DType));
+
+    TLOAD(src, srcGlobal);
+    TLOAD(indexes, idxGlobal);
+    if constexpr (kExplicitRow) {
+        MSCATTER<Coalesce::Row>(dstGlobal, src, indexes);
+    } else {
+        MSCATTER(dstGlobal, src, indexes); // non-templated default must match hardware: Coalesce::Row
+    }
     dst = dstGlobal.data();
 }
 
@@ -49,4 +87,12 @@ void LaunchMScatter(float *out, float *srcTile, uint32_t *idx, void *stream)
     runMScatter<kTileRows, kTileCols, kDstLen>(out, srcTile, idx);
 }
 
+template <int kTileRows, int kTileCols, int kTableRows, bool kExplicitRow>
+void LaunchMScatterRow(float *out, float *srcTile, uint32_t *idx, void *stream)
+{
+    runMScatterRow<kTileRows, kTileCols, kTableRows, kExplicitRow>(out, srcTile, idx);
+}
+
 template void LaunchMScatter<16, 16, 512>(float *out, float *srcTile, uint32_t *idx, void *stream);
+template void LaunchMScatterRow<16, 16, 32, false>(float *out, float *srcTile, uint32_t *idx, void *stream);
+template void LaunchMScatterRow<16, 16, 32, true>(float *out, float *srcTile, uint32_t *idx, void *stream);


### PR DESCRIPTION
## Summary
- Fix the sim/onboard divergence where a non-templated `MGATHER(dst, src, idx)` / `MSCATTER(dst, src, idx)` resolved to `Coalesce::Elem` on the CPU simulator but `Coalesce::Row` on A2/A3 and A5 hardware, so one kernel source could not be validated by a single golden across sim and onboard
- Make CPU sim `MGATHER_IMPL` / `MSCATTER_IMPL` fully templated on the same parameters as A5 (`Coalesce`, `GatherOOB` / `ScatterAtomicOp`, `ScatterOOB`, `ScatterConflict`) with the same `Coalesce::Row` default, so a non-templated call now means Row on sim exactly as on hardware. Row reads/writes `table[idx[r], :]`; Elem keeps the element-wise path; OOB and atomic policies are modeled to match A5
- Open the templated MGATHER/MSCATTER dispatch overloads in `pto_instr.hpp` to the CPU simulator (`#ifdef PTO_NPU_ARCH_A5` -> `|| defined(__CPU_SIM)`) so explicit `MGATHER<Coalesce::Elem>` / `MSCATTER<Coalesce::Elem>` compiles for one portable source
- Update mgather/mscatter STs: existing Elem cases now call the explicit `Coalesce::Elem` form (goldens unchanged), plus new Row-default (non-templated) and Row-explicit cases with goldens
- Migrate the hashfind ST to explicit `MGATHER<Coalesce::Elem>`; its non-templated call relied on the old Elem default and was already silently wrong (Row) on A5 onboard
- Sync mgather.md / mscatter.md to document the aligned CPU semantics

## Testing
- [x] All 124 CPU-SIM ST suites pass (mgather, mscatter, hashfind included)

## Related Issues
Fixes #164