### PR TITLE
fix(backend): Fix CPU DIR_BOTH split tile pipe stalls

### DIFF
--- a/include/pto/cpu/TPush.hpp
+++ b/include/pto/cpu/TPush.hpp
@@ -436,7 +436,9 @@ struct TPipe {
         std::mutex mutex;
         std::condition_variable cv;
         int next_producer_slot = 0;
-        int next_consumer_slot = 0;
+        // Separate cursors keep DIR_BOTH traffic from blocking across directions.
+        int next_c2v_consumer_slot = 0;
+        int next_v2c_consumer_slot = 0;
         std::array<int, 2> next_consumer_slots_by_lane{};
         int occupied = 0;
         int popped_not_freed = 0;
@@ -514,7 +516,8 @@ struct TPipe {
         auto &shared_state = GetSharedState();
         std::lock_guard<std::mutex> lock(shared_state.mutex);
         shared_state.next_producer_slot = 0;
-        shared_state.next_consumer_slot = 0;
+        shared_state.next_c2v_consumer_slot = 0;
+        shared_state.next_v2c_consumer_slot = 0;
         shared_state.next_consumer_slots_by_lane.fill(0);
         shared_state.occupied = 0;
         shared_state.popped_not_freed = 0;
@@ -722,14 +725,17 @@ struct TPipe {
                           Split != TileSplitAxis::TILE_NO_SPLIT) {
                 const uint32_t laneId = cpu_pipe::GetSplitLaneId<Split>();
                 const uint32_t laneMask = cpu_pipe::GetSplitLaneMask<Split>(laneId);
-                shared_state.cv.wait(lock, [&shared_state, laneMask, expectedDir]() {
+                int foundSlot = 0;
+                shared_state.cv.wait(lock, [&shared_state, laneMask, expectedDir, &foundSlot]() {
                     return shared_state.occupied > 0 &&
-                           shared_state.transfer_dirs[static_cast<std::size_t>(shared_state.next_consumer_slot)] ==
-                               expectedDir &&
-                           (shared_state.consumers_claimed[static_cast<std::size_t>(shared_state.next_consumer_slot)] &
-                            laneMask) == 0;
+                           cpu_pipe::FindNextTransferSlot(
+                               shared_state.transfer_dirs, shared_state.next_c2v_consumer_slot, expectedDir, foundSlot,
+                               [&shared_state, laneMask](int candidate) {
+                                   return (shared_state.consumers_claimed[static_cast<std::size_t>(candidate)] &
+                                           laneMask) != 0;
+                               });
                 });
-                tileIndex = shared_state.next_consumer_slot;
+                tileIndex = foundSlot;
                 shared_state.consumers_claimed[static_cast<std::size_t>(tileIndex % RingFiFo::SLOT_NUM)] |= laneMask;
                 subTileIndex = static_cast<int>(laneId);
                 return;
@@ -770,9 +776,12 @@ struct TPipe {
                     // get_subblockdim()<2: single consumer — fall through to the shared-cursor path below.
                 }
                 int foundSlot = 0;
-                shared_state.cv.wait(lock, [&shared_state, expectedDir, &foundSlot]() {
+                int &consumerCursor = (kBothDir && expectedDir == cpu_pipe::TransferDir::V2C) ?
+                                          shared_state.next_v2c_consumer_slot :
+                                          shared_state.next_c2v_consumer_slot;
+                shared_state.cv.wait(lock, [&shared_state, expectedDir, &foundSlot, &consumerCursor]() {
                     return cpu_pipe::FindNextTransferSlot(
-                        shared_state.transfer_dirs, shared_state.next_consumer_slot, expectedDir, foundSlot,
+                        shared_state.transfer_dirs, consumerCursor, expectedDir, foundSlot,
                         [&shared_state](int candidate) {
                             for (int i = 0; i < shared_state.popped_not_freed; ++i) {
                                 if (shared_state.popped_slots[static_cast<std::size_t>(i)] == candidate) {
@@ -784,17 +793,17 @@ struct TPipe {
                 });
                 tileIndex = foundSlot;
                 subTileIndex = static_cast<int>(get_subblockid());
-                shared_state.next_consumer_slot = (tileIndex + 1) % RingFiFo::SLOT_NUM;
+                consumerCursor = (tileIndex + 1) % RingFiFo::SLOT_NUM;
                 cpu_pipe::PushPendingSlot(shared_state.popped_slots, shared_state.popped_not_freed, tileIndex);
                 pendingSlotTracked = true;
                 return;
             }
             shared_state.cv.wait(lock, [&shared_state, expectedDir]() {
                 return shared_state.occupied > 0 &&
-                       shared_state.transfer_dirs[static_cast<std::size_t>(shared_state.next_consumer_slot)] ==
+                       shared_state.transfer_dirs[static_cast<std::size_t>(shared_state.next_c2v_consumer_slot)] ==
                            expectedDir;
             });
-            tileIndex = shared_state.next_consumer_slot;
+            tileIndex = shared_state.next_c2v_consumer_slot;
             subTileIndex = static_cast<int>(get_subblockid());
         }
 
@@ -858,7 +867,7 @@ struct TPipe {
                     // Only a split consumer that advances the shared cursor in free() does so here;
                     // a pending-tracked V2C consumer already advanced it in wait(), and a NO_SPLIT
                     // consumer advances its own per-lane/search cursor in wait() and must not touch
-                    // the shared next_consumer_slot here (it is shared with the other direction).
+                    // the C2V cursor here (it is shared with the other direction).
                     bool advanceConsumerCursor = false;
                     if constexpr (kBothDir) {
                         advanceConsumerCursor = (Split != TileSplitAxis::TILE_NO_SPLIT) && !pendingSlotTracked;
@@ -866,7 +875,7 @@ struct TPipe {
                         advanceConsumerCursor = true;
                     }
                     if (advanceConsumerCursor) {
-                        shared_state.next_consumer_slot = (freeTileIndex + 1) % RingFiFo::SLOT_NUM;
+                        shared_state.next_c2v_consumer_slot = (freeTileIndex + 1) % RingFiFo::SLOT_NUM;
                     }
                     --shared_state.occupied;
                 }
@@ -893,8 +902,7 @@ struct TPipe {
         PTO_INTERNAL void popTileFromVecFiFoSplit(RingFiFo &fifo, TileCons &tile)
         {
             using T = typename TileCons::DType;
-            constexpr uint32_t splitCount = cpu_pipe::GetSplitCount<Split>();
-            const uint32_t splitIndex = (get_subblockid() < splitCount) ? get_subblockid() : (splitCount - 1);
+            const uint32_t splitIndex = cpu_pipe::GetSplitLaneId<Split>();
             const std::size_t slotIndex = static_cast<std::size_t>(tileIndex % RingFiFo::SLOT_NUM);
             const auto &slotStorage = TPipe::GetSharedState().local_slot_storage[slotIndex];
             const auto *slotPtr =

--- a/tests/cpu/st/testcase/tpushpop_cv_nosplit/main.cpp
+++ b/tests/cpu/st/testcase/tpushpop_cv_nosplit/main.cpp
@@ -191,7 +191,7 @@ void runCubeToVectorNoSplitInactiveLaneSkipsProtocol()
         auto &sharedState = Pipe::GetSharedState();
         std::lock_guard<std::mutex> lock(sharedState.mutex);
         EXPECT_EQ(sharedState.occupied, 1);
-        EXPECT_EQ(sharedState.next_consumer_slot, 0);
+        EXPECT_EQ(sharedState.next_c2v_consumer_slot, 0);
     }
 
     VecTile vecTile;

--- a/tests/cpu/st/testcase/tpushpop_vc/main.cpp
+++ b/tests/cpu/st/testcase/tpushpop_vc/main.cpp
@@ -236,6 +236,120 @@ void runSplitWraparoundBothDir()
     std::lock_guard<std::mutex> lock(sharedState.mutex);
     EXPECT_EQ(sharedState.occupied, 0);
 }
+
+template <typename TileData>
+void fillFullTile(TileData &tile, int base)
+{
+    using T = typename TileData::DType;
+    for (int r = 0; r < tile.GetValidRow(); ++r) {
+        for (int c = 0; c < tile.GetValidCol(); ++c) {
+            tile.data()[GetTileElementOffset<TileData>(r, c)] = static_cast<T>(base + r * tile.GetValidCol() + c + 1);
+        }
+    }
+}
+
+template <typename TileData>
+std::vector<typename TileData::DType> readFullTile(TileData &tile)
+{
+    std::vector<typename TileData::DType> out;
+    out.reserve(static_cast<std::size_t>(tile.GetValidRow()) * tile.GetValidCol());
+    for (int r = 0; r < tile.GetValidRow(); ++r) {
+        for (int c = 0; c < tile.GetValidCol(); ++c) {
+            out.push_back(tile.data()[GetTileElementOffset<TileData>(r, c)]);
+        }
+    }
+    return out;
+}
+
+template <typename T, int rows, int cols>
+std::vector<T> makeLinearExpected(int base, int rowStart, int rowCount)
+{
+    std::vector<T> expected;
+    expected.reserve(static_cast<std::size_t>(rowCount) * cols);
+    for (int r = rowStart; r < rowStart + rowCount; ++r) {
+        for (int c = 0; c < cols; ++c) {
+            expected.push_back(static_cast<T>(base + r * cols + c + 1));
+        }
+    }
+    return expected;
+}
+
+void runDirBothGmFifoKeepsC2VOrderAcrossV2CPrefetch()
+{
+    constexpr int kRows = 16;
+    constexpr int kCols = 128;
+    constexpr int kLaneRows = kRows / 2;
+    constexpr int kSlotBytes = 8192;
+    constexpr int kFifoDepth = 4;
+    using Pipe = TPipe<30, Direction::DIR_BOTH, kSlotBytes, kFifoDepth, 4, false>;
+    using CubeProdTile = Tile<TileType::Acc, float, kRows, kCols, BLayout::ColMajor, -1, -1, SLayout::RowMajor, 1024>;
+    using VecTile = Tile<TileType::Vec, float, kLaneRows, kCols, BLayout::RowMajor, kLaneRows, kCols>;
+    using CubeConsTile = Tile<TileType::Mat, float, kRows, kCols, BLayout::ColMajor, -1, -1, SLayout::RowMajor, 512>;
+
+    NPU_MEMORY_CLEAR();
+    Pipe::reset_for_cpu_sim();
+    std::vector<uint8_t> gmStorage(static_cast<std::size_t>(Pipe::RingFiFo::SLOT_SIZE) * Pipe::RingFiFo::SLOT_NUM);
+    Pipe pipe(reinterpret_cast<__gm__ void *>(gmStorage.data()), 0x0, 0x0);
+
+    auto pushC2V = [&](int base) {
+        cpu_sim::ScopedExecutionContext cubeCtx(0, 0, 1);
+        CubeProdTile cubeTile(kRows, kCols);
+        TASSIGN(cubeTile, 0x0);
+        fillFullTile(cubeTile, base);
+        TPUSH<Pipe, CubeProdTile, TileSplitAxis::TILE_UP_DOWN>(pipe, cubeTile);
+    };
+
+    auto popC2V = [&](int base) {
+        for (int lane = 0; lane < 2; ++lane) {
+            cpu_sim::ScopedExecutionContext laneCtx(0, lane, 2);
+            VecTile vecTile;
+            TASSIGN(vecTile, 0x4000 + lane * 0x4000);
+            TPOP<Pipe, VecTile, TileSplitAxis::TILE_UP_DOWN>(pipe, vecTile);
+            const auto actual = readFullTile(vecTile);
+            const auto expected = makeLinearExpected<float, kRows, kCols>(base, lane * kLaneRows, kLaneRows);
+            EXPECT_TRUE(ResultCmp(expected, actual, 0));
+            TFREE<Pipe, TileSplitAxis::TILE_UP_DOWN>(pipe);
+        }
+    };
+
+    auto pushV2C = [&]() {
+        for (int lane = 0; lane < 2; ++lane) {
+            cpu_sim::ScopedExecutionContext laneCtx(0, lane, 2);
+            VecTile vecTile;
+            TASSIGN(vecTile, 0x4000 + lane * 0x4000);
+            fillFullTile(vecTile, 7000 + lane * 1000);
+            TPUSH<Pipe, VecTile, TileSplitAxis::TILE_UP_DOWN>(pipe, vecTile);
+        }
+    };
+
+    auto popV2C = [&]() {
+        cpu_sim::ScopedExecutionContext cubeCtx(0, 0, 1);
+        CubeConsTile cubeTile(kRows, kCols);
+        TASSIGN(cubeTile, 0x0);
+        TPOP<Pipe, CubeConsTile, TileSplitAxis::TILE_UP_DOWN>(pipe, cubeTile);
+        const auto actual = readFullTile(cubeTile);
+        std::vector<float> expected;
+        const auto upper = makeLinearExpected<float, kLaneRows, kCols>(7000, 0, kLaneRows);
+        const auto lower = makeLinearExpected<float, kLaneRows, kCols>(8000, 0, kLaneRows);
+        expected.insert(expected.end(), upper.begin(), upper.end());
+        expected.insert(expected.end(), lower.begin(), lower.end());
+        EXPECT_TRUE(ResultCmp(expected, actual, 0));
+        TFREE<Pipe, TileSplitAxis::TILE_UP_DOWN>(pipe);
+    };
+
+    pushC2V(1000);
+    pushC2V(2000);
+    popC2V(1000);
+    pushV2C();
+    popV2C();
+    pushC2V(3000);
+    popC2V(2000);
+    popC2V(3000);
+
+    auto &sharedState = Pipe::GetSharedState();
+    std::lock_guard<std::mutex> lock(sharedState.mutex);
+    EXPECT_EQ(sharedState.occupied, 0);
+}
 } // namespace
 
 class TPushPopVCSplitTest : public testing::Test {
@@ -281,4 +395,9 @@ TEST_F(TPushPopVCSplitTest, both_dir_up_down_overlapping_pops_read_distinct_slot
 TEST_F(TPushPopVCSplitTest, both_dir_left_right_overlapping_pops_read_distinct_slots_float_16x32)
 {
     runSplitWraparoundBothDir<float, 16, 32, TileSplitAxis::TILE_LEFT_RIGHT>();
+}
+
+TEST_F(TPushPopVCSplitTest, both_dir_up_down_gm_fifo_keeps_c2v_order_across_v2c_prefetch)
+{
+    runDirBothGmFifoKeepsC2VOrderAcrossV2CPrefetch();
 }


### PR DESCRIPTION
## Summary
- Add explicit subblock-id override support to CPU TPipe producer and consumer split-lane calculations
- Keep separate C2V and V2C consumer cursors for DIR_BOTH pipes so interleaved traffic does not block on the wrong FIFO slot
- Add CPU ST coverage for split GM FIFO lane offsets and interleaved DIR_BOTH TILE_UP_DOWN traffic

## Testing
- [x] All 9 targeted tests/cases pass (8 gtest tests + 1 qwen repro)
- [x] `tpushpop_vc`
- [x] `TestQwen314BDecode::StressBatch16Seq3500` on `a2a3sim`
- [x] `git diff --check`

Fixes #183