### PR TITLE
flash_atten: refine README, optimize perf (split-KV), update skill

### DIFF
--- a/.claude/skills/pto-isa-flash-atten-a3-pipeline/SKILL.md
+++ b/.claude/skills/pto-isa-flash-atten-a3-pipeline/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   (cube-side per-tile emit_qk_pv interleaving, vec-side "drain GU then produce
   P"), the QK_PRELOAD / EXP_RING / S1_TILE knobs and their invariants, the UB
   192 KiB budget with the row_slice working-tile shrink, the empirical
-  S1 >= 16384 -> S1_TILE = 512 recommendation, and the op-pattern PIPE_V barrier removal recipe. Use
+  S1 >= 32768 -> S1_TILE = 512 recommendation, and the op-pattern PIPE_V barrier removal recipe. Use
   when tuning the in-tree DSL Flash Attention, porting the four-stage pipeline
   to a new persistent-block kernel that mixes cube + vec stages through a GM
   FIFO, choosing QK_PRELOAD / S1_TILE for a new shape mix, or deciding when a
@@ -24,7 +24,7 @@ A single, focused recipe: how to schedule a Flash Attention prefill kernel on As
 ## Quick Start
 
 - Read [references/fa-4stage-pipeline-recipe.md](references/fa-4stage-pipeline-recipe.md) -- the full pipeline (stages, prologue / steady / epilogue, ring invariants, anti-patterns).
-- Read [references/ub-budget-and-tile-sizing.md](references/ub-budget-and-tile-sizing.md) -- 192 KiB UB budget, row_slice 64 KiB -> 32 KiB shrink, and the empirical `S1 >= 16384 -> S1_TILE = 512` recommendation.
+- Read [references/ub-budget-and-tile-sizing.md](references/ub-budget-and-tile-sizing.md) -- 192 KiB UB budget, row_slice 64 KiB -> 32 KiB shrink, and the empirical `S1 >= 32768 -> S1_TILE = 512` recommendation.
 - Read [references/pipe-v-barrier-patterns.md](references/pipe-v-barrier-patterns.md) -- which generated-C++ `pipe_barrier(PIPE_V)` patterns are safe to drop and why.
 - Reproduce the canonical numbers on Ascend 910B2:
   ```bash
@@ -32,13 +32,13 @@ A single, focused recipe: how to schedule a Flash Attention prefill kernel on As
   python3 run.py                       # full case1..case8 sweep
   python3 run.py --case case1          # one shape
   ```
-  `run.py` rebuilds `build_artifacts/fa.so` per `FA_Q_ROWS`, and its default suite picks `FA_S1_TILE=512` automatically for `S1 >= 16384` (`case5..case8`) as an empirically good default.
+  `run.py` rebuilds `build_artifacts/fa.so` per `FA_Q_ROWS`, and its default suite picks `FA_S1_TILE=512` automatically for `S1 >= 32768` (`case6..case8`) as an empirically good default.
 
 ## Core Workflow
 
 1. **Diagnose** -- confirm the kernel is pipeline-bound (cube or vec idle while the other is busy, or `pipe_barrier(PIPE_V)` stalls dominating the vec side). For the generic profiling loop see [docs/coding/performance-best-practices.md](../../../docs/coding/performance-best-practices.md).
 2. **Apply the recipe** -- four-stage cross-core pipeline with prologue + steady + epilogue, GM-staged FIFO between stages, exp_max ring sized to `QK_PRELOAD`. See [references/fa-4stage-pipeline-recipe.md](references/fa-4stage-pipeline-recipe.md).
-3. **Size the tiles** -- start from the empirical defaults (`S1_TILE=256`, and recommended `512` for `S1 >= 16384`), confirm the row_slice shrink keeps the per-iteration working tile at 32 KiB, validate the UB budget on the host. See [references/ub-budget-and-tile-sizing.md](references/ub-budget-and-tile-sizing.md).
+3. **Size the tiles** -- start from the empirical defaults (`S1_TILE=256`, and recommended `512` for `S1 >= 32768`), confirm the row_slice shrink keeps the per-iteration working tile at 32 KiB, validate the UB budget on the host. See [references/ub-budget-and-tile-sizing.md](references/ub-budget-and-tile-sizing.md).
 4. **Patch barriers** -- run with the default `gu` pattern; only add `softmax-exp-sum` or `softmax-sum-add` after the patch tool confirms there is no direct tile dependency. See [references/pipe-v-barrier-patterns.md](references/pipe-v-barrier-patterns.md).
 5. **Verify** -- correctness vs a host FP32 reference at small shapes; latency and TFLOP/s vs `torch_npu.npu_fused_infer_attention_score` for all benchmark sizes.
 
@@ -56,7 +56,7 @@ This skill is **deliberately narrow** -- it covers only the A3 non-causal prefil
 
 - Treat `EXP_RING == QK_PRELOAD` as a hard invariant. Changing one without the other lets softmax(t + QK_PRELOAD) clobber the rescale factor GU(t) is still using. The host raises a ValueError today; do not relax it.
 - Validate `S1 >= S1_TILE * QK_PRELOAD` and `S1 % S1_TILE == 0` on the host before launching -- surface a clear error rather than letting the FIFO underrun mid-kernel.
-- Keep `S1_TILE` selected per-shape rather than hard-coded: `S1_TILE=256` is the baseline empirical value, and `S1 >= 16384` is recommended to use 512 because it has measured better on the current default shapes. This is not a hard rule or a proof of optimality; treat it as the default heuristic to beat. See the UB budget reference for why a higher S1_TILE is not free.
+- Keep `S1_TILE` selected per-shape rather than hard-coded: `S1_TILE=256` is the baseline empirical value, and `S1 >= 32768` is recommended to use 512 because it has measured better on the current default shapes. This is not a hard rule or a proof of optimality; treat it as the default heuristic to beat. See the UB budget reference for why a higher S1_TILE is not free.
 - The default `gu` PIPE_V removal pattern is stable and on by default. Adding `softmax-exp-sum` or `softmax-sum-add` requires the patch tool's direct-tile-dependency check to pass -- do not enable them blind.
 - Prefer the op-pattern barrier removal over the legacy line-number list (`FA_REMOVE_VEC_BARRIERS`). The line-number path is kept only as an experimental fallback and breaks on every ptoas emit churn.
 - This kernel is A3 only (`--pto-arch=a3 --npu-arch=dav-2201` in `compile.sh`). HEAD / S0 / CUBE_S1 are baked. Do not invent a CANN platform_config wiring for it -- the shape envelope is fixed.

--- a/.claude/skills/pto-isa-flash-atten-a3-pipeline/references/fa-4stage-pipeline-recipe.md
+++ b/.claude/skills/pto-isa-flash-atten-a3-pipeline/references/fa-4stage-pipeline-recipe.md
@@ -89,7 +89,7 @@ Two non-obvious rules:
 
 | Knob | Default | Other values | Hard invariant |
 | --- | --- | --- | --- |
-| `S1_TILE` (`FA_S1_TILE`) | 256 | 512 (recommended for `S1 >= 16384` by current measurements) | Must be a multiple of `CUBE_S1` (`= 128`); the current library implements only `{256, 512}`. Extending this set requires adapting the implementation and validating the new shape, not just changing the heuristic. The 16384 threshold is an empirical recommendation, not a hard rule. |
+| `S1_TILE` (`FA_S1_TILE`) | 256 | 512 (recommended for `S1 >= 32768` by current measurements) | Must be a multiple of `CUBE_S1` (`= 128`); the current library implements only `{256, 512}`. Extending this set requires adapting the implementation and validating the new shape, not just changing the heuristic. The 32768 threshold is an empirical recommendation, not a hard rule. |
 | `QK_PRELOAD` (`FA_QK_PRELOAD`) | 3 (DSL) | 4 (manual parity) | Allow-list `{3, 4}`. |
 | `EXP_RING` (`FA_EXP_RING`) | `= QK_PRELOAD` | -- | Must equal `QK_PRELOAD`; host raises `ValueError` otherwise. |
 | `QK_PRELOAD * S1_TILE` floor on `S1` | -- | -- | `S1 >= QK_PRELOAD * S1_TILE` and `S1 % S1_TILE == 0`. |
@@ -141,7 +141,7 @@ The PTO-DSL Flash Attention kernel ships eight shape-specialized presets (`case1
   - all shapes -- compare against `torch_npu.npu_fused_infer_attention_score` (the run-time picks tolerance based on `Q_ROWS * S1`).
 - Latency / throughput: `run.py` reports per-case `fa_us`, `fused_us`, `speedup`, and TFLOP/s (matmul + scale + softmax op count, 140 TFLOPS convention).
 
-Regression watermark on Ascend 910B2 with the current default knobs (`QK_PRELOAD = 3`, baseline `S1_TILE = 256`, recommended/default-suite `S1_TILE = 512` for `S1 >= 16384`, default `gu` PIPE_V patch):
+Regression watermark on Ascend 910B2 with the current default knobs (`QK_PRELOAD = 3`, baseline `S1_TILE = 256`, recommended/default-suite `S1_TILE = 512` for `S1 >= 32768`, default `gu` PIPE_V patch). These are the pre-cutover numbers: the `case5`/16384 row was measured at `S1_TILE = 512`, before the default-suite cutover moved to 32768:
 
 | Case | S0 = S1 | fa us | torch_npu us | speedup |
 | ---- | ------: | ----: | -----------: | ------: |
@@ -158,7 +158,7 @@ Reading the band:
 
 - `case1..case4` are launch / overhead favored -- the DSL kernel beats the fused op by 3.1x -> 1.3x as the shape grows.
 - `case5..case8` are compute-bound large prefill -- the kernel sits within +-2% of `torch_npu`. Anything materially below 0.95x at these shapes is a regression in the pipeline (re-check `QK_PRELOAD`, `EXP_RING`, and the `gu` PIPE_V patch).
-- `case4` (8192) is the last default-suite case below the empirical 16384 recommendation boundary: it still uses `S1_TILE = 256`, so it sees the largest scheduling overhead per S1 tile.
+- `case5` (16384) is the last default-suite case below the empirical 32768 recommendation boundary: it still uses `S1_TILE = 256`, so it sees the largest scheduling overhead per S1 tile.
 
 ## 8. Anti-Patterns
 

--- a/.claude/skills/pto-isa-flash-atten-a3-pipeline/references/ub-budget-and-tile-sizing.md
+++ b/.claude/skills/pto-isa-flash-atten-a3-pipeline/references/ub-budget-and-tile-sizing.md
@@ -1,6 +1,6 @@
-# UB Budget and Tile Sizing (S1_TILE, row_slice shrink, empirical S1 >= 16384 recommendation)
+# UB Budget and Tile Sizing (S1_TILE, row_slice shrink, empirical S1 >= 32768 recommendation)
 
-The Flash Attention four-stage pipeline lives or dies on the vec UB budget. This file is the standalone reference for **how the working tile is sized, why the row_slice shrink is needed, and why the default suite recommends `S1_TILE=512` for `S1 >= 16384`**. The companion pipeline reference covers the timing knobs (`QK_PRELOAD`, `EXP_RING`); this file is purely about memory.
+The Flash Attention four-stage pipeline lives or dies on the vec UB budget. This file is the standalone reference for **how the working tile is sized, why the row_slice shrink is needed, and why the default suite recommends `S1_TILE=512` for `S1 >= 32768`**. The companion pipeline reference covers the timing knobs (`QK_PRELOAD`, `EXP_RING`); this file is purely about memory.
 
 ## 1. Why UB Sizing Is the Real Constraint
 
@@ -38,20 +38,20 @@ The size is **constant in 32 KiB by construction** -- the row_slice count grows 
 
 GU and PV do **not** row-split (they operate on the full subblock `VecGuRows = S0 / VEC_CORES = 64`). Only the QK -> softmax -> P chain walks per row_slice. The vec side therefore reads a P slot as `TILE_FACTOR` row_slices of `[Vec_S0, S1_TILE]`, but feeds it into PV consumption as one full `[VecGuRows, HEAD]` view.
 
-## 3. The S1 >= 16384 Tile Recommendation
+## 3. The S1 >= 32768 Tile Recommendation
 
 `run.py` picks `S1_TILE` per shape, not per kernel build. The default suite currently uses:
 
 ```python
 def _default_case_s1_tile(seq_len):
-    return 512 if seq_len >= 16384 else 256
+    return 512 if seq_len >= 32768 else 256
 ```
 
 This is a **scheduling-overhead heuristic**, not an architectural limit and not a proof of global optimality:
 
 - `S1_TILE = 256` is the baseline empirical value and is the default builder value.
-- For the current large-S1 default shapes (`case5..case8`, `S1 >= 16384`), `S1_TILE = 512` has measured better because it halves `num_tiles_s1` and reduces per-tile FIFO + sync overhead. The working tile stays 32 KiB because `TILE_FACTOR` doubles to 4 and `Vec_S0` halves to 16.
-- For other shape mixes, `S1 >= 16384 -> 512` is a recommended starting point, not a mandatory rule. If a sweep shows 256 or another supported tile size is faster while satisfying the UB and FIFO constraints, document the shape-specific result.
+- For the current large-S1 default shapes (`case6..case8`, `S1 >= 32768`), `S1_TILE = 512` has measured better because it halves `num_tiles_s1` and reduces per-tile FIFO + sync overhead. The working tile stays 32 KiB because `TILE_FACTOR` doubles to 4 and `Vec_S0` halves to 16.
+- For other shape mixes, `S1 >= 32768 -> 512` is a recommended starting point, not a mandatory rule. If a sweep shows 256 or another supported tile size is faster while satisfying the UB and FIFO constraints, document the shape-specific result.
 
 This is the **flash-attn analogue of the GEMM 32 MiB safety-ratio cliff** only in the sense that it is an empirical threshold where one knob may jump because the cost model crosses a boundary. Treat it as a heuristic default, not a hard rule.
 
@@ -64,7 +64,7 @@ Two costs scale with `S1_TILE`:
 - **GM FIFO slot size.** `SLOT_SIZE_QK = S0 * S1_TILE * 4` and `SLOT_SIZE_P = S0 * S1_TILE * 2`. With `SLOT_NUM = 8` on A3 the GM bytes per AIC block grow linearly. This is GM, not UB, so it is generally fine -- but it costs DMA bandwidth proportionally.
 - **`exp_max` ring footprint.** The ring is `EXP_RING * TILE_FACTOR` rescale-factor tiles, and `TILE_FACTOR = S1_TILE / CUBE_S1`. Going to `S1_TILE = 512` doubles `TILE_FACTOR` (2 -> 4), which doubles the per-ring-slot rescale storage on the vec side. The row_slice shrink rebalances the per-iteration working tile, but the ring itself grows.
 
-The cumulative effect is why the default recommendation only switches to 512 at `S1 >= 16384`. At smaller S1 the per-tile FIFO overhead has not yet dominated in the current benchmark suite, so paying the extra ring footprint has not measured better.
+The cumulative effect is why the default recommendation only switches to 512 at `S1 >= 32768`. At smaller S1 the per-tile FIFO overhead has not yet dominated in the current benchmark suite, so paying the extra ring footprint has not measured better.
 
 ## 5. Constraints the Porter Must Enforce
 
@@ -83,8 +83,8 @@ The host validates the first three today via `ValueError` in `fa_builder.py`; th
 If the kernel builds but ptoas reports local-memory allocation failure or the vec stalls profile out, the working tile is too big:
 
 - Symptom: `local memory allocation failed` from ptoas on a build that previously worked. Cause: someone raised `EXP_RING` without re-checking UB, or added a new vec working tile. Fix: revert the ring change, or split the new tile by row_slice.
-- Symptom: `case5..case8` speedup drops from ~1.0x to ~0.7x with no other change. Possible cause: `S1_TILE` stayed at 256 (e.g. `FA_S1_TILE` env var pinned for a manual sweep) even though 512 is the current recommended default for those shapes. Fix: rerun with the default 512 recommendation and compare before changing the heuristic.
-- Symptom: `case1..case4` speedup drops while `case5..case8` stays put. Possible cause: `S1_TILE` switched to 512 too aggressively below the empirical 16384 boundary. Fix: restore the default 256 baseline for small S1 unless a shape-specific sweep proves otherwise.
+- Symptom: `case6..case8` speedup drops from ~1.0x to ~0.7x with no other change. Possible cause: `S1_TILE` stayed at 256 (e.g. `FA_S1_TILE` env var pinned for a manual sweep) even though 512 is the current recommended default for those shapes. Fix: rerun with the default 512 recommendation and compare before changing the heuristic.
+- Symptom: `case1..case5` speedup drops while `case6..case8` stays put. Possible cause: `S1_TILE` switched to 512 too aggressively below the empirical 32768 boundary. Fix: restore the default 256 baseline for small S1 unless a shape-specific sweep proves otherwise.
 
 ## 7. Anti-Patterns
 

--- a/kernels/python/flash_atten/README.md
+++ b/kernels/python/flash_atten/README.md
@@ -2,19 +2,13 @@
 
 ## Overview
 
-This example demonstrates a high-performance Flash Attention implementation written with the PTO Python DSL (`ptodsl`). It is a Python-DSL port and parity experiment for the manual kernel in `kernels/manual/common/flash_atten`, and it follows the same four-stage software pipeline:
+This example demonstrates a high-performance Flash Attention implementation written with the PTO Python DSL (`ptodsl`). Its goal is to provide a performance-optimal Python-DSL Flash Attention kernel. The kernel is built around a four-stage software pipeline:
 
 ```text
 compute_qk (Cube) -> compute_p (Vector) -> compute_pv (Cube) -> compute_gu (Vector)
 ```
 
-The implementation also references the Huawei CSL PTO DSL AOT Flash Attention 140 TFLOPS example:
-
-```text
-https://github.com/huawei-csl/pto-dsl/tree/main/examples/aot/flash_attention/140tflops
-```
-
-The case is useful for validating that the Python DSL can express a production-style Flash Attention pipeline, including Cube/Vector cooperation, runtime S1 looping, software FIFO staging through global memory, correctness checks, and performance comparison against `torch_npu.npu_fused_infer_attention_score`.
+It shows that the Python DSL can express a fully performance-tuned, production-style Flash Attention pipeline, including Cube/Vector cooperation, runtime S1 looping, software FIFO staging through global memory, correctness checks, and a performance comparison against `torch_npu.npu_fused_infer_attention_score`.
 
 ## Supported Platform
 
@@ -71,6 +65,34 @@ The full runtime/build dependency set is:
 - `ptoas` compatible with the MLIR emitted by the installed `ptodsl`
 - this repository's PTO C++ headers, supplied through `PTO_LIB_PATH`
 
+### Verified environment versions (for reproducible runs)
+
+The performance and correctness results were last reproduced with the exact
+versions below. Pin these for an accurate reproduction; mixing other versions
+usually requires a matching `ptoas` / header pair (see the note that follows the
+table).
+
+| Dependency | Version (pin) | Notes |
+| --- | --- | --- |
+| PTO-ISA repo (this repo; headers via `PTO_LIB_PATH`) | commit `b9122ec586b5a7b4b686ca7498874a1c94b3573c` (2026-06-12) | plus the Flash-Attention working-tree changes under `kernels/python/flash_atten/` and the GlobalData header fix in `include/pto/common/pto_instr.hpp` (see below) |
+| `pto-dsl` Python package (`ptodsl`) | `0.1.2`, commit `6755794cfc145c8ffe4fae92483aa20148e57327` (2026-05-18), branch `main` | the only `ptodsl` runtime/build dependency |
+| `ptoas` | `0.45` | must match the `ptodsl`-emitted MLIR and these C++ headers |
+| CANN toolkit (`Ascend-cann-toolkit`) | `9.0.0` (inner `V100R001C10SPC001B250`) | provides `bisheng` |
+| `bisheng` | clang `15.0.5` (bundled with CANN 9.0.0) | |
+| `torch` | `2.9.0` | |
+| `torch_npu` | `2.9.0` | |
+| Python | `3.10.19` | |
+| Ascend driver | `26.0.rc1` (ascendhal `7.35.23`) | |
+| Target NPU | Ascend A3-class (`--pto-arch=a3`, `--npu-arch=dav-2201`) | |
+
+**`ptoas` / header pairing.** `ptoas` codegen and these C++ headers must be
+compatible. With `ptoas 0.45`, the public GlobalData FIFO ops on the NPU path
+(`TALLOC` / `TPUSH` / `TPOP` / `TFREE`) must pass explicit template arguments
+`<Pipe, GlobalData, Split>` to their `*_IMPL` calls in
+`include/pto/common/pto_instr.hpp`; without this 4-line fix (which mirrors the
+existing `__CPU_SIM` branch) `bisheng` fails with `no member named 'cons'`. The
+fix is required to build this example with `ptoas >= 0.45`.
+
 ## Directory Layout
 
 ```text
@@ -99,16 +121,18 @@ build_artifacts/fa_summary_*.tsv
 
 ## Kernel Scope
 
-Current shape and feature constraints are intentionally aligned with the manual parity target:
+Current shape and feature constraints. The kernel is deliberately specialized for a single shape family so the implementation can be tuned for peak performance:
 
 - `HEAD = 128`
 - `S0 = 128` per Q block
-- `TILE_S1 = 256` by default; `FA_S1_TILE=512` is available for experiments
+- `S1_TILE = 256` by default; `FA_S1_TILE=512` is available for experiments
 - `CUBE_S1 = 128`
-- `QK_PRELOAD = 3` in the DSL-tuned runtime path (`FA_QK_PRELOAD=4` is available for experiments; `MANUAL_QK_PRELOAD = 4` is kept only as the parity target metadata)
+- `QK_PRELOAD = 3` is the performance-tuned default for the DSL runtime path (`FA_QK_PRELOAD=4` is available for experiments)
+- `EXP_RING = QK_PRELOAD` is a hard invariant (`FA_EXP_RING` must equal `FA_QK_PRELOAD`): softmax and `compute_gu` reuse matching rescale slots, so they must share the same ring depth
+- `KV_SPLIT = 1` by default (`FA_KV_SPLIT` may be `1`, `2`, or `4`). When `> 1`, each Q block's KV (S1) is split across `KV_SPLIT` work-units so that `NUM_Q_BLOCKS * KV_SPLIT` units fill the cube-core waves, and a second grid launch (`call_reduce`) flash-combines the per-unit partials into the final normalized `O`. The default suite auto-selects this per shape and per device (see [Build and Run](#build-and-run))
 - non-causal attention only
 - total Q rows are configured by `FA_Q_ROWS` and must be a multiple of `128`
-- total KV rows are supplied at runtime by `run.py`; each S1 length must be at least `S1_TILE * QK_PRELOAD` and divisible by the selected `S1_TILE`
+- total KV rows are supplied at runtime by `run.py`; each S1 length must be divisible by the selected `S1_TILE` and (at `KV_SPLIT = 1`) yield at least `QK_PRELOAD` tiles. When `KV_SPLIT > 1`, the tile count must additionally be divisible by `KV_SPLIT`, and each chunk must still hold at least `QK_PRELOAD` tiles (i.e. `S1 / S1_TILE / KV_SPLIT >= QK_PRELOAD`)
 
 The generated shared library is specialized for the current `FA_Q_ROWS`, while S1 is handled at runtime.
 
@@ -146,18 +170,27 @@ python3 run.py --case case1
 python3 run.py
 ```
 
-The default suite runs `case1` to `case8` and recompiles the kernel for each `FA_Q_ROWS` value. It uses `TILE_S1=256` for `case1` to `case4`, and `TILE_S1=512` for `case5` to `case8` (`S1 >= 16384`).
+The default suite runs `case1` to `case8` and recompiles the kernel for each `FA_Q_ROWS` value. Two knobs are selected per case:
 
-| Case | Q rows (S0 total) | KV rows (S1) |
-| --- | ---: | ---: |
-| `case1` | 1024 | 1024 |
-| `case2` | 2048 | 2048 |
-| `case3` | 4096 | 4096 |
-| `case4` | 8192 | 8192 |
-| `case5` | 16384 | 16384 |
-| `case6` | 32768 | 32768 |
-| `case7` | 65536 | 65536 |
-| `case8` | 131072 | 131072 |
+- `S1_TILE`: `256` for `S1 < 32768` (`case1`–`case5`) and `512` for `S1 >= 32768` (`case6`–`case8`).
+- `KV_SPLIT`: auto-selected per shape **and per device** from the cube-core wave utilization. On the reference 24-cube-core A3 target this enables `KV_SPLIT=2` only for `case5` and keeps `KV_SPLIT=1` everywhere else; a device with a different cube-core count may select differently. Override with `FA_KV_SPLIT`.
+
+| Case | Q rows (S0 total) | KV rows (S1) | `S1_TILE` | `KV_SPLIT`\* |
+| --- | ---: | ---: | ---: | ---: |
+| `case1` | 1024 | 1024 | 256 | 1 |
+| `case2` | 2048 | 2048 | 256 | 1 |
+| `case3` | 4096 | 4096 | 256 | 1 |
+| `case4` | 8192 | 8192 | 256 | 1 |
+| `case5` | 16384 | 16384 | 256 | 2 |
+| `case6` | 32768 | 32768 | 512 | 1 |
+| `case7` | 65536 | 65536 | 512 | 1 |
+| `case8` | 131072 | 131072 | 512 | 1 |
+
+\*The `KV_SPLIT` column is for the reference 24-cube-core A3 target; it is chosen automatically from the cube-core count, so other devices may differ.
+
+### Split-KV (`KV_SPLIT`) wave-quantization fix
+
+When a Q block does not produce enough cube work-units to fill all cube-core waves (low wave utilization), `KV_SPLIT > 1` splits each Q block's KV range into `KV_SPLIT` work-units, raising `TOTAL_UNITS = NUM_Q_BLOCKS * KV_SPLIT`. Each unit computes an unnormalized partial (`O_acc`, running max, running sum); a second grid launch (`call_reduce`, gated by `-DFA_KV_SPLIT` in `compile.sh` and the `#if FA_KV_SPLIT > 1` block in `caller.cpp`) flash-combines the partials per Q block into the final normalized `O`. `KV_SPLIT=1` is the exact baseline (no split, no second launch). The split only pays off when it materially raises utilization and each chunk still satisfies the `QK_PRELOAD` prologue floor, which is why the suite gate enables it only for `case5` on the reference target.
 
 ## Custom Cases
 
@@ -177,6 +210,18 @@ Control benchmark iterations:
 
 ```bash
 FA_Q_ROWS=1024 FA_BENCH_LENGTHS=1024 FA_BENCH_WARMUP=20 FA_BENCH_ITERS=200 python3 run.py
+```
+
+Override the split-KV factor (custom single runs default to `KV_SPLIT=1`; only the default suite auto-selects it):
+
+```bash
+FA_Q_ROWS=16384 FA_BENCH_LENGTHS=16384 FA_S1_TILE=256 FA_KV_SPLIT=2 python3 run.py
+```
+
+Select the benchmark timing mode through the environment (default `event`; `sync` is the conservative host-timed mode, equivalent to `--timing sync`):
+
+```bash
+FA_Q_ROWS=1024 FA_BENCH_LENGTHS=1024 FA_BENCH_TIMING=sync python3 run.py
 ```
 
 Reuse an existing `build_artifacts/fa.so` when it was already compiled for the same `FA_Q_ROWS`:
@@ -235,13 +280,44 @@ python3 run.py --timing sync
 - a host FP32 PyTorch reference when `Q_ROWS * S1` is small enough
 - `torch_npu.npu_fused_infer_attention_score` for all benchmark sizes
 
-Throughput is reported as TFLOP/s using matmul, scale, and softmax operation counts, following the 140 TFLOPS reference script convention.
+Throughput is reported as TFLOP/s computed from matmul, scale, and softmax operation counts (the same operation-count convention as the upstream reference `run.py`). **TFLOP/s is a measured value that depends on the input shape and data, not a fixed target** — absolute numbers vary between shapes and runs, so use the per-shape latency and the speedup against `torch_npu.npu_fused_infer_attention_score` for comparison.
 
 A summary TSV is generated automatically for the default suite. You can choose the output path with `FA_SUMMARY_TSV`:
 
 ```bash
 FA_SUMMARY_TSV=/tmp/fa_summary.tsv python3 run.py --case case1
 ```
+
+## Expected Performance
+
+> The numbers below are the **target** band for the pinned reference environment
+> in the [version table](#verified-environment-versions-for-reproducible-runs)
+> above (Ascend A3-class, 24 cube cores; `ptoas 0.45`; `torch_npu 2.9.0`). As
+> noted in [Output and Correctness](#output-and-correctness), absolute latency and
+> TFLOP/s vary with shape, data, and device — treat these as the reference band to
+> reproduce, not a hard SLA.
+
+With the `TPipe::SyncPeriod` setting in `include/pto/npu/a2a3/TPush.hpp` optimized
+(see [issue #172](https://github.com/hw-native-sys/pto-isa/issues/172) for
+details), the default suite is expected to reach the band below on the reference
+target. Small cases use `event` timing (device time); large cases use `sync`
+timing to avoid the occasional `event` glitch on very large `ctypes` launches (see
+[Removing Redundant PIPE_V Barriers](#removing-redundant-pipe_v-barriers)).
+
+| Case | S0 = S1 | DSL latency (µs) | `torch_npu` (µs) | Speedup | Timing |
+| --- | ---: | ---: | ---: | :---: | :---: |
+| `case1` | 1024 | 21 | 54 | 2.55× | event |
+| `case2` | 2048 | 38 | 73 | 1.91× | event |
+| `case3` | 4096 | 105 | 139 | 1.32× | event |
+| `case4` | 8192 | 239 | 291 | 1.22× | event |
+| `case5` | 16384 | 1001 | 985 | 0.98× | sync |
+| `case6` | 32768 | 3185 | 3184 | 1.00× | sync |
+| `case7` | 65536 | 12106 | 12158 | 1.00× | sync |
+| `case8` | 131072 | 48062 | 48135 | 1.00× | sync |
+
+The expected shape is a large lead at small sizes (where `torch_npu` carries a
+fixed host-dispatch cost), narrowing as the size grows, and reaching parity
+(~185 TFLOP/s) at the largest sizes.
 
 ## Notes
 

--- a/kernels/python/flash_atten/README_zh.md
+++ b/kernels/python/flash_atten/README_zh.md
@@ -2,19 +2,13 @@
 
 ## 概览
 
-本用例展示如何使用 PTO Python DSL（`ptodsl`）实现高性能 Flash Attention。该实现是 `kernels/manual/common/flash_atten` 手写 kernel 的 Python-DSL 迁移与对齐实验，保留了手写版本中的四阶段软流水：
+本用例展示如何使用 PTO Python DSL（`ptodsl`）实现高性能 Flash Attention。该用例的目标是提供一个性能最优的 Python-DSL Flash Attention 实现。该实现围绕四阶段软流水构建：
 
 ```text
 compute_qk（Cube） -> compute_p（Vector） -> compute_pv（Cube） -> compute_gu（Vector）
 ```
 
-实现过程中也参考了 Huawei CSL PTO DSL AOT Flash Attention 140 TFLOPS 示例：
-
-```text
-https://github.com/huawei-csl/pto-dsl/tree/main/examples/aot/flash_attention/140tflops
-```
-
-该用例的意义在于验证 Python DSL 对高性能 Flash Attention 这类复杂算子的表达能力，包括 Cube/Vector 协同、运行时 S1 循环、通过全局内存进行软件 FIFO 暂存、结果正确性校验，以及与 `torch_npu.npu_fused_infer_attention_score` 的性能对比。
+它表明 Python DSL 能够表达一个完整经过性能调优的、生产级 Flash Attention 流水线，包括 Cube/Vector 协同、运行时 S1 循环、通过全局内存进行软件 FIFO 暂存、结果正确性校验，以及与 `torch_npu.npu_fused_infer_attention_score` 的性能对比。
 
 ## 支持平台
 
@@ -67,6 +61,31 @@ python3 -c "import ptodsl, inspect; from ptodsl import to_ir_module; print(ptods
 - 与已安装 `ptodsl` 生成的 MLIR 兼容的 `ptoas`
 - 通过 `PTO_LIB_PATH` 提供的本仓 PTO C++ 头文件
 
+### 已验证环境版本（用于精确复现）
+
+下表为最近一次复现性能与正确性结果所用的精确版本。复现时请按此固定版本；混用
+其他版本通常需要配套的 `ptoas` 与头文件组合（见表后说明）。
+
+| 依赖 | 版本（建议固定） | 说明 |
+| --- | --- | --- |
+| PTO-ISA 仓（本仓，经 `PTO_LIB_PATH` 提供头文件） | commit `b9122ec586b5a7b4b686ca7498874a1c94b3573c`（2026-06-12） | 还包含 `kernels/python/flash_atten/` 下的 Flash-Attention 工作区改动，以及 `include/pto/common/pto_instr.hpp` 中的 GlobalData 头文件修复（见下） |
+| `pto-dsl` Python 包（`ptodsl`） | `0.1.2`，commit `6755794cfc145c8ffe4fae92483aa20148e57327`（2026-05-18），分支 `main` | 唯一的 `ptodsl` 运行/构建依赖 |
+| `ptoas` | `0.45` | 必须与 `ptodsl` 生成的 MLIR 及本仓 C++ 头文件兼容 |
+| CANN toolkit（`Ascend-cann-toolkit`） | `9.0.0`（inner `V100R001C10SPC001B250`） | 提供 `bisheng` |
+| `bisheng` | clang `15.0.5`（CANN 9.0.0 自带） | |
+| `torch` | `2.9.0` | |
+| `torch_npu` | `2.9.0` | |
+| Python | `3.10.19` | |
+| Ascend 驱动 | `26.0.rc1`（ascendhal `7.35.23`） | |
+| 目标 NPU | Ascend A3 类（`--pto-arch=a3`、`--npu-arch=dav-2201`） | |
+
+**`ptoas` 与头文件的配套关系。** `ptoas` 的 codegen 必须与本仓 C++ 头文件兼容。
+使用 `ptoas 0.45` 时，NPU 路径上的公共 GlobalData FIFO 指令
+（`TALLOC` / `TPUSH` / `TPOP` / `TFREE`）在 `include/pto/common/pto_instr.hpp` 中
+调用其 `*_IMPL` 时必须显式带上模板参数 `<Pipe, GlobalData, Split>`；缺少该 4 行
+修复（与现有 `__CPU_SIM` 分支保持一致）时 `bisheng` 会报 `no member named 'cons'`。
+该修复是使用 `ptoas >= 0.45` 构建本用例的前提。
+
 ## 目录结构
 
 ```text
@@ -95,16 +114,18 @@ build_artifacts/fa_summary_*.tsv
 
 ## Kernel 范围
 
-当前形状和功能约束有意与手写版本对齐：
+当前的形状与功能约束。该 kernel 被特意特化到单一形状族，以便实现能够针对峰值性能进行调优：
 
 - `HEAD = 128`
 - 每个 Q block 的 `S0 = 128`
-- 默认 `TILE_S1 = 256`；可通过 `FA_S1_TILE=512` 进行实验
+- 默认 `S1_TILE = 256`；可通过 `FA_S1_TILE=512` 进行实验
 - `CUBE_S1 = 128`
-- DSL 调优后的运行路径使用 `QK_PRELOAD = 3`（可通过 `FA_QK_PRELOAD=4` 进行实验；`MANUAL_QK_PRELOAD = 4` 仅保留为 parity 目标元数据）
+- DSL 运行路径使用经过性能调优的默认值 `QK_PRELOAD = 3`（可通过 `FA_QK_PRELOAD=4` 进行实验）
+- `EXP_RING = QK_PRELOAD` 是硬性不变量（`FA_EXP_RING` 必须等于 `FA_QK_PRELOAD`）：softmax 与 `compute_gu` 复用配套的 rescale slot，因此二者必须共享相同的 ring 深度
+- `KV_SPLIT` 默认为 `1`（`FA_KV_SPLIT` 可取 `1`、`2`、`4`）。当 `> 1` 时，每个 Q block 的 KV（S1）会被切分到 `KV_SPLIT` 个 work-unit，使得 `NUM_Q_BLOCKS * KV_SPLIT` 个 unit 填满 cube core 的波次；随后第二次 grid launch（`call_reduce`）会按 Q block 将各 unit 的部分结果 flash-combine 成最终归一化的 `O`。默认集合会按形状与设备自动选择（见[构建与运行](#构建与运行)）
 - 仅支持非 causal attention
 - Q 总行数通过 `FA_Q_ROWS` 配置，并且必须是 `128` 的整数倍
-- KV 总行数由 `run.py` 在运行时传入；每个 S1 长度需要不小于 `S1_TILE * QK_PRELOAD`，并且能被所选 `S1_TILE` 整除
+- KV 总行数由 `run.py` 在运行时传入；每个 S1 长度必须能被所选 `S1_TILE` 整除，且在 `KV_SPLIT = 1` 时至少切出 `QK_PRELOAD` 个 tile。当 `KV_SPLIT > 1` 时，tile 数还必须能被 `KV_SPLIT` 整除，且每个分片仍至少包含 `QK_PRELOAD` 个 tile（即 `S1 / S1_TILE / KV_SPLIT >= QK_PRELOAD`）
 
 生成的动态库会针对当前 `FA_Q_ROWS` 特化，S1 长度则在运行时处理。
 
@@ -142,18 +163,27 @@ python3 run.py --case case1
 python3 run.py
 ```
 
-默认集合会运行 `case1` 到 `case8`，并针对每个 `FA_Q_ROWS` 重新编译 kernel。`case1` 到 `case4` 使用 `TILE_S1=256`，`case5` 到 `case8`（`S1 >= 16384`）使用 `TILE_S1=512`：
+默认集合会运行 `case1` 到 `case8`，并针对每个 `FA_Q_ROWS` 重新编译 kernel。每个 case 会按形状选择两个参数：
 
-| Case | Q rows（S0 total） | KV rows（S1） |
-| --- | ---: | ---: |
-| `case1` | 1024 | 1024 |
-| `case2` | 2048 | 2048 |
-| `case3` | 4096 | 4096 |
-| `case4` | 8192 | 8192 |
-| `case5` | 16384 | 16384 |
-| `case6` | 32768 | 32768 |
-| `case7` | 65536 | 65536 |
-| `case8` | 131072 | 131072 |
+- `S1_TILE`：`S1 < 32768`（`case1`–`case5`）使用 `256`，`S1 >= 32768`（`case6`–`case8`）使用 `512`。
+- `KV_SPLIT`：按形状**和设备**（cube core 波次利用率）自动选择。在参考的 24 cube core A3 目标上，只有 `case5` 会启用 `KV_SPLIT=2`，其余保持 `KV_SPLIT=1`；cube core 数不同的设备可能选择不同。可用 `FA_KV_SPLIT` 覆盖。
+
+| Case | Q rows（S0 total） | KV rows（S1） | `S1_TILE` | `KV_SPLIT`\* |
+| --- | ---: | ---: | ---: | ---: |
+| `case1` | 1024 | 1024 | 256 | 1 |
+| `case2` | 2048 | 2048 | 256 | 1 |
+| `case3` | 4096 | 4096 | 256 | 1 |
+| `case4` | 8192 | 8192 | 256 | 1 |
+| `case5` | 16384 | 16384 | 256 | 2 |
+| `case6` | 32768 | 32768 | 512 | 1 |
+| `case7` | 65536 | 65536 | 512 | 1 |
+| `case8` | 131072 | 131072 | 512 | 1 |
+
+\*`KV_SPLIT` 列对应参考的 24 cube core A3 目标；它会按 cube core 数自动选择，其他设备可能不同。
+
+### Split-KV（`KV_SPLIT`）波次量化修复
+
+当某个 Q block 产生的 cube work-unit 不足以填满所有 cube core 波次（波次利用率偏低）时，`KV_SPLIT > 1` 会把每个 Q block 的 KV 区间切成 `KV_SPLIT` 个 work-unit，使 `TOTAL_UNITS = NUM_Q_BLOCKS * KV_SPLIT`。每个 unit 计算未归一化的部分结果（`O_acc`、running max、running sum）；随后第二次 grid launch（`call_reduce`，由 `compile.sh` 的 `-DFA_KV_SPLIT` 与 `caller.cpp` 的 `#if FA_KV_SPLIT > 1` 控制）按 Q block 将这些部分结果 flash-combine 成最终归一化的 `O`。`KV_SPLIT=1` 即精确基线（不切分、不做第二次 launch）。只有当切分能显著提升利用率、且每个分片仍满足 `QK_PRELOAD` prologue 下限时才有收益，这也是默认集合在参考设备上仅对 `case5` 启用它的原因。
 
 ## 自定义 Case
 
@@ -173,6 +203,18 @@ FA_Q_ROWS=2048 FA_BENCH_LENGTHS=1024,2048,4096 python3 run.py
 
 ```bash
 FA_Q_ROWS=1024 FA_BENCH_LENGTHS=1024 FA_BENCH_WARMUP=20 FA_BENCH_ITERS=200 python3 run.py
+```
+
+覆盖 split-KV 因子（自定义单次运行默认 `KV_SPLIT=1`，仅默认集合会自动选择）：
+
+```bash
+FA_Q_ROWS=16384 FA_BENCH_LENGTHS=16384 FA_S1_TILE=256 FA_KV_SPLIT=2 python3 run.py
+```
+
+通过环境变量选择 benchmark 计时模式（默认 `event`；`sync` 为更保守的 host 计时模式，等价于 `--timing sync`）：
+
+```bash
+FA_Q_ROWS=1024 FA_BENCH_LENGTHS=1024 FA_BENCH_TIMING=sync python3 run.py
 ```
 
 当 `build_artifacts/fa.so` 已经按相同 `FA_Q_ROWS` 编译过时，可以复用已有动态库：
@@ -231,13 +273,40 @@ python3 run.py --timing sync
 - 当 `Q_ROWS * S1` 不太大时，使用 host 侧 FP32 PyTorch reference
 - 所有 benchmark 尺寸都会对比 `torch_npu.npu_fused_infer_attention_score`
 
-TFLOP/s 统计包含 matmul、scale 和 softmax 操作量，保持与 140 TFLOPS 参考脚本一致的计数口径。
+TFLOP/s 由 matmul、scale 和 softmax 的操作量统计得到（与上游参考 `run.py` 采用相同的操作计数口径）。**TFLOP/s 是随输入形状与数据变化的实测值，而非固定指标**——不同形状、不同运行之间的绝对数值会变化，因此对比时应以各形状的时延以及相对 `torch_npu.npu_fused_infer_attention_score` 的加速比为准。
 
 默认集合会自动生成 summary TSV。也可以通过 `FA_SUMMARY_TSV` 指定输出路径：
 
 ```bash
 FA_SUMMARY_TSV=/tmp/fa_summary.tsv python3 run.py --case case1
 ```
+
+## 期望性能
+
+> 下表为上文[版本表](#已验证环境版本用于精确复现)所列固定参考环境（Ascend A3 类，
+> 24 cube core；`ptoas 0.45`；`torch_npu 2.9.0`）下的**目标**区间。正如
+> [输出与正确性](#输出与正确性)所述，绝对时延与 TFLOP/s 会随形状、数据和设备变化——
+> 请将其视为需要复现的参考区间，而非硬性指标（SLA）。
+
+将 `include/pto/npu/a2a3/TPush.hpp` 中的 `TPipe::SyncPeriod` 设置优化后（详情见
+[issue #172](https://github.com/hw-native-sys/pto-isa/issues/172)），默认集合预期可在
+参考目标上达到下表区间。小 case 使用 `event` 计时（设备时间）；大 case 使用 `sync`
+计时，以规避超大 `ctypes` launch 上偶发的 `event` 读数 glitch（见
+[删除冗余 PIPE_V Barrier](#删除冗余-pipe_v-barrier)）。
+
+| Case | S0 = S1 | DSL 时延（µs） | `torch_npu`（µs） | 加速比 | 计时 |
+| --- | ---: | ---: | ---: | :---: | :---: |
+| `case1` | 1024 | 21 | 54 | 2.55× | event |
+| `case2` | 2048 | 38 | 73 | 1.91× | event |
+| `case3` | 4096 | 105 | 139 | 1.32× | event |
+| `case4` | 8192 | 239 | 291 | 1.22× | event |
+| `case5` | 16384 | 1001 | 985 | 0.98× | sync |
+| `case6` | 32768 | 3185 | 3184 | 1.00× | sync |
+| `case7` | 65536 | 12106 | 12158 | 1.00× | sync |
+| `case8` | 131072 | 48062 | 48135 | 1.00× | sync |
+
+期望形态为：小尺寸大幅领先（`torch_npu` 有固定的 host 派发开销），随尺寸增大收窄，
+在最大尺寸基本持平（~185 TFLOP/s）。
 
 ## 注意事项
 

--- a/kernels/python/flash_atten/caller.cpp
+++ b/kernels/python/flash_atten/caller.cpp
@@ -31,4 +31,12 @@ extern "C" void call_kernel(uint32_t blockDim, void *stream, uint8_t *gmSlotBuff
     call_both<<<blockDim, nullptr, stream>>>((__gm__ uint64_t *)fftsAddr, (__gm__ float *)gmSlotBuffer,
                                              (__gm__ half *)gmSlotBuffer, (__gm__ half *)q, (__gm__ half *)k,
                                              (__gm__ half *)v, (__gm__ float *)o, s0, s1);
+
+#if defined(FA_KV_SPLIT) && (FA_KV_SPLIT > 1)
+    // T1-A: second grid launch flash-combines the KV_SPLIT partials per Q block
+    // into the final O. Same stream => ordered after call_both (grid sync); same
+    // blockDim => the partial-region base (num_blocks * GM_ELEMS_PER_BLOCK) matches.
+    call_reduce<<<blockDim, nullptr, stream>>>((__gm__ uint64_t *)fftsAddr, (__gm__ float *)gmSlotBuffer,
+                                               (__gm__ half *)gmSlotBuffer, (__gm__ float *)o, s0, s1);
+#endif
 }

--- a/kernels/python/flash_atten/compile.sh
+++ b/kernels/python/flash_atten/compile.sh
@@ -102,6 +102,7 @@ fi
     -cce-enable-mix \
     --npu-arch=dav-2201 -DMEMORY_BASE \
     -std=gnu++17 \
+    -DFA_KV_SPLIT="${FA_KV_SPLIT:-1}" \
     -DKERNEL_CPP="\"${COMPILE_CPP}\"" \
     "${SCRIPT_DIR}/caller.cpp" \
     -o "${LIB_PATH}"

--- a/kernels/python/flash_atten/kernels/fa_builder.py
+++ b/kernels/python/flash_atten/kernels/fa_builder.py
@@ -118,6 +118,27 @@ EXP_RING = int(os.environ.get("FA_EXP_RING", os.environ.get("FA_DSL_EXP_RING", s
 if EXP_RING != QK_PRELOAD:
     raise ValueError("FA_EXP_RING must currently equal FA_QK_PRELOAD ({}), got {}".format(QK_PRELOAD, EXP_RING))
 
+# T1-A wave-quantization fix: split each Q block's KV (S1) across KV_SPLIT
+# work-units, so total_units = NUM_Q_BLOCKS * KV_SPLIT fills the cube-core waves
+# more evenly (e.g. 128 Q blocks over 24 cores = 88.9% util -> 256 units = 97%).
+# Each unit streams softmax over its KV chunk and writes an UNNORMALIZED partial
+# (O_acc, running_max m, running_sum l) to a GM scratch region; a second kernel
+# launch (reduce_kernel) flash-combines the KV_SPLIT partials per Q block into
+# the final normalized O. KV_SPLIT=1 is the exact baseline (no split / no reduce
+# launch); the split path is gated everywhere by `KV_SPLIT > 1`.
+KV_SPLIT = int(os.environ.get("FA_KV_SPLIT", "1"))
+if KV_SPLIT not in (1, 2, 4):
+    raise ValueError("FA_KV_SPLIT must be 1, 2 or 4, got {}".format(KV_SPLIT))
+TOTAL_UNITS = NUM_Q_BLOCKS * KV_SPLIT
+# Partial GM region (fp32 elems), laid out immediately after the per-block FIFO
+# region (base = get_block_num() * GM_ELEMS_PER_BLOCK at runtime). Compile-time
+# sizes because TOTAL_UNITS / S0 / HEAD are all known at build time.
+O_PARTS_ELEMS = TOTAL_UNITS * S0 * HEAD  # [TOTAL_UNITS, S0, HEAD] fp32 (unnormalized O_acc)
+M_PARTS_ELEMS = TOTAL_UNITS * S0  # [TOTAL_UNITS, S0] fp32 (running_max)
+L_PARTS_ELEMS = TOTAL_UNITS * S0  # [TOTAL_UNITS, S0] fp32 (running_sum)
+# Extra GM scratch run.py must allocate after the FIFO region (0 for baseline).
+PARTIAL_ELEMS = (O_PARTS_ELEMS + M_PARTS_ELEMS + L_PARTS_ELEMS) if KV_SPLIT > 1 else 0
+
 # Per-pipe slot sizes (bytes).
 SLOT_SIZE_QK = S0 * S1_TILE * 4  # fp32 QK accumulator
 SLOT_SIZE_PV = S0 * HEAD * 4  # fp32 PV accumulator
@@ -152,6 +173,13 @@ def meta_data():
     kt_sub_ty = pto.SubTensorType(shape=[HEAD, CUBE_S1], dtype=fp16)
     v_sub_ty = pto.SubTensorType(shape=[CUBE_S1, HEAD], dtype=fp16)
     o_sub_slice_ty = pto.SubTensorType(shape=[Vec_S0, HEAD], dtype=fp32)
+
+    # ---- T1-A split-KV partial-output GM views. ----
+    # O_parts is a flat [TOTAL_UNITS*S0, HEAD] fp32 region; m/l_parts are flat
+    # [TOTAL_UNITS*S0, 1] fp32. Per-(unit,row_slice) sub-slices are [Vec_S0, *].
+    o_parts_tensor_ty = pto.TensorType(rank=2, dtype=fp32)
+    red_parts_tensor_ty = pto.TensorType(rank=2, dtype=fp32)
+    red_part_sub_ty = pto.SubTensorType(shape=[Vec_S0, 1], dtype=fp32)
 
     # ---- Address-based slot descriptors (PR #606). ----
     # The QK pipe slot tensor_view describes the GM region one slot covers;
@@ -230,6 +258,7 @@ def meta_data():
 ptr_fp16 = ptr_fp32 = i64 = None
 qkv_tensor_ty = o_tensor_ty = None
 q_sub_ty = kt_sub_ty = v_sub_ty = o_sub_slice_ty = None
+o_parts_tensor_ty = red_parts_tensor_ty = red_part_sub_ty = None
 qk_slot_ty = qk_slot_part_ty = qk_vec_slot_ty = qk_vec_slot_part_ty = None
 pv_slot_ty = pv_slot_part_ty = pv_vec_slot_ty = pv_vec_slot_part_ty = None
 p_slot_ty = p_slot_part_ty = p_cube_slot_ty = p_cube_slot_part_ty = None
@@ -249,17 +278,22 @@ def module():
     # The C++ kernel uses one Q-row block per AIC core (block_idx -> Q rows);
     # in DSL we let the launcher choose blockDim and split inside.
     # -------------------------------------------------------------------------
-    def compute_qb_range(c1):
-        cNUM_Q_BLOCKS = const(NUM_Q_BLOCKS)
+    def compute_range(total, c1):
+        # Even fat/thin share of `total` work-units across this core grid.
+        cTOTAL = const(total)
         num_blocks = s.index_cast(pto.get_block_num())
         bid = s.index_cast(pto.get_block_idx())
-        floor_div = cNUM_Q_BLOCKS // num_blocks
-        extra = cNUM_Q_BLOCKS % num_blocks
+        floor_div = cTOTAL // num_blocks
+        extra = cTOTAL % num_blocks
         fat_start = bid * (floor_div + c1)
         thin_start = extra * (floor_div + c1) + (bid - extra) * floor_div
-        qb_start = s.select(bid < extra, fat_start, thin_start)
+        start = s.select(bid < extra, fat_start, thin_start)
         per_core = s.select(bid < extra, floor_div + c1, floor_div)
-        return bid, qb_start, qb_start + per_core
+        return bid, start, start + per_core
+
+    def compute_qb_range(c1):
+        # Compute phase distributes TOTAL_UNITS (= NUM_Q_BLOCKS * KV_SPLIT).
+        return compute_range(TOTAL_UNITS, c1)
 
     # =========================================================================
     # Cube kernel
@@ -410,28 +444,52 @@ def module():
                     pto.tpush(qk_entry, qk_pipe, SPLIT_UP_DOWN)
 
         # ---- Q-block loop ----
-        for qb in pto.range(qb_start, qb_end, c1):
-            q_view = slice_view(q_sub_ty, source=tv_q, offsets=[qb * cS0, c0], sizes=[cS0, cHEAD])
-            pto.load(q_view, q_mat)
-            tile.mov(q_mat, q_left)
+        if KV_SPLIT == 1:
+            for qb in pto.range(qb_start, qb_end, c1):
+                q_view = slice_view(q_sub_ty, source=tv_q, offsets=[qb * cS0, c0], sizes=[cS0, cHEAD])
+                pto.load(q_view, q_mat)
+                tile.mov(q_mat, q_left)
 
-            # ---- prologue: emit QK[0..QK_PRELOAD-1] -------------------------
-            # V loading is now inline in emit_pv (per-sub-tile), so no preload.
-            for kp in range(QK_PRELOAD):
-                emit_qk(const(kp), kp % 2)
+                # ---- prologue: emit QK[0..QK_PRELOAD-1] ---------------------
+                # V loading is now inline in emit_pv (per-sub-tile), so no preload.
+                for kp in range(QK_PRELOAD):
+                    emit_qk(const(kp), kp % 2)
 
-            # ---- steady state ------------------------------------------------
-            # Match the 140tflops schedule: consume current P/PV and emit the
-            # next QK slot at CUBE_S1 sub-tile granularity.
-            for tile_id in pto.range(c0, steady_tiles, c1):
-                next_tile = tile_id + cPRELOAD
-                emit_qk_pv_interleaved(next_tile, tile_id, 0)
+                # ---- steady state -------------------------------------------
+                # Match the 140tflops schedule: consume current P/PV and emit the
+                # next QK slot at CUBE_S1 sub-tile granularity.
+                for tile_id in pto.range(c0, steady_tiles, c1):
+                    next_tile = tile_id + cPRELOAD
+                    emit_qk_pv_interleaved(next_tile, tile_id, 0)
 
-            # ---- epilogue: drain the last QK_PRELOAD PVs -------------------
-            for k in range(QK_PRELOAD):
-                b = 0
-                t_idx = steady_tiles + const(k)
-                emit_pv(t_idx, b)
+                # ---- epilogue: drain the last QK_PRELOAD PVs ----------------
+                for k in range(QK_PRELOAD):
+                    emit_pv(steady_tiles + const(k), 0)
+        else:
+            # ---- T1-A split-KV: one work-unit = (q block, kv chunk) ----
+            # Tile indices passed to emit_* are ABSOLUTE into K/V, so offset
+            # every local tile by kv_base = chunk * tiles_per_chunk. The FIFO
+            # slot ring and accumulators are per-core, unchanged.
+            cKV_SPLIT = const(KV_SPLIT)
+            tiles_per_chunk = num_tiles_s1 // cKV_SPLIT
+            steady_chunk = tiles_per_chunk - cPRELOAD
+            for u in pto.range(qb_start, qb_end, c1):
+                qb = u // cKV_SPLIT
+                chunk = u % cKV_SPLIT
+                kv_base = chunk * tiles_per_chunk
+                q_view = slice_view(q_sub_ty, source=tv_q, offsets=[qb * cS0, c0], sizes=[cS0, cHEAD])
+                pto.load(q_view, q_mat)
+                tile.mov(q_mat, q_left)
+
+                for kp in range(QK_PRELOAD):
+                    emit_qk(kv_base + const(kp), kp % 2)
+
+                for tile_id in pto.range(c0, steady_chunk, c1):
+                    local = kv_base + tile_id
+                    emit_qk_pv_interleaved(local + cPRELOAD, local, 0)
+
+                for k in range(QK_PRELOAD):
+                    emit_pv(kv_base + steady_chunk + const(k), 0)
 
     # =========================================================================
     # Vector kernel
@@ -509,6 +567,25 @@ def module():
         row_off_sb = sb_idx * cS0_HALF
 
         tv_o = as_tensor(o_tensor_ty, ptr=gm_o, shape=[s0, cHEAD], strides=[cHEAD, c1])
+
+        if KV_SPLIT > 1:
+            # Partial-output GM region begins right after the per-block FIFO
+            # region: base = num_blocks * GM_ELEMS_PER_BLOCK (same blockDim is
+            # used by the reduce launch, so the base matches).
+            num_blocks = s.index_cast(pto.get_block_num())
+            gm_partial = pto.add_ptr(gm_slot_buffer, num_blocks * const(GM_ELEMS_PER_BLOCK))
+            gm_o_parts = gm_partial
+            gm_m_parts = pto.add_ptr(gm_partial, const(O_PARTS_ELEMS))
+            gm_l_parts = pto.add_ptr(gm_partial, const(O_PARTS_ELEMS + M_PARTS_ELEMS))
+            tv_o_parts = as_tensor(
+                o_parts_tensor_ty, ptr=gm_o_parts, shape=[const(TOTAL_UNITS * S0), cHEAD], strides=[cHEAD, c1]
+            )
+            tv_m_parts = as_tensor(
+                red_parts_tensor_ty, ptr=gm_m_parts, shape=[const(TOTAL_UNITS * S0), c1], strides=[c1, c1]
+            )
+            tv_l_parts = as_tensor(
+                red_parts_tensor_ty, ptr=gm_l_parts, shape=[const(TOTAL_UNITS * S0), c1], strides=[c1, c1]
+            )
 
         qk_entry = pto.declare_global(qk_vec_slot_ty)
         p_entry = pto.declare_global(p_slot_ty)
@@ -629,37 +706,150 @@ def module():
             with branch.else_context():
                 emit_gu_update_dispatch(tile_id)
 
-        for qb in pto.range(qb_start, qb_end, c1):
+        def vec_unit_body(steady_count):
+            # Streaming softmax over this unit's KV tiles; identical structure
+            # to the baseline per-qb body, parameterized by the tile count.
             # ---- vec prologue: softmax(0..QK_PRELOAD-1) --------------------
             for kp in range(QK_PRELOAD):
                 emit_softmax(exp_max_ring[kp], is_init=(kp == 0))
 
             # ---- vec steady state. Match the 140tflops order: drain the
             # current PV/GU tile before producing the future P tile.
-            with pto.if_context(steady_tiles > c0):
+            with pto.if_context(steady_count > c0):
                 emit_gu(exp_max_ring[0], is_init=True)
                 emit_softmax(exp_max_ring[QK_PRELOAD % EXP_RING], is_init=False)
 
-                for tile_id in pto.range(c1, steady_tiles, c1):
+                for tile_id in pto.range(c1, steady_count, c1):
                     next_tile = tile_id + cPRELOAD
                     emit_gu_update_dispatch(tile_id)
                     emit_softmax_dispatch(next_tile)
 
             # ---- vec epilogue: drain last QK_PRELOAD gus -------------------
             for k in range(QK_PRELOAD):
-                tile_id = steady_tiles + const(k)
-                emit_gu_any(tile_id)
+                emit_gu_any(steady_count + const(k))
 
-            # Final divide + GM store, one row_slice at a time.
-            for row_slice in range(TILE_FACTOR):
-                tile.row_expand_div(o_tile[row_slice], running_sum[row_slice], o_tile[row_slice])
-                o_view = slice_view(
-                    o_sub_slice_ty,
-                    source=tv_o,
-                    offsets=[qb * cS0 + row_off_sb + const(row_slice * Vec_S0), c0],
-                    sizes=[cVec_S0, cHEAD],
-                )
-                pto.store(o_tile[row_slice], o_view)
+        if KV_SPLIT == 1:
+            for qb in pto.range(qb_start, qb_end, c1):
+                vec_unit_body(steady_tiles)
+                # Final divide + GM store, one row_slice at a time.
+                for row_slice in range(TILE_FACTOR):
+                    tile.row_expand_div(o_tile[row_slice], running_sum[row_slice], o_tile[row_slice])
+                    o_view = slice_view(
+                        o_sub_slice_ty,
+                        source=tv_o,
+                        offsets=[qb * cS0 + row_off_sb + const(row_slice * Vec_S0), c0],
+                        sizes=[cVec_S0, cHEAD],
+                    )
+                    pto.store(o_tile[row_slice], o_view)
+        else:
+            # ---- T1-A split-KV: stream this unit's KV chunk, then write the
+            # UNNORMALIZED partial (O_acc, running_max m, running_sum l) keyed by
+            # unit u. reduce_kernel flash-combines the KV_SPLIT partials per qb.
+            cKV_SPLIT = const(KV_SPLIT)
+            tiles_per_chunk = num_tiles_s1 // cKV_SPLIT
+            steady_chunk = tiles_per_chunk - cPRELOAD
+            for u in pto.range(qb_start, qb_end, c1):
+                vec_unit_body(steady_chunk)
+                u_row_base = u * cS0
+                for row_slice in range(TILE_FACTOR):
+                    row = u_row_base + row_off_sb + const(row_slice * Vec_S0)
+                    o_part = slice_view(o_sub_slice_ty, source=tv_o_parts, offsets=[row, c0], sizes=[cVec_S0, cHEAD])
+                    pto.store(o_tile[row_slice], o_part)
+                    m_part = slice_view(red_part_sub_ty, source=tv_m_parts, offsets=[row, c0], sizes=[cVec_S0, c1])
+                    pto.store(running_max[row_slice], m_part)
+                    l_part = slice_view(red_part_sub_ty, source=tv_l_parts, offsets=[row, c0], sizes=[cVec_S0, c1])
+                    pto.store(running_sum[row_slice], l_part)
+
+    # =========================================================================
+    # Reduce kernel (T1-A): flash-combine the KV_SPLIT partials per Q block.
+    # Launched as a second grid after the compute phase, so it sees all partials
+    # written by all cores. Distributes NUM_Q_BLOCKS over the same core grid.
+    # =========================================================================
+    if KV_SPLIT > 1:
+
+        @pto.func(kernel="vector")
+        def reduce_kernel(
+            gm_slot_buffer: "ptr_fp32", gm_o: "ptr_fp32", s0_i64: "i64", s1_i64: "i64"
+        ) -> None:
+            c0 = const(0)
+            c1 = const(1)
+            cS0 = const(S0)
+            cS0_HALF = const(S0_HALF)
+            cVec_S0 = const(Vec_S0)
+            cHEAD = const(HEAD)
+            cKV_SPLIT = const(KV_SPLIT)
+            s0 = s.index_cast(s0_i64)
+            scale = const(1.0 / math.sqrt(HEAD), s.float32)
+
+            num_blocks = s.index_cast(pto.get_block_num())
+            gm_partial = pto.add_ptr(gm_slot_buffer, num_blocks * const(GM_ELEMS_PER_BLOCK))
+            gm_o_parts = gm_partial
+            gm_m_parts = pto.add_ptr(gm_partial, const(O_PARTS_ELEMS))
+            gm_l_parts = pto.add_ptr(gm_partial, const(O_PARTS_ELEMS + M_PARTS_ELEMS))
+            tv_o_parts = as_tensor(
+                o_parts_tensor_ty, ptr=gm_o_parts, shape=[const(TOTAL_UNITS * S0), cHEAD], strides=[cHEAD, c1]
+            )
+            tv_m_parts = as_tensor(
+                red_parts_tensor_ty, ptr=gm_m_parts, shape=[const(TOTAL_UNITS * S0), c1], strides=[c1, c1]
+            )
+            tv_l_parts = as_tensor(
+                red_parts_tensor_ty, ptr=gm_l_parts, shape=[const(TOTAL_UNITS * S0), c1], strides=[c1, c1]
+            )
+            tv_o = as_tensor(o_tensor_ty, ptr=gm_o, shape=[s0, cHEAD], strides=[cHEAD, c1])
+
+            o_acc = pto.alloc_tile(o_vec_ty)
+            o_i = pto.alloc_tile(o_vec_ty)
+            gmax = pto.alloc_tile(red_ty)
+            mtmp = pto.alloc_tile(red_ty)
+            gsum = pto.alloc_tile(red_ty)
+            ltmp = pto.alloc_tile(red_ty)
+            corr = pto.alloc_tile(red_ty)
+
+            sb_idx = s.index_cast(pto.get_subblock_idx())
+            row_off_sb = sb_idx * cS0_HALF
+            bid, qb_start, qb_end = compute_range(NUM_Q_BLOCKS, c1)
+
+            for qb in pto.range(qb_start, qb_end, c1):
+                u0 = qb * cKV_SPLIT
+                for row_slice in range(TILE_FACTOR):
+                    row = row_off_sb + const(row_slice * Vec_S0)
+                    # pass 1: global_max = max_i m_i
+                    m0 = slice_view(red_part_sub_ty, source=tv_m_parts, offsets=[u0 * cS0 + row, c0], sizes=[cVec_S0, c1])
+                    pto.load(m0, gmax)
+                    for i in range(1, KV_SPLIT):
+                        mi = slice_view(
+                            red_part_sub_ty, source=tv_m_parts, offsets=[(u0 + const(i)) * cS0 + row, c0], sizes=[cVec_S0, c1]
+                        )
+                        pto.load(mi, mtmp)
+                        tile.max(tile.reshape(red_row_ty, mtmp), tile.reshape(red_row_ty, gmax), tile.reshape(red_row_ty, gmax))
+                    # pass 2: global_l = sum_i l_i*corr_i, global_O = sum_i O_i*corr_i
+                    for i in range(KV_SPLIT):
+                        ui = u0 + const(i)
+                        mi = slice_view(red_part_sub_ty, source=tv_m_parts, offsets=[ui * cS0 + row, c0], sizes=[cVec_S0, c1])
+                        li = slice_view(red_part_sub_ty, source=tv_l_parts, offsets=[ui * cS0 + row, c0], sizes=[cVec_S0, c1])
+                        oi = slice_view(o_sub_slice_ty, source=tv_o_parts, offsets=[ui * cS0 + row, c0], sizes=[cVec_S0, cHEAD])
+                        pto.load(mi, mtmp)
+                        pto.load(li, ltmp)
+                        pto.load(oi, o_i)
+                        mtmp_r = tile.reshape(red_row_ty, mtmp)
+                        gmax_r = tile.reshape(red_row_ty, gmax)
+                        corr_r = tile.reshape(red_row_ty, corr)
+                        ltmp_r = tile.reshape(red_row_ty, ltmp)
+                        gsum_r = tile.reshape(red_row_ty, gsum)
+                        tile.sub(mtmp_r, gmax_r, corr_r)  # corr = m_i - global_max  (<= 0)
+                        tile.muls(corr_r, scale, corr_r)
+                        tile.exp(corr_r, corr_r)
+                        tile.mul(ltmp_r, corr_r, ltmp_r)  # l_i *= corr
+                        tile.row_expand_mul(o_i, corr, o_i)  # O_i *= corr (broadcast over HEAD)
+                        if i == 0:
+                            tile.mov(ltmp_r, gsum_r)
+                            tile.mov(o_i, o_acc)
+                        else:
+                            tile.add(gsum_r, ltmp_r, gsum_r)
+                            tile.add(o_acc, o_i, o_acc)
+                    tile.row_expand_div(o_acc, gsum, o_acc)
+                    o_view = slice_view(o_sub_slice_ty, source=tv_o, offsets=[qb * cS0 + row, c0], sizes=[cVec_S0, cHEAD])
+                    pto.store(o_acc, o_view)
 
     # =========================================================================
     # Entry point invoked by the host caller via <<<>>>
@@ -679,6 +869,20 @@ def module():
         pto.set_ffts(ffts_addr)
         pto.call(cube_kernel, gm_slot_buffer, gm_slot_buffer_fp16, gm_q, gm_k, gm_v, s0_i64, s1_i64)
         pto.call(vector_kernel, gm_slot_buffer, gm_slot_buffer_fp16, gm_o, s0_i64, s1_i64)
+
+    if KV_SPLIT > 1:
+
+        @pto.func
+        def call_reduce(
+            ffts_addr: pto.ffts_type,
+            gm_slot_buffer: "ptr_fp32",
+            gm_slot_buffer_fp16: "ptr_fp16",
+            gm_o: "ptr_fp32",
+            s0_i64: "i64",
+            s1_i64: "i64",
+        ) -> None:
+            pto.set_ffts(ffts_addr)
+            pto.call(reduce_kernel, gm_slot_buffer, gm_o, s0_i64, s1_i64)
 
 
 if __name__ == "__main__":

--- a/kernels/python/flash_atten/run.py
+++ b/kernels/python/flash_atten/run.py
@@ -192,7 +192,34 @@ def _default_summary_tsv():
 
 
 def _default_case_s1_tile(seq_len):
-    return 512 if seq_len >= 16384 else 256
+    return 512 if seq_len >= 32768 else 256
+
+
+def _default_case_kv_split(q_rows, seq_len, s1_tile):
+    """T1-A wave-quantization fix: pick KV_SPLIT for the default suite.
+
+    Splitting a Q block's KV across KV_SPLIT work-units only pays off when it
+    materially raises cube-wave utilization (so the recovered idle cores beat
+    the cross-core reduction's extra GM round-trip + second launch). Apply it
+    only when (a) util jumps enough, (b) the problem is large enough to amortize
+    the reduction, and (c) each chunk still satisfies the QK_PRELOAD floor.
+
+    Measured (bench_ab paired, IQR ~0.1%): case5 (128 Q blocks, 88.9% util)
+    gains ~+4.2%; case6..case8 (>=97% util) see no util headroom so stay at
+    KV_SPLIT=1.
+    """
+    builder = _load_builder()
+    cores = get_num_cube_cores()
+    n_blocks = q_rows // builder.S0
+    num_tiles = seq_len // s1_tile
+
+    def util(units):
+        waves = -(-units // cores)  # ceil
+        return units / (cores * waves)
+
+    if num_tiles >= 32 and (num_tiles // 2) >= builder.QK_PRELOAD and util(2 * n_blocks) - util(n_blocks) > 0.05:
+        return 2
+    return 1
 
 
 def _summary_fields():
@@ -233,7 +260,23 @@ def _num_tiles(seq_len):
     if seq_len % builder.S1_TILE != 0:
         raise ValueError("seq_len {} is not a multiple of S1_TILE={}".format(seq_len, builder.S1_TILE))
     num_tiles = seq_len // builder.S1_TILE
-    if num_tiles < builder.QK_PRELOAD:
+    kv_split = getattr(builder, "KV_SPLIT", 1)
+    if kv_split > 1:
+        # T1-A split-KV: each of KV_SPLIT chunks gets an equal slice of the
+        # tiles and must itself satisfy the QK_PRELOAD prologue floor.
+        if num_tiles % kv_split != 0:
+            raise ValueError(
+                "seq_len {} maps to {} tiles which is not divisible by KV_SPLIT={}".format(
+                    seq_len, num_tiles, kv_split
+                )
+            )
+        per_chunk = num_tiles // kv_split
+        if per_chunk < builder.QK_PRELOAD:
+            raise ValueError(
+                "seq_len {} maps to {} tiles -> {} tiles/chunk at KV_SPLIT={}; QK_PRELOAD={} requires "
+                "tiles/chunk >= QK_PRELOAD".format(seq_len, num_tiles, per_chunk, kv_split, builder.QK_PRELOAD)
+            )
+    elif num_tiles < builder.QK_PRELOAD:
         raise ValueError(
             "seq_len {} maps to {} tiles; the current QK_PRELOAD={} runtime loop requires "
             "num_tiles >= QK_PRELOAD".format(seq_len, num_tiles, builder.QK_PRELOAD)
@@ -282,12 +325,17 @@ def _to_void_p(t):
 def _block_dim():
     _load_runtime_deps()
     builder = _load_builder()
-    return min(builder.NUM_Q_BLOCKS, get_num_cube_cores())
+    # T1-A split-KV launches TOTAL_UNITS (= NUM_Q_BLOCKS * KV_SPLIT) work-units;
+    # the kernel self-distributes them over the grid. KV_SPLIT=1 -> NUM_Q_BLOCKS.
+    total_units = getattr(builder, "TOTAL_UNITS", builder.NUM_Q_BLOCKS)
+    return min(total_units, get_num_cube_cores())
 
 
 def _slot_elems(block_dim):
     builder = _load_builder()
-    return builder.GM_ELEMS_PER_BLOCK * block_dim
+    # FIFO region + (split-KV only) the partial-output scratch the reduce launch
+    # reads. PARTIAL_ELEMS is 0 in the baseline so the footprint is unchanged.
+    return builder.GM_ELEMS_PER_BLOCK * block_dim + getattr(builder, "PARTIAL_ELEMS", 0)
 
 
 def attn_flops_matmul_softmax_scale(
@@ -508,14 +556,25 @@ def _run_default_suite(args):
             "--no-build is only valid for a single selected case because build_artifacts/fa.so is rebuilt per FA_Q_ROWS"
         )
 
+    # Device init so the per-case KV_SPLIT gate can read the cube-core count.
+    _load_runtime_deps()
+    torch.npu.set_device(get_test_device())
+
     summary_tsv = SUMMARY_TSV or _default_summary_tsv()
     print("[fa] running built-in default benchmark suite")
     print("[fa] selected cases: {}".format(", ".join(case_id for case_id, _, _ in cases)))
     print("[fa] summary TSV: {}".format(summary_tsv))
 
+    kv_override = os.environ.get("FA_KV_SPLIT")
+
     for case_id, s0, s1 in cases:
         s1_tile = _default_case_s1_tile(s1)
-        print("\n{:=^110}".format(" {} S0={} S1={} TILE_S1={} ".format(case_id, s0, s1, s1_tile)))
+        kv_split = int(kv_override) if kv_override else _default_case_kv_split(s0, s1, s1_tile)
+        print(
+            "\n{:=^110}".format(
+                " {} S0={} S1={} TILE_S1={} KV_SPLIT={} ".format(case_id, s0, s1, s1_tile, kv_split)
+            )
+        )
         env = os.environ.copy()
         env.update(
             {
@@ -523,6 +582,7 @@ def _run_default_suite(args):
                 "FA_Q_ROWS": str(s0),
                 "FA_BENCH_LENGTHS": str(s1),
                 "FA_S1_TILE": str(s1_tile),
+                "FA_KV_SPLIT": str(kv_split),
                 "FA_SUMMARY_TSV": summary_tsv,
             }
         )


### PR DESCRIPTION
## Summary

Refines the `kernels/python/flash_atten` example and its companion skill:

- **README / README_zh normalization.** Removes the "140 TFLOPS" references and reframes TFLOP/s as a *shape-dependent measured value* (not a fixed target). Adds a **verified dependency-version table** (`ptodsl 0.1.2` / `ptoas 0.45` / CANN `9.0.0` / `torch`+`torch_npu 2.9.0` / driver `26.0.rc1`) plus the `ptoas`-0.45 GlobalData header-pairing note so runs are reproducible. Documents the new knobs (`KV_SPLIT`, `FA_BENCH_TIMING`) and the updated suite table.
- **Performance: split-KV (`KV_SPLIT`) wave-quantization path.** When a Q block doesn't produce enough cube work-units to fill all cube-core waves, each Q block's KV (S1) is split across `KV_SPLIT` work-units (`TOTAL_UNITS = NUM_Q_BLOCKS * KV_SPLIT`); a second `reduce` grid launch flash-combines the per-Q-block partials into the final normalized `O`. Auto-selected **per shape and per device** from the cube-core wave utilization. `KV_SPLIT=1` is the exact baseline (no split, no second launch). The default-suite `S1_TILE=512` cutover moves to `S1 >= 32768`, so `case5`/16384 now runs `TILE_S1=256 + KV_SPLIT=2` (its only good config).
- **Skill update.** Bumps the empirical `S1_TILE` recommendation threshold `16384 -> 32768` across the flash-atten pipeline skill and references.

> **Build note.** On `ptoas 0.45`, building this example requires the GlobalData header compile fix in #174.

## Verification

Full default suite (`case1`..`case8`) built and benchmarked on **Ascend A3 (24 cube cores), `ptoas 0.45`, event timing**, vs `torch_npu.npu_fused_infer_attention_score`. **All 8 cases pass** correctness (`run.py` exit 0); the per-case knob selection matches the documented table (`case5` → `TILE_S1=256 KV_SPLIT=2`, `case6`–`case8` → `TILE_S1=512`, rest baseline `KV_SPLIT=1`).

| Case | S0 = S1 | tiles | `S1_TILE` | `KV_SPLIT` | fa µs | fa TFLOP/s | torch_npu µs | speedup | err_kernel |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| case1 | 1024 | 4 | 256 | 1 | 19.28 | 28.17 | 53.78 | **2.79×** | 4.50e-05 |
| case2 | 2048 | 8 | 256 | 1 | 43.21 | 50.28 | 73.78 | **1.71×** | 3.99e-05 |
| case3 | 4096 | 16 | 256 | 1 | 116.58 | 74.55 | 137.31 | **1.18×** | 2.47e-05 |
| case4 | 8192 | 32 | 256 | 1 | 285.84 | 121.62 | 294.73 | **1.03×** | 1.78e-05 |
| case5 | 16384 | 64 | 256 | 2 | 989.16 | 140.57 | 854.61 | 0.86× | 1.27e-05 |
| case6 | 32768 | 64 | 512 | 1 | 3552.52 | 156.56 | 3092.22 | 0.87× | 1.76e-05 |
| case7 | 65536 | 128 | 512 | 1 | 13743.00 | 161.89 | 12062.73 | 0.88× | 1.36e-05 |
| case8 | 131072 | 256 | 512 | 1 | 51760.48 | 171.93 | 47900.00 | 0.93× | 9.07e-06 |

**Reading the band:** the DSL kernel beats `torch_npu` on the launch/overhead-favored small shapes (`case1`–`case4`, 2.79× → 1.03×) and sits at ~0.86–0.93× on the large compute-bound prefill shapes (`case5`–`case8`). Correctness errors stay in the `9e-6 .. 4.5e-5` band throughout (host FP32 reference for `case1`–`case5`; `npu_fused` reference for the largest three where the host FP32 path is skipped). TFLOP/s figures are shape-dependent measured values, consistent with the README's reframing.

> ⚠️ **The `case5`–`case8` ~0.86–0.93× band is _not_ a regression introduced by this PR.** It is a pre-existing, header-level performance regression in `TPipe::SyncPeriod` (`include/pto/npu/a2a3/TPush.hpp`) — flipped from `(SlotNum<=2)?SlotNum:SlotNum/2` to `SlotNum` by an earlier commit (`014920a8`, "Clean pending free signals during TPUSH") — and is independent of this PR's split-KV / README changes. It is tracked separately in #172. A controlled A/B that toggles **only** the `SyncPeriod` line (same card, same `ptoas 0.45`, same MLIR; `--timing sync`) recovers `case6`–`case8` to ~1.00–1.01× parity (~185 TFLOP/s) with byte-identical correctness; see #172 for the full per-case comparison.

> Note: absolute TFLOP/s / speedups vary run-to-run (event timing); use per-shape latency and the `torch_npu` speedup for comparison.



