### PR TITLE
fix(tests): drop stale -w from A5 smoke tsubreluconv/taddreluconv

### DIFF
--- a/tests/run_st.sh
+++ b/tests/run_st.sh
@@ -471,8 +471,8 @@ if [ "$ENABLE_A5" = "true" ]; then
     # python3 tests/script/run_st.py $ARGS -w -v a5 -t tpartargmin -g TPARTARGMINTest.case_fp32_64x64_64x64_64x64
     # Temporarily skip the unstable A5 concatidx smoke case until the kernel/result mismatch is fixed.
     # python3 tests/script/run_st.py $ARGS -w -v a5 -t tconcatidx -g TCONCATTest.case_int16_16x32_16x16_16x16_8x16_8x16
-    python3 tests/script/run_st.py $ARGS -w -v a5 -t tsubreluconv -g TSUBRELUCONVTest.case1
-    python3 tests/script/run_st.py $ARGS -w -v a5 -t taddreluconv -g TADDRELUCONVTest.case1
+    python3 tests/script/run_st.py $ARGS -v a5 -t tsubreluconv -g TSUBRELUCONVTest.case1
+    python3 tests/script/run_st.py $ARGS -v a5 -t taddreluconv -g TADDRELUCONVTest.case1
     python3 tests/script/run_st.py $ARGS -v a5 -t taxpy -g TAXPYTest.case1
     python3 tests/script/run_st.py $ARGS -v a5 -t tdequant -g TDEQUANTTest.case1
     python3 tests/script/run_st.py $ARGS -v a5 -t tconcat -g TCONCATTest.case_half_16x128_16x64_16x64_16x63_16x64


### PR DESCRIPTION
The A5 simple smoke block has no front-loaded build_st.py; each case is expected to build itself via run_st.py. tsubreluconv and taddreluconv still carried --without-build (-w), which skips build_project. Since run_smoke.sh cleans tests/npu/a5/src/st/build before each run, the build dir did not exist and `cp testcase/.../gen_data.py build/gen_data.py` failed with "No such file or directory", aborting the A5 smoke in ~2s on the very first case.

Remove -w so these two cases self-build like the rest of the A5 simple list.