### PR TITLE
fix(common): forward explicit <Pipe, GlobalData, Split> on NPU GlobalData FIFO ops (ptoas 0.45 build fix)

### DIFF
--- a/include/pto/common/pto_instr.hpp
+++ b/include/pto/common/pto_instr.hpp
@@ -2134,7 +2134,7 @@ PTO_INST RecordEvent TALLOC(Pipe &pipe, GlobalData &gmTensor, WaitEvents &...eve
 #ifdef __CPU_SIM
     TALLOC_GLOBAL_IMPL<Pipe, GlobalData, Split>(pipe, gmTensor);
 #else
-    TALLOC_IMPL(pipe, gmTensor);
+    TALLOC_IMPL<Pipe, GlobalData, Split>(pipe, gmTensor);
 #endif
     return {};
 }
@@ -2148,7 +2148,7 @@ PTO_INST RecordEvent TPUSH(Pipe &pipe, GlobalData &gmTensor, WaitEvents &...even
 #ifdef __CPU_SIM
     TPUSH_GLOBAL_IMPL<Pipe, GlobalData, Split>(pipe, gmTensor);
 #else
-    TPUSH_IMPL(pipe, gmTensor);
+    TPUSH_IMPL<Pipe, GlobalData, Split>(pipe, gmTensor);
 #endif
     return {};
 }
@@ -2162,7 +2162,7 @@ PTO_INST RecordEvent TPOP(Pipe &pipe, GlobalData &gmTensor, WaitEvents &...event
 #ifdef __CPU_SIM
     TPOP_GLOBAL_IMPL<Pipe, GlobalData, Split>(pipe, gmTensor);
 #else
-    TPOP_IMPL(pipe, gmTensor);
+    TPOP_IMPL<Pipe, GlobalData, Split>(pipe, gmTensor);
 #endif
     return {};
 }
@@ -2176,7 +2176,7 @@ PTO_INST RecordEvent TFREE(Pipe &pipe, GlobalData &gmTensor, WaitEvents &...even
 #ifdef __CPU_SIM
     TFREE_GLOBAL_IMPL<Pipe, GlobalData, Split>(pipe, gmTensor);
 #else
-    TFREE_IMPL(pipe, gmTensor);
+    TFREE_IMPL<Pipe, GlobalData, Split>(pipe, gmTensor);
 #endif
     return {};
 }


### PR DESCRIPTION
## Summary

Framework-level build fix for `include/pto/common/pto_instr.hpp`.

The `GlobalData` overloads of `TALLOC` / `TPUSH` / `TPOP` / `TFREE` in `include/pto/common/pto_instr.hpp` called the backend `*_IMPL` on the **non-`__CPU_SIM`** path via plain argument deduction:

```cpp
#ifdef __CPU_SIM
    TPUSH_GLOBAL_IMPL<Pipe, GlobalData, Split>(pipe, gmTensor);   // already explicit
#else
    TPUSH_IMPL(pipe, gmTensor);                                   // relied on deduction
#endif
```

The non-type template parameter `Split` is **not deducible** from the call arguments — it appears only in the offset math inside the `_IMPL` body (`getPushSubAIVOffset<GlobalData, Split>()`, `push<Tile, Split>`, …). Against `ptoas 0.45` and the current in-tree backend headers (where the `_IMPL` no longer defaults `Split`) this **fails to compile**; against older headers that did default `Split` it **silently used the wrong `Split`** for the address computation.

This passes `<Pipe, GlobalData, Split>` explicitly on the NPU path, mirroring the existing `__CPU_SIM` branch.

## Scope / impact

- **NPU path only.** CPU and SIM (`__CPU_SIM`) builds are untouched (they already passed explicit args via `*_GLOBAL_IMPL`).
- **GlobalData (GM-FIFO) overloads only.** The tile-data overloads were already explicit and are not changed.
- **No new ambiguity.** The tile-data vs global-data overloads are guarded by mutually-exclusive SFINAE (`is_tile_data_v` vs `is_global_data_v`); `TALLOC_IMPL`/`TFREE_IMPL` also differ in template arity.
- For callers using the default `Split` (`TILE_UP_DOWN`) behavior is unchanged; for callers passing a non-default `Split` (e.g. `distributed_ffn_grid`'s `TILE_NO_SPLIT`) it is a correctness fix.
- ptoas-version-independent: works whether or not the backend `_IMPL` defaults `Split`.

## Verification

Builds and runs the `kernels/python/flash_atten` example (and other GM-FIFO GlobalData kernels) on **Ascend A3, `ptoas 0.45`**: the full `case1`..`case8` suite builds and passes. Without this change the example does not compile against `ptoas 0.45`.
