### PR TITLE
fix(a2a3): resolve TStoreAccFp redefinition and TTrans undefined dstC0 (#204)

### DIFF
--- a/include/pto/npu/a2a3/TStore.hpp
+++ b/include/pto/npu/a2a3/TStore.hpp
@@ -165,36 +165,6 @@ __tf__ AICORE void TStoreAcc(
     }
 }
 
-template <typename GlobalData, typename TileData, typename FpTileData,
-          QuantMode_t quantizationMode = QuantMode_t::NoQuant, ReluPreMode reluPreMode = ReluPreMode::NoRelu>
-__tf__ AICORE void TStoreAccFp(typename GlobalData::DType __out__ *dst, typename TileData::TileDType __in__ src,
-                               typename FpTileData::TileDType __in__ fp, int gShape0, int gShape1, int gShape2,
-                               int gShape3, int gShape4, int gStride0, int gStride1, int gStride2, int gStride3,
-                               int gStride4, int validRow, int validCol)
-{
-    __fbuf__ typename FpTileData::DType *fpDstAddr = (__fbuf__ typename FpTileData::DType *)__cce_get_tile_ptr(fp);
-    uint64_t deqTensorAddr = ((uint64_t)fpDstAddr >> static_cast<uint64_t>(7)) << 8;
-    set_fpc(deqTensorAddr);
-    pipe_barrier(PIPE_FIX);
-    if constexpr (GlobalData::layout == Layout::ND) {
-        TStoreAccNz2nd<GlobalData, TileData, quantizationMode, reluPreMode>(
-            dst, __cce_get_tile_ptr(src), gShape0, gShape1, gShape2, gShape3, gShape4, gStride0, gStride1, gStride2,
-            gStride3, gStride4, validRow, validCol);
-    } else if constexpr (GlobalData::layout == Layout::NZ) {
-        TStoreAccNz2nz<GlobalData, TileData, quantizationMode, reluPreMode>(
-            dst, __cce_get_tile_ptr(src), gShape0, gShape1, gShape2, gShape3, gShape4, gStride0, gStride1, gStride2,
-            gStride3, gStride4, validRow, validCol);
-    } else if constexpr (GlobalData::layout == Layout::NC1HWC0) {
-        TStoreAccNz2NC1HWC0<GlobalData, TileData, quantizationMode, reluPreMode>(
-            dst, __cce_get_tile_ptr(src), gShape0, gShape1, gShape2, gShape3, gShape4, gStride1, gStride3, validRow,
-            validCol);
-    } else if constexpr (GlobalData::layout == Layout::NDC1HWC0) {
-        TStoreAccNz2NDC1HWC0<GlobalData, TileData, quantizationMode, reluPreMode>(
-            dst, __cce_get_tile_ptr(src), gShape0, gShape1, gShape2, gShape3, gShape4, gStride2, gStride4, validRow,
-            validCol);
-    }
-}
-
 template <typename TileData, typename GlobalData, bool isQuant>
 PTO_INTERNAL void CheckAcc2gm(GlobalData& dst, TileData& src)
 {

--- a/include/pto/npu/a2a3/TTrans.hpp
+++ b/include/pto/npu/a2a3/TTrans.hpp
@@ -406,13 +406,22 @@ template <typename T, unsigned blockSizeElem, bool reverse = false>
 PTO_INTERNAL void ConvNCHW2NC1HWC0Unalign(
     __ubuf__ T* dst, __ubuf__ T* src, unsigned srcN, unsigned srcC, unsigned srcH, unsigned srcW, unsigned validC0)
 {
-    unsigned srcStride = srcH * srcW;
-    unsigned dstStride = dstC0;
-    unsigned validCol = srcH * srcW;
-    unsigned validRow = dstC0;
-    unsigned dstC1 = (srcC + dstC0 - 1) / dstC0;
-    unsigned nStride = dstC1 * dstC0 * srcH * srcW;
-    unsigned cStride = dstC0 * srcH * srcW;
+    unsigned srcStride, dstStride, validCol, validRow, validC1;
+    if constexpr (reverse) {
+        srcStride = validC0;
+        dstStride = srcH * srcW;
+        validCol = validC0;
+        validRow = srcH * srcW;
+        validC1 = srcC;
+    } else {
+        srcStride = srcH * srcW;
+        dstStride = validC0;
+        validCol = srcH * srcW;
+        validRow = validC0;
+        validC1 = (srcC + validC0 - 1) / validC0;
+    }
+    unsigned cStride = validC0 * srcH * srcW;
+    unsigned nStride = validC1 * cStride;
     constexpr unsigned yTileSizeElem = (sizeof(T) == 1) ? Y_ELEM_B8 : Y_ELEM_OTHER;
     // N C1 C0 HW -> N C1 HW C0
     for (int n = 0; n < srcN; n++) {
@@ -457,14 +466,11 @@ __tf__ PTO_INTERNAL void TTransConvNCHW2NC1HWC0(
         validC1 = (srcC + validC0 - 1) / validC0;
     }
     if (((dstStride % blockSizeElem) != 0) || ((srcStride % blockSizeElem) != 0) || srcStride / blockSizeElem > 255) {
-        ConvNCHW2NC1HWC0Unalign<Tsrc, blockSizeElem>(dstPtrOrig, srcPtrOrig, srcN, srcC, srcH, srcW, dstC0);
+        ConvNCHW2NC1HWC0Unalign<Tsrc, blockSizeElem, reverse>(dstPtrOrig, srcPtrOrig, srcN, srcC, srcH, srcW, validC0);
         return;
     }
-    unsigned validCol = srcH * srcW;
-    unsigned validRow = dstC0;
-    unsigned dstC1 = (srcC + dstC0 - 1) / dstC0;
-    unsigned nStride = dstC1 * dstC0 * srcH * srcW;
-    unsigned cStride = dstC0 * srcH * srcW;
+    unsigned cStride = validC0 * srcH * srcW;
+    unsigned nStride = validC1 * cStride;
     // N C1 C0 HW -> N C1 HW C0
     for (int n = 0; n < srcN; n++) {
         for (int c = 0; c < validC1; c++) {
@@ -533,14 +539,10 @@ PTO_INTERNAL void ConvGNCHW2GNC1HWC0Unalign(
     __ubuf__ T* dst, __ubuf__ T* src, unsigned srcG, unsigned srcN, unsigned srcC, unsigned srcH, unsigned srcW,
     unsigned validC0)
 {
-    unsigned srcStride = srcH * srcW;
-    unsigned dstStride = dstC0;
-    unsigned validCol = srcH * srcW;
-    unsigned validRow = dstC0;
-    unsigned dstC1 = (srcC + dstC0 - 1) / dstC0;
-    unsigned gStride = srcN * dstC1 * dstC0 * srcH * srcW;
-    unsigned nStride = dstC1 * dstC0 * srcH * srcW;
-    unsigned cStride = dstC0 * srcH * srcW;
+    unsigned validC1 = reverse ? srcC : ((srcC + validC0 - 1) / validC0);
+    unsigned cStride = validC0 * srcH * srcW;
+    unsigned nStride = validC1 * cStride;
+    unsigned gStride = srcN * nStride;
     constexpr unsigned yTileSizeElem = (sizeof(T) == 1) ? Y_ELEM_B8 : Y_ELEM_OTHER;
     for (unsigned g = 0; g < srcG; g++) {
         __ubuf__ T* srcPtr = src + g * gStride;
@@ -581,12 +583,9 @@ __tf__ PTO_INTERNAL void TTransConvGNCHW2GNC1HWC0(
             dstPtrOrig, srcPtrOrig, srcG, srcN, srcC, srcH, srcW, validC0);
         return;
     }
-    unsigned validCol = srcH * srcW;
-    unsigned validRow = dstC0;
-    unsigned dstC1 = (srcC + dstC0 - 1) / dstC0;
-    unsigned gStride = srcN * dstC1 * dstC0 * srcH * srcW;
-    unsigned nStride = dstC1 * dstC0 * srcH * srcW;
-    unsigned cStride = dstC0 * srcH * srcW;
+    unsigned cStride = validC0 * srcH * srcW;
+    unsigned nStride = validC1 * cStride;
+    unsigned gStride = srcN * nStride;
     for (unsigned g = 0; g < srcG; g++) {
         for (unsigned n = 0; n < srcN; n++) {
             for (unsigned c = 0; c < validC1; c++) {


### PR DESCRIPTION
## Summary

Fixes #204 — two compile-time breaks in `include/pto/npu/a2a3/` introduced by the a2a3→common code extraction. Any kernel whose TU pulls in both `pto/common/pto_instr_impl.hpp` and `pto/npu/a2a3/TPush.hpp` (→ `TStore.hpp` + `TTrans.hpp`) failed to build.

### 1. `TStore.hpp` — `TStoreAccFp` double definition
`TStore.hpp` defined `TStoreAccFp` locally **and** already `#include`s `pto/common/arch/memory/tstore_common.hpp`, which defines the identical body again → `redefinition of 'TStoreAccFp'`. Removed the redundant local definition; the common copy is reached via the existing include. (Zero behavior change — bodies are identical modulo formatting, exactly as #204 notes.)

### 2. `TTrans.hpp` — undefined `dstC0` + redeclarations
`ConvNCHW2NC1HWC0Unalign` / `ConvGNCHW2GNC1HWC0Unalign` and their `TTransConv*` parents still referenced `dstC0` after the parameter was renamed to `validC0`, and the parents additionally redeclared `validCol`/`validRow`.

This restores the last-known-good logic (present on `a93c6818`, regressed by `55bd170e`):
- use `validC0` everywhere instead of the undefined `dstC0`;
- restore the `if constexpr (reverse)` handling that the two `*Unalign` helpers had lost;
- fix the `validC1` loop bound in `ConvNCHW2NC1HWC0Unalign`;
- drop the duplicate stride-computation block in both `TTransConv*` parents.

> **Note on scope vs. the issue's suggested fix:** #204's recommended fix only renames `dstC0`→`validC0` in the two `*Unalign` helpers. That alone is **insufficient** — it leaves `validC1` undefined in the helper loop and does not touch the parent functions (`TTransConvNCHW2NC1HWC0` lines ~460-467, `TTransConvGNCHW2GNC1HWC0` lines ~584-589), whose `dstC0` uses and `validCol`/`validRow` redeclarations still fail to compile. This PR fixes all four functions.

## Reproduce / verify

```bash
bash kernels/manual/a2a3/distributed_ffn_grid/run_reducesum.sh --build-only -r npu -v Ascend910B1
```

- **Before:** ~20 errors, all in `TTrans.hpp` (undeclared `dstC0`, `redefinition of 'validCol'/'validRow'`) and `TStore.hpp` (`redefinition of 'TStoreAccFp'`, masked by the TTrans errors hitting `-ferror-limit`).
- **After:** **zero** errors from `TTrans.hpp` / `TStore.hpp` / `tstore_common.hpp`. Build now progresses past these headers.

Sibling backends (`a5`, `kirin9030`, `kirinDev0000`) were checked: they only hold *call sites* for `TStoreAccFp` (no local definition) and were unaffected — the duplicate was a2a3-specific.

## Out of scope (reported separately)

Once the TTrans errors no longer mask them, the same reproducer surfaces two **pre-existing, unrelated** issues that are NOT part of #204 and are left untouched here:
- `tmov_common.hpp:16` — `redefinition of 'TMovCcToCb'` (a2a3 `TMov.hpp:19` vs the common copy; the two bodies *diverge* — `pto_copy_matrix_cc_to_cbuf(..., static_cast<uint8_t>(reluMode))` vs `copy_matrix_cc_to_cbuf(..., reluMode)` — so it needs a separate design decision, not a plain deletion).
- GridPipe include wiring in the `distributed_ffn_grid` demo (`GRID_TPOP_IMPL`/`GRID_TPUSH_IMPL`/`HcclDeviceContext` undeclared).

🤖 Generated with [Claude Code](https://claude.com/claude-code)