### PR TITLE
fix(a2a3): resolve 9e6c6d5b extraction build breaks — TStoreAccFp, TTrans dstC0, TMovCcToCb (#204)

### DIFF
--- a/include/pto/common/arch/memory/tmov_common.hpp
+++ b/include/pto/common/arch/memory/tmov_common.hpp
@@ -11,22 +11,25 @@ See LICENSE in the root of the software repository for the full text of the Lice
 #ifndef TMOV_COMMON_MEMORY
 #define TMOV_COMMON_MEMORY
 #include <pto/common/utils.hpp>
+#include <pto/common/arch_cce_intrinsic.hpp>
 
 template <typename DstTileData, typename SrcTileData, QuantMode_t QuantPre, ReluPreMode reluMode>
-__tf__ AICORE void TMovCcToCb(typename DstTileData::TileDType __out__ dst, typename SrcTileData::TileDType __in__ src,
-                              uint16_t validRow, uint16_t validCol)
+__tf__ AICORE void TMovCcToCb(
+    typename DstTileData::TileDType __out__ dst, typename SrcTileData::TileDType __in__ src, uint16_t validRow,
+    uint16_t validCol)
 {
     using SrcType = typename SrcTileData::DType;
     using DstType = typename DstTileData::DType;
     constexpr int32_t c0Size = BLOCK_BYTE_SIZE / sizeof(DstType);
-    __cc__ SrcType *srcAddr = (__cc__ SrcType *)__cce_get_tile_ptr(src);
-    __cbuf__ DstType *dstAddr = (__cbuf__ DstType *)__cce_get_tile_ptr(dst);
+    __cc__ SrcType* srcAddr = (__cc__ SrcType*)__cce_get_tile_ptr(src);
+    __cbuf__ DstType* dstAddr = (__cbuf__ DstType*)__cce_get_tile_ptr(dst);
 
     constexpr uint32_t dstStride_dst_D = DstTileData::Rows;
     constexpr uint16_t srcStride = SrcTileData::Rows;
     validCol = CeilDivision(validCol, c0Size) * c0Size;
-    copy_matrix_cc_to_cbuf(dstAddr, srcAddr, 0, validCol, SrcTileData::Rows, dstStride_dst_D, srcStride, 0, QuantPre,
-                           reluMode, false, false);
+    pto_copy_matrix_cc_to_cbuf(
+        dstAddr, srcAddr, 0, validCol, SrcTileData::Rows, dstStride_dst_D, srcStride, 0, QuantPre,
+        static_cast<uint8_t>(reluMode), false, false);
 }
 
 template <typename DstTileData, typename SrcTileData>

--- a/include/pto/npu/a2a3/TMov.hpp
+++ b/include/pto/npu/a2a3/TMov.hpp
@@ -15,24 +15,11 @@ See LICENSE in the root of the software repository for the full text of the Lice
 
 namespace pto {
 
-template <typename DstTileData, typename SrcTileData, QuantMode_t QuantPre, ReluPreMode reluMode>
-__tf__ AICORE void TMovCcToCb(
-    typename DstTileData::TileDType __out__ dst, typename SrcTileData::TileDType __in__ src, uint16_t validRow,
-    uint16_t validCol)
-{
-    using SrcType = typename SrcTileData::DType;
-    using DstType = typename DstTileData::DType;
-    constexpr int32_t c0Size = BLOCK_BYTE_SIZE / sizeof(DstType);
-    __cc__ SrcType* srcAddr = (__cc__ SrcType*)__cce_get_tile_ptr(src);
-    __cbuf__ DstType* dstAddr = (__cbuf__ DstType*)__cce_get_tile_ptr(dst);
-
-    constexpr uint32_t dstStride_dst_D = DstTileData::Rows;
-    constexpr uint16_t srcStride = SrcTileData::Rows;
-    validCol = CeilDivision(validCol, c0Size) * c0Size;
-    pto_copy_matrix_cc_to_cbuf(
-        dstAddr, srcAddr, 0, validCol, SrcTileData::Rows, dstStride_dst_D, srcStride, 0, QuantPre,
-        static_cast<uint8_t>(reluMode), false, false);
-}
+// TMovCcToCb is defined once in pto/common/arch/memory/tmov_common.hpp (included
+// below) and reached transitively. The a2a3-local copy was removed to resolve the
+// redefinition left by the 9e6c6d5b a2a3->common extraction (issue #204); the
+// common body now uses the unified pto_copy_matrix_cc_to_cbuf wrapper, matching
+// the body that lived here.
 
 template <typename DstTileData, typename SrcTileData>
 __tf__ AICORE void TMovToBt(typename DstTileData::TileDType __out__ dst, typename SrcTileData::TileDType __in__ src)

--- a/include/pto/npu/a2a3/TStore.hpp
+++ b/include/pto/npu/a2a3/TStore.hpp
@@ -165,36 +165,6 @@ __tf__ AICORE void TStoreAcc(
     }
 }
 
-template <typename GlobalData, typename TileData, typename FpTileData,
-          QuantMode_t quantizationMode = QuantMode_t::NoQuant, ReluPreMode reluPreMode = ReluPreMode::NoRelu>
-__tf__ AICORE void TStoreAccFp(typename GlobalData::DType __out__ *dst, typename TileData::TileDType __in__ src,
-                               typename FpTileData::TileDType __in__ fp, int gShape0, int gShape1, int gShape2,
-                               int gShape3, int gShape4, int gStride0, int gStride1, int gStride2, int gStride3,
-                               int gStride4, int validRow, int validCol)
-{
-    __fbuf__ typename FpTileData::DType *fpDstAddr = (__fbuf__ typename FpTileData::DType *)__cce_get_tile_ptr(fp);
-    uint64_t deqTensorAddr = ((uint64_t)fpDstAddr >> static_cast<uint64_t>(7)) << 8;
-    set_fpc(deqTensorAddr);
-    pipe_barrier(PIPE_FIX);
-    if constexpr (GlobalData::layout == Layout::ND) {
-        TStoreAccNz2nd<GlobalData, TileData, quantizationMode, reluPreMode>(
-            dst, __cce_get_tile_ptr(src), gShape0, gShape1, gShape2, gShape3, gShape4, gStride0, gStride1, gStride2,
-            gStride3, gStride4, validRow, validCol);
-    } else if constexpr (GlobalData::layout == Layout::NZ) {
-        TStoreAccNz2nz<GlobalData, TileData, quantizationMode, reluPreMode>(
-            dst, __cce_get_tile_ptr(src), gShape0, gShape1, gShape2, gShape3, gShape4, gStride0, gStride1, gStride2,
-            gStride3, gStride4, validRow, validCol);
-    } else if constexpr (GlobalData::layout == Layout::NC1HWC0) {
-        TStoreAccNz2NC1HWC0<GlobalData, TileData, quantizationMode, reluPreMode>(
-            dst, __cce_get_tile_ptr(src), gShape0, gShape1, gShape2, gShape3, gShape4, gStride1, gStride3, validRow,
-            validCol);
-    } else if constexpr (GlobalData::layout == Layout::NDC1HWC0) {
-        TStoreAccNz2NDC1HWC0<GlobalData, TileData, quantizationMode, reluPreMode>(
-            dst, __cce_get_tile_ptr(src), gShape0, gShape1, gShape2, gShape3, gShape4, gStride2, gStride4, validRow,
-            validCol);
-    }
-}
-
 template <typename TileData, typename GlobalData, bool isQuant>
 PTO_INTERNAL void CheckAcc2gm(GlobalData& dst, TileData& src)
 {

--- a/include/pto/npu/a2a3/TTrans.hpp
+++ b/include/pto/npu/a2a3/TTrans.hpp
@@ -126,7 +126,7 @@ PTO_INTERNAL void TransB8FullSubTiles(
             set_va_reg_sb(VA7, &tmpUb1[HALF_ADDR_NUM]);
             if (numSubTileY == 1) { // [32, 32]
                 Op::TransB8Instr(1, 0, 0);
-            } else {                // larger then [32, 32], e.g, [32, 64]
+            } else { // larger then [32, 32], e.g, [32, 64]
                 Op::TransB8Instr(numSubTileY, 1, vconvSrcStride);
             }
         } // end of numSubTileX
@@ -354,7 +354,7 @@ PTO_INTERNAL void TransRepeatXB8FullSubTiles(
             set_va_reg_sb(VA1, &tmpUb[HALF_ADDR_NUM]);
             if (numSubTileX == 1) { // [32, 32]
                 Op::TransB8Instr(1, 0, 0);
-            } else {                // larger than [32, 32], e.g, [32, 64]
+            } else { // larger than [32, 32], e.g, [32, 64]
                 Op::TransB8Instr(numSubTileX, vconvDstStride, 1);
             }
         } // end of numSubTileY
@@ -406,13 +406,22 @@ template <typename T, unsigned blockSizeElem, bool reverse = false>
 PTO_INTERNAL void ConvNCHW2NC1HWC0Unalign(
     __ubuf__ T* dst, __ubuf__ T* src, unsigned srcN, unsigned srcC, unsigned srcH, unsigned srcW, unsigned validC0)
 {
-    unsigned srcStride = srcH * srcW;
-    unsigned dstStride = dstC0;
-    unsigned validCol = srcH * srcW;
-    unsigned validRow = dstC0;
-    unsigned dstC1 = (srcC + dstC0 - 1) / dstC0;
-    unsigned nStride = dstC1 * dstC0 * srcH * srcW;
-    unsigned cStride = dstC0 * srcH * srcW;
+    unsigned srcStride, dstStride, validCol, validRow, validC1;
+    if constexpr (reverse) {
+        srcStride = validC0;
+        dstStride = srcH * srcW;
+        validCol = validC0;
+        validRow = srcH * srcW;
+        validC1 = srcC;
+    } else {
+        srcStride = srcH * srcW;
+        dstStride = validC0;
+        validCol = srcH * srcW;
+        validRow = validC0;
+        validC1 = (srcC + validC0 - 1) / validC0;
+    }
+    unsigned cStride = validC0 * srcH * srcW;
+    unsigned nStride = validC1 * cStride;
     constexpr unsigned yTileSizeElem = (sizeof(T) == 1) ? Y_ELEM_B8 : Y_ELEM_OTHER;
     // N C1 C0 HW -> N C1 HW C0
     for (int n = 0; n < srcN; n++) {
@@ -457,14 +466,11 @@ __tf__ PTO_INTERNAL void TTransConvNCHW2NC1HWC0(
         validC1 = (srcC + validC0 - 1) / validC0;
     }
     if (((dstStride % blockSizeElem) != 0) || ((srcStride % blockSizeElem) != 0) || srcStride / blockSizeElem > 255) {
-        ConvNCHW2NC1HWC0Unalign<Tsrc, blockSizeElem>(dstPtrOrig, srcPtrOrig, srcN, srcC, srcH, srcW, dstC0);
+        ConvNCHW2NC1HWC0Unalign<Tsrc, blockSizeElem, reverse>(dstPtrOrig, srcPtrOrig, srcN, srcC, srcH, srcW, validC0);
         return;
     }
-    unsigned validCol = srcH * srcW;
-    unsigned validRow = dstC0;
-    unsigned dstC1 = (srcC + dstC0 - 1) / dstC0;
-    unsigned nStride = dstC1 * dstC0 * srcH * srcW;
-    unsigned cStride = dstC0 * srcH * srcW;
+    unsigned cStride = validC0 * srcH * srcW;
+    unsigned nStride = validC1 * cStride;
     // N C1 C0 HW -> N C1 HW C0
     for (int n = 0; n < srcN; n++) {
         for (int c = 0; c < validC1; c++) {
@@ -533,14 +539,10 @@ PTO_INTERNAL void ConvGNCHW2GNC1HWC0Unalign(
     __ubuf__ T* dst, __ubuf__ T* src, unsigned srcG, unsigned srcN, unsigned srcC, unsigned srcH, unsigned srcW,
     unsigned validC0)
 {
-    unsigned srcStride = srcH * srcW;
-    unsigned dstStride = dstC0;
-    unsigned validCol = srcH * srcW;
-    unsigned validRow = dstC0;
-    unsigned dstC1 = (srcC + dstC0 - 1) / dstC0;
-    unsigned gStride = srcN * dstC1 * dstC0 * srcH * srcW;
-    unsigned nStride = dstC1 * dstC0 * srcH * srcW;
-    unsigned cStride = dstC0 * srcH * srcW;
+    unsigned validC1 = reverse ? srcC : ((srcC + validC0 - 1) / validC0);
+    unsigned cStride = validC0 * srcH * srcW;
+    unsigned nStride = validC1 * cStride;
+    unsigned gStride = srcN * nStride;
     constexpr unsigned yTileSizeElem = (sizeof(T) == 1) ? Y_ELEM_B8 : Y_ELEM_OTHER;
     for (unsigned g = 0; g < srcG; g++) {
         __ubuf__ T* srcPtr = src + g * gStride;
@@ -581,12 +583,9 @@ __tf__ PTO_INTERNAL void TTransConvGNCHW2GNC1HWC0(
             dstPtrOrig, srcPtrOrig, srcG, srcN, srcC, srcH, srcW, validC0);
         return;
     }
-    unsigned validCol = srcH * srcW;
-    unsigned validRow = dstC0;
-    unsigned dstC1 = (srcC + dstC0 - 1) / dstC0;
-    unsigned gStride = srcN * dstC1 * dstC0 * srcH * srcW;
-    unsigned nStride = dstC1 * dstC0 * srcH * srcW;
-    unsigned cStride = dstC0 * srcH * srcW;
+    unsigned cStride = validC0 * srcH * srcW;
+    unsigned nStride = validC1 * cStride;
+    unsigned gStride = srcN * nStride;
     for (unsigned g = 0; g < srcG; g++) {
         for (unsigned n = 0; n < srcN; n++) {
             for (unsigned c = 0; c < validC1; c++) {


### PR DESCRIPTION
## Summary

Fixes #204 — completes the repair of the three compile-time breaks in `include/pto/npu/a2a3/` (and the shared common layer) left by the a2a3→common code extraction in `9e6c6d5b`. Any kernel whose translation unit pulls in both `pto/common/pto_instr_impl.hpp` and `pto/npu/a2a3/TPush.hpp` failed to build.

**This supersedes #205.** #205 fixed the first two breaks (TStore + TTrans); this PR keeps that exact, already-verified commit and adds the third fix (`TMovCcToCb`), so the whole extraction break is resolved in one place. Once this merges, #205 can stay closed.

## The three breaks

### 1. `TStore.hpp` — `TStoreAccFp` double definition
`TStore.hpp` defined `TStoreAccFp` locally **and** already `#include`s `pto/common/arch/memory/tstore_common.hpp`, which defines the identical body again → `redefinition of 'TStoreAccFp'`. Removed the redundant local definition; the common copy is reached via the existing include. (Zero behavior change — bodies are identical modulo formatting.)

### 2. `TTrans.hpp` — undefined `dstC0` + redeclarations
`ConvNCHW2NC1HWC0Unalign` / `ConvGNCHW2GNC1HWC0Unalign` and their `TTransConv*` parents still referenced `dstC0` after the parameter was renamed to `validC0`, and the parents additionally redeclared `validCol`/`validRow`. Restores the last-known-good logic (present until `55bd170e`): use `validC0` everywhere, restore the `reverse` template handling in the `*Unalign` helpers, fix the `validC1` loop bound, and drop the duplicate stride block in the parents.

### 3. `TMovCcToCb` double definition (new vs #205 — "problem A" in #204)
`9e6c6d5b` moved `TMovCcToCb` into `pto/common/arch/memory/tmov_common.hpp` but left the a2a3-local copy in `include/pto/npu/a2a3/TMov.hpp`. Because `a2a3/TMov.hpp` `#include`s `tmov_common.hpp`, any TU that reaches `a2a3/TMov.hpp` (e.g. via `pto_instr_impl.hpp`, which includes it twice) sees both definitions:

```
tmov_common.hpp:16:20: error: redefinition of 'TMovCcToCb'
TMov.hpp:19:20: note: previous definition is here
```

This was masked until #1/#2 were fixed (the `-ferror-limit` budget was spent on TStore/TTrans first). Rather than the local workaround of dropping the common copy, this completes the extraction the way `756787a9`'s unified-wrapper intent intended:
- `tmov_common.hpp`: align the body to the unified `pto_copy_matrix_cc_to_cbuf` wrapper (the same call the a2a3 copy used, incl. `static_cast<uint8_t>(reluMode)`) and include `pto/common/arch_cce_intrinsic.hpp` for its declaration. **common is now the single canonical, cross-arch definition.**
- `a2a3/TMov.hpp`: delete the now-redundant local copy.

## Verification

- Builds past all three headers. Reproduced with `run_reducesum.sh --build-only -r npu -v Ascend910B1`: on `origin/main` the build dies with ~20 errors all in `TStore.hpp`/`TTrans.hpp`; after #1/#2 it dies in `TMovCcToCb`; after this PR there are **zero errors from `TStore.hpp`/`TTrans.hpp`/`tmov_common.hpp`/`TMov.hpp`** (remaining `distributed_ffn_grid` demo errors are the unrelated GridPipe follow-ups tracked separately in #204, problem B).
- `TMovCcToCb` isolated before/after with a minimal TU (`#include <pto/pto-inst.hpp>` + `#include <pto/npu/a2a3/TMov.hpp>`):
  - **before:** `error: redefinition of 'TMovCcToCb'` (exit 1)
  - **after:** clean parse, 0 errors (exit 0); `TMovCcToCb` is single-defined in common.
- `a2a3/TMov.hpp` is the only consumer of `tmov_common.hpp`; the a5/kirin backends keep their own local `TMovCcToCb` and do not include common, so they are unaffected.

Fixes #204.
