### PR TITLE
[CPU-SIM] Fix Consumer::setEntryOffset casing to match Producer and NPU header

### DIFF
--- a/include/pto/cpu/TPush.hpp
+++ b/include/pto/cpu/TPush.hpp
@@ -704,7 +704,7 @@ struct TPipe {
             return isFree;
         }
 
-        PTO_INTERNAL void setentryOffset(int offset)
+        PTO_INTERNAL void setEntryOffset(int offset)
         {
             entryOffset = offset;
         }


### PR DESCRIPTION
## Problem

The CPU-sim TPipe header (`include/pto/cpu/TPush.hpp`) spells the
consumer-side entry-offset setter as **`setentryOffset`** (lowercase `e`),
while:

- `Producer::setEntryOffset` in the **same** file, and
- both `Producer`/`Consumer` in `include/pto/npu/a2a3/TPush.hpp` (and the a5 NPU header)

use the canonical **`setEntryOffset`**.

As a result, a kernel that calls `pipe.cons.setEntryOffset(...)` — the
spelling that compiles and runs correctly on the **NPU** backend — fails to
compile under the **CPU simulator**:

```
error: 'struct pto::TPipe<...>::Consumer' has no member named
'setEntryOffset'; did you mean 'setentryOffset'?
```

No single spelling compiled on both backends, so per-lane tile-pipe kernels
that set a consumer entry offset (e.g. fused-attention sub-block-id lane
separation) could not be made portable between onboard and sim without a
compiler-gated alias.

## Fix

Rename `Consumer::setentryOffset` -> `Consumer::setEntryOffset` so the CPU-sim
consumer matches the CPU-sim producer and the NPU headers.

The mis-cased name has **no callers anywhere in the repo** (only the
definition — verified with `git grep setentryOffset`), so this is a safe,
source-compatible change that simply unblocks the canonical call under
CPU-sim.

## Provenance

The typo was introduced in `b0839f6a` ("CPU SIM support for
TPipe/TPUSH/TPOP/TFREE") and has been present on every branch including the
current `main` ever since.
