### PR TITLE
fix(a2a3): correct TConcat blockLen for unequal src0/src1 column sizes and add test case

### DIFF
--- a/include/pto/npu/a2a3/TConcat.hpp
+++ b/include/pto/npu/a2a3/TConcat.hpp
@@ -34,18 +34,20 @@ __tf__ PTO_INTERNAL void TConcatImpl(typename TileDataD::TileDType __out__ dst,
     constexpr unsigned src0RowStride = TileDataS0::RowStride;
     constexpr unsigned src1RowStride = TileDataS1::RowStride;
 
-    unsigned blockLen = (validCol0 * sizeof(TD) + BLOCK_BYTE_SIZE - 1) / BLOCK_BYTE_SIZE;
-    unsigned src0Gap = (TileDataS0::Cols * sizeof(TD) + BLOCK_BYTE_SIZE - 1) / BLOCK_BYTE_SIZE - blockLen;
-    unsigned dstGap = (TileDataD::Cols * sizeof(TD) + BLOCK_BYTE_SIZE - 1) / BLOCK_BYTE_SIZE - blockLen;
+    unsigned src0BlockLen = (validCol0 * sizeof(TD) + BLOCK_BYTE_SIZE - 1) / BLOCK_BYTE_SIZE;
+    unsigned src1BlockLen = (validCol1 * sizeof(TD) + BLOCK_BYTE_SIZE - 1) / BLOCK_BYTE_SIZE;
+    unsigned src0Gap = (TileDataS0::Cols * sizeof(TD) + BLOCK_BYTE_SIZE - 1) / BLOCK_BYTE_SIZE - src0BlockLen;
+    unsigned dstGap = (TileDataD::Cols * sizeof(TD) + BLOCK_BYTE_SIZE - 1) / BLOCK_BYTE_SIZE - src0BlockLen;
     for (int i = 0; i < validRow; i++) {
-        pto_copy_ubuf_to_ubuf(dstPtr + i * dstRowStride, src0Ptr + i * src0RowStride, 1, blockLen, src0Gap, dstGap);
+        pto_copy_ubuf_to_ubuf(dstPtr + i * dstRowStride, src0Ptr + i * src0RowStride, 1, src0BlockLen, src0Gap, dstGap);
     }
 
     bool isAligned = (validCol0 % elementsPerBlock) == 0;
     if (isAligned) {
-        unsigned src1Gap = (TileDataS1::Cols * sizeof(TD) + BLOCK_BYTE_SIZE - 1) / BLOCK_BYTE_SIZE - blockLen;
+        unsigned src1Gap = (TileDataS1::Cols * sizeof(TD) + BLOCK_BYTE_SIZE - 1) / BLOCK_BYTE_SIZE - src1BlockLen;
+        dstGap = (TileDataD::Cols * sizeof(TD) + BLOCK_BYTE_SIZE - 1) / BLOCK_BYTE_SIZE - src1BlockLen;
         for (int i = 0; i < validRow; i++) {
-            pto_copy_ubuf_to_ubuf(dstPtr + i * dstRowStride + validCol0, src1Ptr + i * src1RowStride, 1, blockLen,
+            pto_copy_ubuf_to_ubuf(dstPtr + i * dstRowStride + validCol0, src1Ptr + i * src1RowStride, 1, src1BlockLen,
                                   src1Gap, dstGap);
         }
     } else {

--- a/tests/npu/a2a3/src/st/testcase/tconcat/gen_data.py
+++ b/tests/npu/a2a3/src/st/testcase/tconcat/gen_data.py
@@ -87,6 +87,7 @@ if __name__ == "__main__":
         TConcatParams(np.float16, 16, 128, 16, 64, 16, 64, 16, 63, 64),
         TConcatParams(np.float32, 16, 64, 16, 32, 16, 32, 16, 31, 32),
         TConcatParams(np.int16, 32, 256, 32, 128, 32, 128, 32, 127, 128),
+        TConcatParams(np.int16, 32, 192, 32, 128, 32, 128, 32, 128, 64),
     ]
 
     for param in case_params_list:

--- a/tests/npu/a2a3/src/st/testcase/tconcat/main.cpp
+++ b/tests/npu/a2a3/src/st/testcase/tconcat/main.cpp
@@ -141,3 +141,8 @@ TEST_F(TCONCATTest, case_int16_32x256_32x128_32x128_32x127_32x128)
 {
     test_tconcat<int16_t, 32, 256, 32, 128, 32, 128, 32, 127, 128>();
 }
+
+TEST_F(TCONCATTest, case_int16_32x192_32x128_32x128_32x128_32x64)
+{
+    test_tconcat<int16_t, 32, 192, 32, 128, 32, 128, 32, 128, 64>();
+}

--- a/tests/npu/a2a3/src/st/testcase/tconcat/tconcat_kernel.cpp
+++ b/tests/npu/a2a3/src/st/testcase/tconcat/tconcat_kernel.cpp
@@ -84,3 +84,5 @@ template void LaunchTConcat<float, 16, 64, 16, 32, 16, 32, 16, 31, 32>(float *ou
                                                                        void *stream);
 template void LaunchTConcat<int16_t, 32, 256, 32, 128, 32, 128, 32, 127, 128>(int16_t *out, int16_t *src0,
                                                                               int16_t *src1, void *stream);
+template void LaunchTConcat<int16_t, 32, 192, 32, 128, 32, 128, 32, 128, 64>(int16_t *out, int16_t *src0, int16_t *src1,
+                                                                             void *stream);


### PR DESCRIPTION
Split single blockLen into src0BlockLen and src1BlockLen in TConcatImpl to fix incorrect copy length when src0 and src1 have different column counts. Recalculate dstGap for the aligned src1 copy phase. Add case_int16_32x192_32x128_32x128_32x128_32x64 test case to cover this scenario.