### PR TITLE
fix(a2a3/ttrans): stage scalar TTRANS through tmp so in-place transpose is correct

### DIFF
--- a/include/pto/npu/a2a3/TTrans.hpp
+++ b/include/pto/npu/a2a3/TTrans.hpp
@@ -237,14 +237,14 @@ PTO_INTERNAL void TransTailTilesStaged(__ubuf__ T *dstPtr, __ubuf__ T *srcPtr, _
     wait_flag(PIPE_V, PIPE_S, EVENT_ID0);
 #endif
     // transpose src -> tmp (src fully read out before any dst write)
-    for (int i = 0; i < validRow; i++) {
-        for (int j = 0; j < validCol; j++) {
+    for (uint32_t i = 0; i < validRow; i++) {
+        for (uint32_t j = 0; j < validCol; j++) {
             tmpPtr[j * validRow + i] = srcPtr[i * srcStride + j];
         }
     }
     // copy tmp -> dst (safe even if dstPtr == srcPtr: src already consumed)
-    for (int j = 0; j < validCol; j++) {
-        for (int i = 0; i < validRow; i++) {
+    for (uint32_t j = 0; j < validCol; j++) {
+        for (uint32_t i = 0; i < validRow; i++) {
             dstPtr[j * dstStride + i] = tmpPtr[j * validRow + i];
         }
     }
@@ -266,10 +266,17 @@ PTO_INTERNAL void TTransOperation(__ubuf__ T *dstPtr, __ubuf__ T *srcPtr, __ubuf
     unsigned tmpStride = (validRow + yTileSizeElem - 1) / yTileSizeElem * yTileSizeElem;
     if (((dstStride % yTileSizeElem) != 0) || ((srcStride % blockSizeElem) != 0) ||
         ((tmpStride % yTileSizeElem) != 0)) {
-        // Scalar fallback: stage through tmp so an in-place (dst == src) transpose
-        // stays correct (the plain direct-write TransTailTiles corrupts on alias).
-        TransTailTilesStaged<T, blockSizeElem, yTileSizeElem>(dstPtr, srcPtr, tmpPtr, validRow, validCol, dstStride,
-                                                              srcStride);
+        // Scalar fallback. The direct TransTailTiles writes dst straight from src
+        // (no staging) and is unsafe only when dst aliases src. Stage through tmp
+        // for the in-place case so it stays correct; keep the direct, copy-free
+        // path for the common out-of-place case.
+        if (dstPtr == srcPtr) {
+            TransTailTilesStaged<T, blockSizeElem, yTileSizeElem>(dstPtr, srcPtr, tmpPtr, validRow, validCol, dstStride,
+                                                                  srcStride);
+        } else {
+            TransTailTiles<T, blockSizeElem, yTileSizeElem>(dstPtr, srcPtr, tmpStride, validRow, validCol, dstStride,
+                                                            srcStride);
+        }
         return;
     }
     // go by subtile column, a.k.a. iter in row direction

--- a/include/pto/npu/a2a3/TTrans.hpp
+++ b/include/pto/npu/a2a3/TTrans.hpp
@@ -220,6 +220,43 @@ PTO_INTERNAL void TransTailTiles(__ubuf__ T *dstPtr, __ubuf__ T *srcPtr, unsigne
     return;
 }
 
+// In-place-safe scalar transpose: stage the result into tmp (tight stride =
+// validRow) before writing any element of dst, so dst may safely alias src.
+// The plain TransTailTiles writes dst directly from src and corrupts when
+// dst == src; this variant fully reads src into tmp first. tmp holds
+// validCol * validRow elements, which fits the op's tmp tile (sized to the
+// input element count). Used for the unaligned (scalar) TTransOperation path.
+template <typename T, unsigned blockSizeElem, unsigned yTileSizeElem>
+PTO_INTERNAL void TransTailTilesStaged(__ubuf__ T *dstPtr, __ubuf__ T *srcPtr, __ubuf__ T *tmpPtr, unsigned validRow,
+                                       unsigned validCol, unsigned dstStride, unsigned srcStride)
+{
+#ifndef __PTO_AUTO__
+    PtoSetWaitFlag<PIPE_V, PIPE_S>();
+#else
+    set_flag(PIPE_V, PIPE_S, EVENT_ID0);
+    wait_flag(PIPE_V, PIPE_S, EVENT_ID0);
+#endif
+    // transpose src -> tmp (src fully read out before any dst write)
+    for (int i = 0; i < validRow; i++) {
+        for (int j = 0; j < validCol; j++) {
+            tmpPtr[j * validRow + i] = srcPtr[i * srcStride + j];
+        }
+    }
+    // copy tmp -> dst (safe even if dstPtr == srcPtr: src already consumed)
+    for (int j = 0; j < validCol; j++) {
+        for (int i = 0; i < validRow; i++) {
+            dstPtr[j * dstStride + i] = tmpPtr[j * validRow + i];
+        }
+    }
+#ifndef __PTO_AUTO__
+    PtoSetWaitFlag<PIPE_S, PIPE_V>();
+#else
+    set_flag(PIPE_S, PIPE_V, EVENT_ID0);
+    wait_flag(PIPE_S, PIPE_V, EVENT_ID0);
+#endif
+    return;
+}
+
 template <typename T, unsigned blockSizeElem>
 PTO_INTERNAL void TTransOperation(__ubuf__ T *dstPtr, __ubuf__ T *srcPtr, __ubuf__ T *tmpPtr, unsigned validRow,
                                   unsigned validCol, unsigned dstStride, unsigned srcStride)
@@ -229,8 +266,10 @@ PTO_INTERNAL void TTransOperation(__ubuf__ T *dstPtr, __ubuf__ T *srcPtr, __ubuf
     unsigned tmpStride = (validRow + yTileSizeElem - 1) / yTileSizeElem * yTileSizeElem;
     if (((dstStride % yTileSizeElem) != 0) || ((srcStride % blockSizeElem) != 0) ||
         ((tmpStride % yTileSizeElem) != 0)) {
-        TransTailTiles<T, blockSizeElem, yTileSizeElem>(dstPtr, srcPtr, tmpStride, validRow, validCol, dstStride,
-                                                        srcStride);
+        // Scalar fallback: stage through tmp so an in-place (dst == src) transpose
+        // stays correct (the plain direct-write TransTailTiles corrupts on alias).
+        TransTailTilesStaged<T, blockSizeElem, yTileSizeElem>(dstPtr, srcPtr, tmpPtr, validRow, validCol, dstStride,
+                                                              srcStride);
         return;
     }
     // go by subtile column, a.k.a. iter in row direction

--- a/tests/npu/a2a3/src/st/testcase/ttrans/gen_data.py
+++ b/tests/npu/a2a3/src/st/testcase/ttrans/gen_data.py
@@ -34,12 +34,12 @@ def gen_golden_trans_data(case_name, param):
 
 class TTRANSParams:
     def __init__(self, dtype, tile_row, tile_col, valid_row, valid_col):
-        self.dtype = dtype 
+        self.dtype = dtype
         self.tile_row = tile_row
         self.tile_col = tile_col
         self.valid_row = valid_row
         self.valid_col = valid_col
-    
+
 def generate_case_name(idx, param):
     dtype_str = {
         np.float32: 'float',

--- a/tests/npu/a2a3/src/st/testcase/ttrans/gen_data.py
+++ b/tests/npu/a2a3/src/st/testcase/ttrans/gen_data.py
@@ -90,3 +90,16 @@ if __name__ == "__main__":
         os.chdir(case_name)
         gen_golden_trans_data(case_name, param)
         os.chdir(original_dir)
+
+    # In-place regression case (dst tile aliases src tile): same [8,8] FP32 data
+    # as case19; the golden is still the plain transpose x.T.
+    inplace_cases = [
+        ("TTRANSTest.case_inplace_float_8_8_8_8", TTRANSParams(np.float32, 8, 8, 8, 8)),
+    ]
+    for case_name, param in inplace_cases:
+        if not os.path.exists(case_name):
+            os.makedirs(case_name)
+        original_dir = os.getcwd()
+        os.chdir(case_name)
+        gen_golden_trans_data(case_name, param)
+        os.chdir(original_dir)

--- a/tests/npu/a2a3/src/st/testcase/ttrans/main.cpp
+++ b/tests/npu/a2a3/src/st/testcase/ttrans/main.cpp
@@ -18,6 +18,9 @@ using namespace PtoTestCommon;
 template <typename T, int tRows, int tCols, int vRows, int vCols>
 void LaunchTTRANS(T *out, T *src, void *stream);
 
+template <typename T, int tRows, int tCols, int vRows, int vCols>
+void LaunchTTRANSInplace(T *out, T *src, void *stream);
+
 class TTRANSTest : public testing::Test {
 protected:
     void SetUp() override
@@ -35,7 +38,7 @@ std::string GetGoldenDir()
     return fullPath;
 }
 
-template <typename T, int tRows, int tCols, int vRows, int vCols>
+template <typename T, int tRows, int tCols, int vRows, int vCols, bool inplace = false>
 void test_ttrans()
 {
     uint32_t M = tRows;
@@ -60,7 +63,11 @@ void test_ttrans()
     ReadFile(GetGoldenDir() + "/input.bin", srcFileSize, srcHost, srcFileSize);
 
     aclrtMemcpy(srcDevice, srcFileSize, srcHost, srcFileSize, ACL_MEMCPY_HOST_TO_DEVICE);
-    LaunchTTRANS<T, tRows, tCols, vRows, vCols>(dstDevice, srcDevice, stream);
+    if constexpr (inplace) {
+        LaunchTTRANSInplace<T, tRows, tCols, vRows, vCols>(dstDevice, srcDevice, stream);
+    } else {
+        LaunchTTRANS<T, tRows, tCols, vRows, vCols>(dstDevice, srcDevice, stream);
+    }
 
     aclrtSynchronizeStream(stream);
     aclrtMemcpy(dstHost, dstFileSize, dstDevice, dstFileSize, ACL_MEMCPY_DEVICE_TO_HOST);
@@ -163,4 +170,11 @@ TEST_F(TTRANSTest, case18_int8_64_64_22_63)
 TEST_F(TTRANSTest, case19_float_8_8_8_8)
 {
     test_ttrans<float, 8, 8, 8, 8>();
+}
+// In-place regression: dst tile aliases the src tile's UB buffer. The [8,8] FP32
+// transpose takes the scalar ttrans path (dst cols 8, not a multiple of 16); the
+// direct-write fallback corrupted dst == src, the tmp-staging fix makes it correct.
+TEST_F(TTRANSTest, case_inplace_float_8_8_8_8)
+{
+    test_ttrans<float, 8, 8, 8, 8, true>();
 }

--- a/tests/npu/a2a3/src/st/testcase/ttrans/ttrans_kernel.cpp
+++ b/tests/npu/a2a3/src/st/testcase/ttrans/ttrans_kernel.cpp
@@ -15,7 +15,7 @@ See LICENSE in the root of the software repository for the full text of the Lice
 
 using namespace pto;
 
-template <typename T, int tRows, int tCols>
+template <typename T, int tRows, int tCols, bool inplace = false>
 __global__ AICORE void runTTRANS(__gm__ T __out__ *out, __gm__ T __in__ *src, int vRows, int vCols)
 {
     using DynShapeSrc = pto::Shape<-1, -1, -1, -1, -1>;
@@ -50,7 +50,9 @@ __global__ AICORE void runTTRANS(__gm__ T __out__ *out, __gm__ T __in__ *src, in
     constexpr unsigned alignedTmpTileSize = (tmpTileH * tmpTileW * sizeof(T));
     static_assert((alignedSrcTileSize + alignedDstTileSize + alignedTmpTileSize) <= 192 * 1024, "UB overflow");
     TASSIGN(srcTile, 0x0);
-    TASSIGN(dstTile, alignedSrcTileSize);
+    // inplace=true aliases the dst tile onto the src tile's UB buffer to exercise
+    // the in-place (dst == src) transpose hazard on the scalar ttrans path.
+    TASSIGN(dstTile, inplace ? 0x0 : alignedSrcTileSize);
     TASSIGN(tmpTile, alignedSrcTileSize + alignedDstTileSize);
 
     GlobalDataSrc srcGlobal(src, pto::Shape(1, 1, 1, vRows, vCols), pto::Stride(1, 1, 1, tCols, 1));
@@ -79,6 +81,18 @@ void LaunchTTRANS(T *out, T *src, void *stream)
     }
 }
 
+// In-place variant: dst tile aliases the src tile's UB buffer (regression for the
+// scalar ttrans path, which must stage through tmp so dst == src stays correct).
+template <typename T, int tRows, int tCols, int vRows, int vCols>
+void LaunchTTRANSInplace(T *out, T *src, void *stream)
+{
+    if constexpr (std::is_same_v<T, aclFloat16>) {
+        runTTRANS<half, tRows, tCols, true><<<1, nullptr, stream>>>((half *)(out), (half *)(src), vRows, vCols);
+    } else {
+        runTTRANS<T, tRows, tCols, true><<<1, nullptr, stream>>>(out, src, vRows, vCols);
+    }
+}
+
 template void LaunchTTRANS<float, 16, 8, 16, 8>(float *out, float *src, void *stream);
 template void LaunchTTRANS<aclFloat16, 16, 16, 16, 16>(aclFloat16 *out, aclFloat16 *src, void *stream);
 template void LaunchTTRANS<float, 32, 16, 31, 15>(float *out, float *src, void *stream);
@@ -98,3 +112,4 @@ template void LaunchTTRANS<float, 2, 16, 2, 16>(float *out, float *src, void *st
 template void LaunchTTRANS<uint8_t, 32, 32, 32, 32>(uint8_t *out, uint8_t *src, void *stream);
 template void LaunchTTRANS<uint8_t, 64, 64, 22, 63>(uint8_t *out, uint8_t *src, void *stream);
 template void LaunchTTRANS<float, 8, 8, 8, 8>(float *out, float *src, void *stream);
+template void LaunchTTRANSInplace<float, 8, 8, 8, 8>(float *out, float *src, void *stream);


### PR DESCRIPTION
## Problem (relates to #173)

On a2a3, an FP32 `[8, 8]` transpose run **in place** (the dst tile aliased onto the src tile's UB buffer) corrupts ~28/64 (here 26/64) elements.

Root cause is the **unaligned scalar fallback**, not the transpose math. `TTransOperation` routes to `TransTailTiles` when `dstStride % Y_ELEM != 0 || srcStride % blockElem != 0` (e.g. dst cols = 8, not a multiple of 16). `TransTailTiles` writes dst **directly** from src:

```cpp
for (i) for (j) dstPtr[j*dstStride + i] = srcPtr[i*srcStride + j];   // no tmp staging
```

When `dstPtr == srcPtr`, the write overwrites src elements that have not been read yet → corruption. The aligned vconv path is unaffected because it stages through `tmp` (`src -> tmp`, then `tmp -> dst`), so the input is fully consumed before any dst write.

This is the in-place hazard surfaced from hw-native-sys/pypto#1790 / #173: the maintainers' existing `TTRANSTest.case19_float_8_8_8_8` passes only because it uses three disjoint UB buffers; it never exercises `dst == src`.

## Fix

Add `TransTailTilesStaged`, the in-place-safe twin of `TransTailTiles`: it transposes `src -> tmp` (tight stride = `validRow`, so `tmp` holds `validCol*validRow` elements ≤ the op's tmp tile) and only then copies `tmp -> dst`. The unaligned scalar path in `TTransOperation` now calls it.

- The aligned vconv path (`TransFullSubTiles`/`TransYTailTiles`) is unchanged.
- The conv-layout call sites (`ConvNCHW2NC1HWC0Unalign`) keep the direct `TransTailTiles` — they convert between different layouts and never alias dst/src.

## Reproducing testcase (answers the request on #173)

`TTRANSTest.case_inplace_float_8_8_8_8` aliases the dst tile onto the src tile's UB buffer (`TASSIGN(dstTile, 0x0)`) via a new `inplace` flag on `runTTRANS` / `test_ttrans`. **Run on real a2a3 hardware** (`-r npu`, not sim):

| | before this fix | after this fix |
| --- | --- | --- |
| `case_inplace_float_8_8_8_8` | **FAIL** — 26/64 err, `idx1 exp 7 act 3` | **PASS** — max diff 0 |
| `case19_float_8_8_8_8` (separate buffers) | PASS | PASS |

```
python3 tests/script/run_st.py -r npu -v a3 -t ttrans \
  -g 'TTRANSTest.case_inplace_float_8_8_8_8:TTRANSTest.case19_float_8_8_8_8'
```