### PR TITLE
fix(cpu): Make split-K atomic-add stores truly atomic

### DIFF
--- a/include/pto/cpu/TMatmul.hpp
+++ b/include/pto/cpu/TMatmul.hpp
@@ -20,23 +20,22 @@ template <typename TileAcc, typename TileLeft, typename TileRight>
 void TMatmulNzZn(typename TileAcc::TileDType dst, typename TileAcc::TileDType acc, typename TileLeft::TileDType src0,
                  typename TileRight::TileDType src1, uint16_t M, uint16_t N, uint16_t K)
 {
+    using DType = typename TileAcc::DType;
+    using AccT = std::conditional_t<std::is_floating_point_v<DType>, double, DType>;
     cpu::parallel_for_1d(0, M, static_cast<std::size_t>(M) * N * K, [&](std::size_t i) {
         for (uint16_t j = 0; j < N; j++) {
-            typename TileAcc::DType mul_acc = 0;
+            AccT mul_acc = 0;
 
             // PTO_CPU_VECTORIZE_LOOP
             for (uint16_t k = 0; k < K; k++) {
                 size_t src0Idx = GetTileElementOffset<TileLeft>(i, k);
                 size_t src1Idx = GetTileElementOffset<TileRight>(k, j);
 
-                auto a = (double)static_cast<typename TileAcc::DType>(src0[src0Idx]);
-                auto b = (double)static_cast<typename TileAcc::DType>(src1[src1Idx]);
-                mul_acc += static_cast<typename TileAcc::DType>(src0[src0Idx]) *
-                           static_cast<typename TileAcc::DType>(src1[src1Idx]);
+                mul_acc += static_cast<AccT>(static_cast<DType>(src0[src0Idx]) * static_cast<DType>(src1[src1Idx]));
             }
 
             size_t dstIdx = GetTileElementOffset<TileAcc>(i, j);
-            dst[dstIdx] = acc ? acc[dstIdx] + mul_acc : mul_acc;
+            dst[dstIdx] = acc ? static_cast<DType>(acc[dstIdx] + mul_acc) : static_cast<DType>(mul_acc);
         }
     });
 }
@@ -46,9 +45,11 @@ void TMatmulMX(typename TileAcc::TileDType dst, typename TileAcc::TileDType acc,
                typename TileRight::TileDType src1, typename TileLeftScale::TileDType scale0,
                typename TileRightScale::TileDType scale1, uint16_t M, uint16_t N, uint16_t K)
 {
+    using DType = typename TileAcc::DType;
+    using AccT = std::conditional_t<std::is_floating_point_v<DType>, double, DType>;
     cpu::parallel_for_1d(0, M, static_cast<std::size_t>(M) * N * K, [&](std::size_t i) {
         for (uint16_t j = 0; j < N; j++) {
-            typename TileAcc::DType mul_acc = 0;
+            AccT mul_acc = 0;
 
             PTO_CPU_VECTORIZE_LOOP
             for (uint16_t k = 0; k < K; k++) {
@@ -57,11 +58,11 @@ void TMatmulMX(typename TileAcc::TileDType dst, typename TileAcc::TileDType acc,
                 size_t src0Idx = GetTileElementOffset<TileLeft>(i, k);
                 size_t src1Idx = GetTileElementOffset<TileRight>(k, j);
                 double scaleFactor = scale0[scale0Idx] * scale1[scale1Idx];
-                mul_acc += src0[src0Idx] * src1[src1Idx] * scaleFactor;
+                mul_acc += static_cast<AccT>(src0[src0Idx] * src1[src1Idx] * scaleFactor);
             }
 
             size_t dstIdx = GetTileElementOffset<TileAcc>(i, j);
-            dst[dstIdx] = acc ? acc[dstIdx] + mul_acc : mul_acc;
+            dst[dstIdx] = acc ? static_cast<DType>(acc[dstIdx] + mul_acc) : static_cast<DType>(mul_acc);
         }
     });
 }

--- a/include/pto/cpu/TStore.hpp
+++ b/include/pto/cpu/TStore.hpp
@@ -104,7 +104,7 @@ __tf__ PTO_INLINE void StorePlainMatrix(typename GlobalData::DType __out__ *dst,
                                      out = static_cast<D>(val);
                                  }
                                  if constexpr (atomicAdd) {
-                                     dst[dstIdx] += out;
+                                     AtomicAccumulate(&dst[dstIdx], out);
                                  } else {
                                      dst[dstIdx] = out;
                                  }
@@ -141,7 +141,7 @@ __tf__ PTO_INLINE void StorePlainMatrix(typename GlobalData::DType __out__ *dst,
                                      out = static_cast<D>(val);
                                  }
                                  if constexpr (atomicAdd) {
-                                     dst[dstIdx] += out;
+                                     AtomicAccumulate(&dst[dstIdx], out);
                                  } else {
                                      dst[dstIdx] = out;
                                  }

--- a/include/pto/cpu/common.hpp
+++ b/include/pto/cpu/common.hpp
@@ -12,8 +12,25 @@ See LICENSE in the root of the software repository for the full text of the Lice
 #define COMMON_HPP
 
 #include <pto/common/type.hpp>
+#include <type_traits>
 
 namespace pto {
+
+template <typename T>
+PTO_INLINE void AtomicAccumulate(T *addr, T val)
+{
+    if constexpr (std::is_integral_v<T>) {
+        __atomic_fetch_add(addr, val, __ATOMIC_RELAXED);
+    } else {
+        T expected;
+        __atomic_load(addr, &expected, __ATOMIC_RELAXED);
+        T desired;
+        do {
+            desired = static_cast<T>(expected + val);
+        } while (
+            !__atomic_compare_exchange(addr, &expected, &desired, /*weak=*/true, __ATOMIC_RELAXED, __ATOMIC_RELAXED));
+    }
+}
 
 enum QuantModeCPU_t
 {
@@ -183,7 +200,7 @@ PTO_INLINE void StoreElement(D *dst, size_t dstIdx, S value, size_t r, size_t c,
     }
     D converted = ConvertStoreValue<D, S, quantMode, applyRelu>(value, scalar);
     if constexpr (atomicAdd) {
-        dst[dstIdx] += converted;
+        AtomicAccumulate(&dst[dstIdx], converted);
     } else {
         dst[dstIdx] = converted;
     }


### PR DESCRIPTION
## Summary
- Add `AtomicAccumulate(T* addr, T val)` in cpu/common.hpp: integral types use `__atomic_fetch_add` (relaxed); floating-point types use an `__atomic_load` + `__atomic_compare_exchange` CAS loop (portable across clang/gcc, no C++20 dependency)
- Route all three atomic-add leaves through it: StoreElement (cpu/common.hpp) and both StorePlainMatrix overloads (cpu/TStore.hpp, row- and column-major)
- Widen the floating-point matmul accumulator in cpu/TMatmul.hpp (TMatmulNzZn, TMatmulMX) from the tile DType to double; integer (int8 -> int32) accumulation stays exact. A naive sequential fp32 reduce drifts ~K ULP from the cube/torch blocked sum and can flip elements on a .5 int8-quant boundary in zero-tolerance W8A8 checks
- Non-atomic stores and the real-HW npu/ path are unchanged

## Testing
- [x] dsv4 qkv_proj_rope.py a2a3sim: 16/16 runs PASS (was flaky)
- [x] All 125 CPU ST tests pass (tests/run_cpu.py, g++ 15.2.0)
- [x] No regression in non-atomic store or existing matmul callers