### PR TITLE
fix: keep host and CPU simulator roles isolated

### DIFF
--- a/include/pto/comm/async/sdma/sdma_workspace_manager.hpp
+++ b/include/pto/comm/async/sdma/sdma_workspace_manager.hpp
@@ -25,7 +25,7 @@ See LICENSE in the root of the software repository for the full text of the Lice
 #include <dlfcn.h>
 
 #include "acl/acl.h"
-#include "pto/comm/async_common/async_types.hpp"
+#include "pto/comm/async_common/sdma_constants.hpp"
 
 #ifndef ACL_STREAM_DEVICE_USE_ONLY
 #define ACL_STREAM_DEVICE_USE_ONLY 0x00000020U

--- a/include/pto/comm/async_common/async_types.hpp
+++ b/include/pto/comm/async_common/async_types.hpp
@@ -13,6 +13,7 @@ See LICENSE in the root of the software repository for the full text of the Lice
 
 #include <cstdint>
 #include <climits>
+#include "pto/comm/async_common/sdma_constants.hpp"
 #include "pto/comm/comm_types.hpp"
 
 namespace pto {
@@ -26,12 +27,6 @@ constexpr uint32_t kSdmaFlagLength = 128U;
 constexpr uint32_t kUbAlignSize = 256U;
 constexpr uint32_t kSdmaEventRecordBytes = 16U;
 constexpr uint32_t kSdmaEventSlotCount = kSdmaFlagLength / kSdmaEventRecordBytes;
-constexpr uint32_t kSdmaContextWorkspaceBytes = 16U * 1024U;
-constexpr uint32_t kSdmaFlagPayloadBytesPerGroup = 512U;
-constexpr uint32_t kSdmaMaxChannelGroups = 48U;
-constexpr uint32_t kSdmaWorkspaceBytes =
-    kSdmaContextWorkspaceBytes + kSdmaMaxChannelGroups * kSdmaFlagPayloadBytesPerGroup;
-
 constexpr uint32_t SDMA_FLAG_LENGTH = kSdmaFlagLength;
 constexpr uint32_t UB_ALIGN_SIZE = kUbAlignSize;
 constexpr uint32_t SDMA_EVENT_RECORD_BYTES = kSdmaEventRecordBytes;

--- a/include/pto/comm/async_common/sdma_constants.hpp
+++ b/include/pto/comm/async_common/sdma_constants.hpp
@@ -1,0 +1,30 @@
+/**
+Copyright (c) 2025 Huawei Technologies Co., Ltd.
+This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+CANN Open Software License Agreement Version 2.0 (the "License").
+Please refer to the License for details. You may not use this file except in compliance with the License.
+THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+See LICENSE in the root of the software repository for the full text of the license.
+*/
+
+#ifndef PTO_COMM_ASYNC_COMMON_SDMA_CONSTANTS_HPP
+#define PTO_COMM_ASYNC_COMMON_SDMA_CONSTANTS_HPP
+
+#include <cstdint>
+
+namespace pto {
+namespace comm {
+namespace sdma {
+
+constexpr uint32_t kSdmaContextWorkspaceBytes = 16U * 1024U;
+constexpr uint32_t kSdmaFlagPayloadBytesPerGroup = 512U;
+constexpr uint32_t kSdmaMaxChannelGroups = 48U;
+constexpr uint32_t kSdmaWorkspaceBytes =
+    kSdmaContextWorkspaceBytes + kSdmaMaxChannelGroups * kSdmaFlagPayloadBytesPerGroup;
+
+} // namespace sdma
+} // namespace comm
+} // namespace pto
+
+#endif // PTO_COMM_ASYNC_COMMON_SDMA_CONSTANTS_HPP

--- a/include/pto/common/arch_macro.hpp
+++ b/include/pto/common/arch_macro.hpp
@@ -11,13 +11,9 @@ See LICENSE in the root of the software repository for the full text of the Lice
 #ifndef ARCH_MACRO_HPP
 #define ARCH_MACRO_HPP
 
-#if defined(__CPU_SIM)
-#ifndef __DAV_CUBE__
+#if defined(__CPU_SIM) && !defined(__DAV_CUBE__) && !defined(__DAV_VEC__)
 #define __DAV_CUBE__
-#endif
-#ifndef __DAV_VEC__
 #define __DAV_VEC__
-#endif
 #endif
 
 #if __NPU_ARCH__ == 2201

--- a/include/pto/common/cpu_stub.hpp
+++ b/include/pto/common/cpu_stub.hpp
@@ -126,6 +126,9 @@ struct cache_line_t {
     static constexpr int ENTIRE_DATA_CACHE = 0;
     static constexpr int CACHELINE_OUT = 0;
 };
+struct dcci_dst_t {
+    static constexpr int CACHELINE_OUT = 0;
+};
 inline constexpr mem_dsb_t DSB_DDR = 0;
 inline constexpr mem_dsb_t DSB_ALL = 0;
 inline constexpr mem_dsb_t DSB_UB = 0;


### PR DESCRIPTION
## 修改说明

本 PR 通过两个相互独立、范围受控的兼容性修复，解除 hw-native-sys/simpler#1644 升级 PTO-ISA 时遇到的阻塞。下面按文件分别说明修改原因和实现方式。

### `include/pto/comm/async_common/sdma_constants.hpp`（新增）

**为什么：** host 侧的 SDMA workspace manager 实际只需要四个 workspace 大小常量，但这些常量原来定义在 `async_types.hpp` 中。为了读取几个整数常量而包含这个面向设备侧的宽依赖头文件，会把 Tile、`__ubuf__`、`__cbuf__` 等设备类型和限定符带入普通 host C++ 编译。

**怎么改：** 新增一个仅依赖 `<cstdint>` 的轻量头文件，集中定义 `kSdmaContextWorkspaceBytes`、`kSdmaFlagPayloadBytesPerGroup`、`kSdmaMaxChannelGroups` 和 `kSdmaWorkspaceBytes`。所有数值保持不变，workspace 总大小仍为 40 KiB。

### `include/pto/comm/async_common/async_types.hpp`

**为什么：** 抽取常量后，需要保证它们只有一个定义来源；同时还要兼容现有设备侧代码——这些代码可能只包含 `async_types.hpp`，并期望仍能访问上述常量。

**怎么改：** 在 `async_types.hpp` 中包含新的 `sdma_constants.hpp`，并删除原来的四个本地定义。常量名称和命名空间保持不变，现有调用方不需要迁移。

### `include/pto/comm/async/sdma/sdma_workspace_manager.hpp`

**为什么：** 这是 Simpler host 编译失败的直接入口。该 manager 只使用 workspace 大小常量，却包含了整个 `async_types.hpp`，导致 host `g++` 解析设备侧类型和限定符。

**怎么改：** 将对 `async_types.hpp` 的包含替换为对 `sdma_constants.hpp` 的包含。不改变 workspace 计算或运行逻辑，只把依赖收窄到 host-safe 的轻量头文件。

### `include/pto/common/arch_macro.hpp`

**为什么：** 原逻辑在 `__CPU_SIM` 下分别补齐缺失的 role 宏。当 Simpler 为 AIC kernel 显式指定 `__DAV_CUBE__`，或为 AIV kernel 显式指定 `__DAV_VEC__` 时，PTO-ISA 仍会补上另一个 role。mixed kernel 因此可能同时编译两个 role 路径，或错误进入提前返回分支。但 PTO-ISA 独立 CPU-SIM 测试在没有指定任何 role 时，仍需要保留原来的双 role 默认行为。

**怎么改：** 只有在定义了 `__CPU_SIM` 且 `__DAV_CUBE__`、`__DAV_VEC__` 都未提供时，才默认同时定义两个 role。显式指定 CUBE-only 或 VECTOR-only 时保持原选择；没有指定 role 的 CPU-SIM 调用方仍会得到两个默认 role。

## 测试

- 对全部修改文件执行 `pre-commit`
- 使用普通 g++17 对 `sdma_workspace_manager.hpp` 做独立语法检查
- 验证三种 `__CPU_SIM` 宏组合：未指定 role、仅 CUBE、仅 VECTOR
- A3 compile-only 用例：`tmov_kernel`、`tstore_acc2gm_kernel`、`ttrans_conv_kernel`、`tprefetch_async_kernel`
- Simpler editable install 及全部 host/simulator runtime 构建成功
- Simpler golden 数值测试：A2/A3 `spmd_paged_attention_highperf`、A5 `bgemm`
- Simpler worker collectives：`a2a3sim` 和 `a5sim` 各 19 个场景全部通过
- 设置 `PTO_CPU_SIM_TWAIT_MAX_SPINS=0` 后，两个 simulator 的 4-rank ring allreduce 均通过

GitHub 上的 pre-commit、文档、CPU simulator smoke 和完整 CPU ST 均已通过。A5 NPU smoke 的失败与已合入的基线 PR #222 完全相同，相关 run/job 证据已记录在 PR 评论中；该失败需要上游管理员执行重跑。
