### PR TITLE
fix(backend): Thread runtime lane id through pipe auto-split

### DIFF
--- a/include/pto/npu/a2a3/TAlloc.hpp
+++ b/include/pto/npu/a2a3/TAlloc.hpp
@@ -19,7 +19,7 @@ namespace pto {
 
 // get sub-block offset for global data
 template <typename GlobalData, TileSplitAxis Split>
-PTO_INTERNAL uint64_t getSubAIVOffset()
+PTO_INTERNAL uint64_t getSubAIVOffset(int lane)
 {
     if constexpr (Split == TileSplitAxis::TILE_NO_SPLIT) {
         return 0;
@@ -28,9 +28,9 @@ PTO_INTERNAL uint64_t getSubAIVOffset()
     constexpr int prodM = GlobalData::staticShape[pto::GlobalTensorDim::DIM_3];
     constexpr int prodN = GlobalData::staticShape[pto::GlobalTensorDim::DIM_4];
     if constexpr (Split == TileSplitAxis::TILE_UP_DOWN) {
-        return get_subblockid() * prodM * prodN * sizeof(typename GlobalData::RawDType);
+        return static_cast<uint32_t>(lane) * prodM * prodN * sizeof(typename GlobalData::RawDType);
     } else { // TILE_LEFT_RIGHT
-        return get_subblockid() * prodN * sizeof(typename GlobalData::RawDType);
+        return static_cast<uint32_t>(lane) * prodN * sizeof(typename GlobalData::RawDType);
     }
 }
 
@@ -53,13 +53,13 @@ PTO_INTERNAL void TALLOC_IMPL(Pipe &pipe, GlobalData &gmTensor)
     if constexpr (Pipe::is_c2v) {
         entryBase += slotOffset;
     } else if constexpr (Pipe::is_v2c) {
-        entryBase += slotOffset + getSubAIVOffset<GlobalData, Split>();
+        entryBase += slotOffset + getSubAIVOffset<GlobalData, Split>(pipe.prod.laneId());
     } else if constexpr (Pipe::is_both) {
 #ifdef __DAV_CUBE__
         entryBase += slotOffset;
 #endif
 #ifdef __DAV_VEC__
-        entryBase += slotOffset + getSubAIVOffset<GlobalData, Split>();
+        entryBase += slotOffset + getSubAIVOffset<GlobalData, Split>(pipe.prod.laneId());
 #endif
     }
 

--- a/include/pto/npu/a2a3/TPop.hpp
+++ b/include/pto/npu/a2a3/TPop.hpp
@@ -39,7 +39,7 @@ PTO_INTERNAL void TPOP_IMPL(Pipe &pipe, TileCons &tile)
 
 // get sub-block offset for global data
 template <typename GlobalData, TileSplitAxis Split>
-PTO_INTERNAL uint64_t getPopSubAIVOffset()
+PTO_INTERNAL uint64_t getPopSubAIVOffset(int lane)
 {
     if constexpr (Split == TileSplitAxis::TILE_NO_SPLIT) {
         return 0;
@@ -48,9 +48,9 @@ PTO_INTERNAL uint64_t getPopSubAIVOffset()
     constexpr int consM = GlobalData::staticShape[pto::GlobalTensorDim::DIM_3];
     constexpr int consN = GlobalData::staticShape[pto::GlobalTensorDim::DIM_4];
     if constexpr (Split == TileSplitAxis::TILE_UP_DOWN) {
-        return get_subblockid() * consM * consN * sizeof(typename GlobalData::RawDType);
+        return static_cast<uint32_t>(lane) * consM * consN * sizeof(typename GlobalData::RawDType);
     } else { // TILE_LEFT_RIGHT
-        return get_subblockid() * consN * sizeof(typename GlobalData::RawDType);
+        return static_cast<uint32_t>(lane) * consN * sizeof(typename GlobalData::RawDType);
     }
 }
 
@@ -69,12 +69,12 @@ PTO_INTERNAL void TPOP_IMPL(Pipe &pipe, GlobalData &gmTensor)
     uint64_t entryBase = (uint64_t)pipe.fifo.GM_SLOT_BUFFER;
     const uint64_t slotOffset = (pipe.cons.tileIndex % Pipe::RingFiFo::SLOT_NUM) * Pipe::RingFiFo::SLOT_SIZE;
     if constexpr (Pipe::is_c2v) {
-        entryBase += slotOffset + getPopSubAIVOffset<GlobalData, Split>();
+        entryBase += slotOffset + getPopSubAIVOffset<GlobalData, Split>(pipe.cons.laneId());
     } else if constexpr (Pipe::is_v2c) {
         entryBase += slotOffset;
     } else if constexpr (Pipe::is_both) {
 #ifdef __DAV_VEC__
-        entryBase += slotOffset + getPopSubAIVOffset<GlobalData, Split>();
+        entryBase += slotOffset + getPopSubAIVOffset<GlobalData, Split>(pipe.cons.laneId());
 #endif
 #ifdef __DAV_CUBE__
         entryBase += slotOffset;

--- a/include/pto/npu/a2a3/TPush.hpp
+++ b/include/pto/npu/a2a3/TPush.hpp
@@ -84,8 +84,19 @@ struct TPipe {
         bool isAllocate = true;
         bool isRecord = true;
         int entryOffset = 0;
+        int subBlockId = -1;
 
         PTO_INTERNAL Producer() = default;
+
+        PTO_INTERNAL void setSubBlockId(int lane)
+        {
+            subBlockId = lane;
+        }
+
+        PTO_INTERNAL uint32_t laneId() const
+        {
+            return (subBlockId >= 0) ? static_cast<uint32_t>(subBlockId) : get_subblockid();
+        }
 
         PTO_INTERNAL void setAllocateStatus(bool allocate)
         {
@@ -205,10 +216,10 @@ struct TPipe {
                 subAIVOffset = 0;
             } else if constexpr (Split == TileSplitAxis::TILE_UP_DOWN) {
                 // TILE_UP_DOWN  : Vec1 starts at the second row-block → offset = ProdM * ProdN * sizeof(T)
-                subAIVOffset = get_subblockid() * gmValidR * gmValidC * sizeof(T);
+                subAIVOffset = laneId() * gmValidR * gmValidC * sizeof(T);
             } else { // TILE_LEFT_RIGHT
                 // TILE_LEFT_RIGHT: Vec1 starts at column ProdN within row 0 → offset = ProdN * sizeof(T)
-                subAIVOffset = get_subblockid() * gmValidC * sizeof(T);
+                subAIVOffset = laneId() * gmValidC * sizeof(T);
             }
             using GlobalShape = pto::Shape<1, 1, 1, -1, -1>;
             using GlobalStride = pto::Stride<1, 1, 1, -1, 1>;
@@ -309,7 +320,7 @@ struct TPipe {
 #endif
             }
         } // end of push
-    }; // end of Producer
+    };    // end of Producer
 
     struct Consumer {
         int tileIndex = 0;
@@ -317,8 +328,19 @@ struct TPipe {
         bool isWait = true;
         bool isFree = true;
         int entryOffset = 0;
+        int subBlockId = -1;
 
         PTO_INTERNAL Consumer() = default;
+
+        PTO_INTERNAL void setSubBlockId(int lane)
+        {
+            subBlockId = lane;
+        }
+
+        PTO_INTERNAL uint32_t laneId() const
+        {
+            return (subBlockId >= 0) ? static_cast<uint32_t>(subBlockId) : get_subblockid();
+        }
 
         PTO_INTERNAL void setTileId(int tid, int sub_tid)
         {
@@ -432,10 +454,10 @@ struct TPipe {
                 subAIVOffset = 0; // TILE_NO_SPLIT : single reader, no offset needed
             } else if constexpr (Split == TileSplitAxis::TILE_UP_DOWN) {
                 // TILE_UP_DOWN  : Vec1 starts at the second row-block → offset = VEC_M * ProdN * sizeof(T)
-                subAIVOffset = get_subblockid() * ConsM * ConsN * sizeof(T);
+                subAIVOffset = laneId() * ConsM * ConsN * sizeof(T);
             } else { // TILE_LEFT_RIGHT
                 // TILE_LEFT_RIGHT: Vec1 starts at column ConsN within row 0 → offset = ConsN * sizeof(T)
-                subAIVOffset = get_subblockid() * ConsN * sizeof(T);
+                subAIVOffset = laneId() * ConsN * sizeof(T);
             }
             __gm__ T *addr = (__gm__ T *)((uint64_t)fifo.GM_SLOT_BUFFER + entryBase + subAIVOffset + entryOffset);
             using GlobalData =
@@ -496,9 +518,19 @@ struct TPipe {
     Producer prod;
     Consumer cons;
 
-    PTO_INTERNAL explicit TPipe(__gm__ void *GM_SLOT_BUFFER, uint32_t C2V_CONSUMER_BUF, uint32_t V2C_CONSUMER_BUF)
+    PTO_INTERNAL explicit TPipe(__gm__ void *GM_SLOT_BUFFER, uint32_t C2V_CONSUMER_BUF, uint32_t V2C_CONSUMER_BUF,
+                                int subBlockId = -1)
         : fifo(GM_SLOT_BUFFER, C2V_CONSUMER_BUF, V2C_CONSUMER_BUF), prod(), cons()
-    {}
+    {
+        prod.setSubBlockId(subBlockId);
+        cons.setSubBlockId(subBlockId);
+    }
+
+    PTO_INTERNAL void setSubBlockId(int subBlockId)
+    {
+        prod.setSubBlockId(subBlockId);
+        cons.setSubBlockId(subBlockId);
+    }
 
     // Destructor for TPipe: drain leftover free credits on FlagID+1.
     // Initial TPUSH calls skip allocate() via shouldWaitFree (tileIndex < SlotNum, or 0 for depth 1).

--- a/include/pto/npu/a5/TAlloc.hpp
+++ b/include/pto/npu/a5/TAlloc.hpp
@@ -19,14 +19,14 @@ namespace pto {
 
 // get sub-block offset for global data
 template <typename GlobalData, TileSplitAxis Split>
-PTO_INTERNAL uint64_t getSubAIVOffset()
+PTO_INTERNAL uint64_t getSubAIVOffset(int lane)
 {
     constexpr int prodN = GlobalData::staticShape[pto::GlobalTensorDim::DIM_4];
     constexpr int prodM = GlobalData::staticShape[pto::GlobalTensorDim::DIM_3];
     if constexpr (Split == TileSplitAxis::TILE_UP_DOWN) {
-        return get_subblockid() * prodM * prodN * sizeof(typename GlobalData::RawDType);
+        return static_cast<uint32_t>(lane) * prodM * prodN * sizeof(typename GlobalData::RawDType);
     } else { // TILE_LEFT_RIGHT
-        return get_subblockid() * prodN * sizeof(typename GlobalData::RawDType);
+        return static_cast<uint32_t>(lane) * prodN * sizeof(typename GlobalData::RawDType);
     }
 
     if constexpr (Split == TileSplitAxis::TILE_NO_SPLIT) {
@@ -54,13 +54,13 @@ PTO_INTERNAL void TALLOC_IMPL(Pipe &pipe, GlobalData &gmTensor)
     if constexpr (Pipe::is_c2v_gm) {
         entryBase += slotOffset;
     } else if constexpr (Pipe::is_v2c_gm) {
-        entryBase += slotOffset + getSubAIVOffset<GlobalData, Split>();
+        entryBase += slotOffset + getSubAIVOffset<GlobalData, Split>(pipe.prod.laneId());
     } else if constexpr (Pipe::is_both_gm) {
 #ifdef __DAV_CUBE__
         entryBase += slotOffset;
 #endif
 #ifdef __DAV_VEC__
-        entryBase += slotOffset + getSubAIVOffset<GlobalData, Split>();
+        entryBase += slotOffset + getSubAIVOffset<GlobalData, Split>(pipe.prod.laneId());
 #endif
     }
 

--- a/include/pto/npu/a5/TPop.hpp
+++ b/include/pto/npu/a5/TPop.hpp
@@ -46,7 +46,7 @@ PTO_INTERNAL std::enable_if_t<is_tile_data_v<TileCons>, void> TPOP_IMPL(Pipe &pi
 
 // get sub-block offset for global data
 template <typename GlobalData, TileSplitAxis Split>
-PTO_INTERNAL uint64_t getPopSubAIVOffset()
+PTO_INTERNAL uint64_t getPopSubAIVOffset(int lane)
 {
     if constexpr (Split == TileSplitAxis::TILE_NO_SPLIT) {
         return 0;
@@ -55,9 +55,9 @@ PTO_INTERNAL uint64_t getPopSubAIVOffset()
     constexpr int consM = GlobalData::staticShape[pto::GlobalTensorDim::DIM_3];
     constexpr int consN = GlobalData::staticShape[pto::GlobalTensorDim::DIM_4];
     if constexpr (Split == TileSplitAxis::TILE_UP_DOWN) {
-        return get_subblockid() * consM * consN * sizeof(typename GlobalData::RawDType);
+        return static_cast<uint32_t>(lane) * consM * consN * sizeof(typename GlobalData::RawDType);
     } else { // TILE_LEFT_RIGHT
-        return get_subblockid() * consN * sizeof(typename GlobalData::RawDType);
+        return static_cast<uint32_t>(lane) * consN * sizeof(typename GlobalData::RawDType);
     }
 }
 
@@ -76,12 +76,12 @@ PTO_INTERNAL void TPOP_IMPL(Pipe &pipe, GlobalData &gmTensor)
     uint64_t entryBase = (uint64_t)pipe.fifo.GM_SLOT_BUFFER;
     const uint64_t slotOffset = (pipe.cons.tileIndex % Pipe::RingFiFo::SLOT_NUM) * Pipe::RingFiFo::SLOT_SIZE;
     if constexpr (Pipe::is_c2v_gm) {
-        entryBase += slotOffset + getPopSubAIVOffset<GlobalData, Split>();
+        entryBase += slotOffset + getPopSubAIVOffset<GlobalData, Split>(pipe.cons.laneId());
     } else if constexpr (Pipe::is_v2c_gm) {
         entryBase += slotOffset;
     } else if constexpr (Pipe::is_both_gm) {
 #ifdef __DAV_VEC__
-        entryBase += slotOffset + getPopSubAIVOffset<GlobalData, Split>();
+        entryBase += slotOffset + getPopSubAIVOffset<GlobalData, Split>(pipe.cons.laneId());
 #endif
 #ifdef __DAV_CUBE__
         entryBase += slotOffset;

--- a/include/pto/npu/a5/TPush.hpp
+++ b/include/pto/npu/a5/TPush.hpp
@@ -81,8 +81,19 @@ struct TPipe {
         bool isRecord = true;
         bool isAllocate = true;
         int entryOffset = 0;
+        int subBlockId = -1;
 
         PTO_INTERNAL Producer() = default;
+
+        PTO_INTERNAL void setSubBlockId(int lane)
+        {
+            subBlockId = lane;
+        }
+
+        PTO_INTERNAL uint32_t laneId() const
+        {
+            return (subBlockId >= 0) ? static_cast<uint32_t>(subBlockId) : get_subblockid();
+        }
 
         PTO_INTERNAL void setTileId(int tIndex, int subIndex)
         {
@@ -268,13 +279,13 @@ struct TPipe {
                 // single vector core
                 TINSERT_IMPL(matTile, tile, static_cast<uint16_t>(0), static_cast<uint16_t>(0));
             } else if constexpr (Split == TileSplitAxis::TILE_UP_DOWN) {
-                int rowIndex = ProdM * static_cast<size_t>(get_subblockid());
+                int rowIndex = ProdM * static_cast<size_t>(laneId());
                 TINSERT_IMPL(matTile, tile, static_cast<uint16_t>(rowIndex), static_cast<uint16_t>(0));
             } else if constexpr (Split == TileSplitAxis::TILE_LEFT_RIGHT) {
                 PTO_ASSERT(tile.GetValidCol() * sizeof(T) % 32 == 0,
                            "Fix: For V2C(UB->L1), tile's valid column must be multiple of 32 bytes due to hardware "
                            "requirement.");
-                uint32_t colIndex = ProdN * static_cast<size_t>(get_subblockid());
+                uint32_t colIndex = ProdN * static_cast<size_t>(laneId());
                 TINSERT_IMPL(matTile, tile, static_cast<uint16_t>(0), static_cast<uint16_t>(colIndex));
             }
         }
@@ -309,9 +320,9 @@ struct TPipe {
             if constexpr (Split == TileSplitAxis::TILE_NO_SPLIT) {
                 subAIVOffset = 0;
             } else if constexpr (Split == TileSplitAxis::TILE_UP_DOWN) {
-                subAIVOffset = get_subblockid() * gmValidR * gmValidC * sizeof(T);
+                subAIVOffset = laneId() * gmValidR * gmValidC * sizeof(T);
             } else { // TILE_LEFT_RIGHT
-                subAIVOffset = get_subblockid() * gmValidC * sizeof(T);
+                subAIVOffset = laneId() * gmValidC * sizeof(T);
             }
             using GlobalShape = pto::Shape<1, 1, 1, -1, -1>;
             using GlobalStride = pto::Stride<1, 1, 1, -1, 1>;
@@ -442,8 +453,19 @@ struct TPipe {
         bool isWait = true;
         bool isFree = true;
         int entryOffset = 0;
+        int subBlockId = -1;
 
         PTO_INTERNAL Consumer() = default;
+
+        PTO_INTERNAL void setSubBlockId(int lane)
+        {
+            subBlockId = lane;
+        }
+
+        PTO_INTERNAL uint32_t laneId() const
+        {
+            return (subBlockId >= 0) ? static_cast<uint32_t>(subBlockId) : get_subblockid();
+        }
 
         PTO_INTERNAL void setTileId(int tid, int sub_tid)
         {
@@ -625,10 +647,10 @@ struct TPipe {
             size_t subAIVOffset = 0;
             if constexpr (Split == TileSplitAxis::TILE_UP_DOWN) {
                 // TILE_UP_DOWN  : Vec1 starts at the second row-block → offset = VEC_M * ProdN * sizeof(T)
-                subAIVOffset = get_subblockid() * ConsM * ConsN * sizeof(T);
+                subAIVOffset = laneId() * ConsM * ConsN * sizeof(T);
             } else if constexpr (Split == TileSplitAxis::TILE_LEFT_RIGHT) { // TILE_LEFT_RIGHT
                 // TILE_LEFT_RIGHT: Vec1 starts at column ConsN within row 0 → offset = ConsN * sizeof(T)
-                subAIVOffset = get_subblockid() * ConsN * sizeof(T);
+                subAIVOffset = laneId() * ConsN * sizeof(T);
             } else if constexpr (Split == TileSplitAxis::TILE_NO_SPLIT) {
                 subAIVOffset = 0; // TILE_NO_SPLIT : single reader, no offset needed
             }
@@ -701,9 +723,19 @@ struct TPipe {
     Producer prod;
     Consumer cons;
 
-    PTO_INTERNAL explicit TPipe(__gm__ void *GM_SLOT_BUFFER, uint32_t C2V_CONSUMER_BUF, uint32_t V2C_CONSUMER_BUF)
+    PTO_INTERNAL explicit TPipe(__gm__ void *GM_SLOT_BUFFER, uint32_t C2V_CONSUMER_BUF, uint32_t V2C_CONSUMER_BUF,
+                                int subBlockId = -1)
         : fifo(GM_SLOT_BUFFER, C2V_CONSUMER_BUF, V2C_CONSUMER_BUF), prod(), cons()
-    {}
+    {
+        prod.setSubBlockId(subBlockId);
+        cons.setSubBlockId(subBlockId);
+    }
+
+    PTO_INTERNAL void setSubBlockId(int subBlockId)
+    {
+        prod.setSubBlockId(subBlockId);
+        cons.setSubBlockId(subBlockId);
+    }
 
     // Destructor for TPipe
     PTO_INTERNAL ~TPipe()
@@ -828,8 +860,19 @@ struct TMPipe {
         bool isAllocate = true;
         bool isRecord = true;
         int entryOffset = 0;
+        int subBlockId = -1;
 
         PTO_INTERNAL Producer() = default;
+
+        PTO_INTERNAL void setSubBlockId(int lane)
+        {
+            subBlockId = lane;
+        }
+
+        PTO_INTERNAL uint32_t laneId() const
+        {
+            return (subBlockId >= 0) ? static_cast<uint32_t>(subBlockId) : get_subblockid();
+        }
 
         PTO_INTERNAL void setTileId(int t_id, int sub_t_id)
         {
@@ -1017,14 +1060,14 @@ struct TMPipe {
             if constexpr (isSplitM) {
                 // split M between vectors
                 constexpr uint32_t VecM = ConsM / VEC_CORES;
-                int row_offset = VecM * static_cast<size_t>(get_subblockid());
+                int row_offset = VecM * static_cast<size_t>(laneId());
                 uint64_t entryBase = (tile_id % DataFiFo::fifoDepth) * ConsM * ConsN * sizeof(T);
                 TileDataCons matTile;
                 TASSIGN_IMPL(matTile, fifo.fifoBase + entryBase + entryOffset);
                 TINSERT_IMPL(matTile, tile, static_cast<uint16_t>(row_offset), static_cast<uint16_t>(0));
             } else if constexpr (isSplitN) {
                 // split N between vectors
-                int col_index = ProdN * static_cast<size_t>(get_subblockid());
+                int col_index = ProdN * static_cast<size_t>(laneId());
                 uint64_t entryBase = (tile_id % DataFiFo::fifoDepth) * ConsM * ConsN * sizeof(T);
                 TileDataCons matTile;
                 TASSIGN_IMPL(matTile, fifo.fifoBase + entryBase + entryOffset);
@@ -1097,8 +1140,19 @@ struct TMPipe {
         bool isWait = true;
         bool isFree = true;
         int entryOffset = 0;
+        int subBlockId = -1;
 
         PTO_INTERNAL Consumer() = default;
+
+        PTO_INTERNAL void setSubBlockId(int lane)
+        {
+            subBlockId = lane;
+        }
+
+        PTO_INTERNAL uint32_t laneId() const
+        {
+            return (subBlockId >= 0) ? static_cast<uint32_t>(subBlockId) : get_subblockid();
+        }
 
         PTO_INTERNAL void setTileId(int tid, int sub_tid)
         {
@@ -1315,9 +1369,12 @@ struct TMPipe {
 
     // Constructors for GM_FIFO base address initialization
     template <FIFOType T = FiFoType, typename std::enable_if_t<T == FIFOType::GM_FIFO, int> = 0>
-    PTO_INTERNAL explicit TMPipe(__gm__ typename TileDataCons::DType *gmFiFoBase, uint32_t localFiFoBase)
+    PTO_INTERNAL explicit TMPipe(__gm__ typename TileDataCons::DType *gmFiFoBase, uint32_t localFiFoBase,
+                                 int subBlockId = -1)
         : fifo(gmFiFoBase, localFiFoBase), prod(), cons()
     {
+        prod.setSubBlockId(subBlockId);
+        cons.setSubBlockId(subBlockId);
         cons.free();
     }
 
@@ -1325,6 +1382,12 @@ struct TMPipe {
     PTO_INTERNAL explicit TMPipe(uint32_t fifoBase) : fifo(fifoBase), prod(), cons()
     {
         cons.free();
+    }
+
+    PTO_INTERNAL void setSubBlockId(int subBlockId)
+    {
+        prod.setSubBlockId(subBlockId);
+        cons.setSubBlockId(subBlockId);
     }
 
     // Destructor for TPipe


### PR DESCRIPTION
## Summary
- Add optional runtime sub-block id plumbing to A2/A3 and A5 TPipe producer/consumer paths, with native fallback to get_subblockid()
- Use the threaded lane id for auto-split GM offsets and tile insert positions instead of reading the hardware sub-block id directly
- Extend A5 TMPipe GM FIFO construction with the same lane id support and setter API