### PR TITLE
fix(backend): Qualify dcci cache line arguments

### DIFF
--- a/docs/isa/tile/ops/memory-and-data-movement/mscatter.md
+++ b/docs/isa/tile/ops/memory-and-data-movement/mscatter.md
@@ -475,12 +475,12 @@ The A5 implementation hides almost the entire pipe model behind `cce::async_invo
 ```cpp
 AICORE PTO_INLINE void FlushScatterOutput()
 {
-    dcci(static_cast<__gm__ void *>(0), ENTIRE_DATA_CACHE);
+    dcci(static_cast<__gm__ void *>(0), cache_line_t::ENTIRE_DATA_CACHE);
     dsb(DSB_DDR);
 }
 ```
 
-`dcci(0, ENTIRE_DATA_CACHE)` invalidates the AIV scalar D-cache so any buffered GM writes are pushed to HBM; `dsb(DSB_DDR)` blocks until the writes are observable at the DDR boundary. This is a **wrapper-level pattern** (not part of the `MSCATTER` intrinsic) — kernel authors should append it to their scatter wrapper when the host code reads back the GM table immediately after the kernel returns.
+`dcci(0, cache_line_t::ENTIRE_DATA_CACHE)` invalidates the AIV scalar D-cache so any buffered GM writes are pushed to HBM; `dsb(DSB_DDR)` blocks until the writes are observable at the DDR boundary. This is a **wrapper-level pattern** (not part of the `MSCATTER` intrinsic) — kernel authors should append it to their scatter wrapper when the host code reads back the GM table immediately after the kernel returns.
 
 ## UB Memory Budget
 

--- a/include/pto/npu/a2a3/grid_intrinsic.hpp
+++ b/include/pto/npu/a2a3/grid_intrinsic.hpp
@@ -463,11 +463,11 @@ inline AICORE void MockMtsprCounter(__gm__ uint32_t *remoteFlag, uint32_t newVal
         // Match the canonical TNotify Set pattern: pre-invalidate, store,
         // post-invalidate, dsb(DSB_DDR).  Compiler barriers prevent reordering.
         __asm__ __volatile__("" ::: "memory");
-        dcci(reinterpret_cast<__gm__ void *>(const_cast<__gm__ uint32_t *>(ptr)), SINGLE_CACHE_LINE);
+        dcci(reinterpret_cast<__gm__ void *>(const_cast<__gm__ uint32_t *>(ptr)), cache_line_t::SINGLE_CACHE_LINE);
         __asm__ __volatile__("" ::: "memory");
         *ptr = newValue;
         __asm__ __volatile__("" ::: "memory");
-        dcci(reinterpret_cast<__gm__ void *>(const_cast<__gm__ uint32_t *>(ptr)), SINGLE_CACHE_LINE);
+        dcci(reinterpret_cast<__gm__ void *>(const_cast<__gm__ uint32_t *>(ptr)), cache_line_t::SINGLE_CACHE_LINE);
         __asm__ __volatile__("" ::: "memory");
         dsb(DSB_DDR);
     }
@@ -517,7 +517,7 @@ inline AICORE bool MockTryWfeCounter(__gm__ uint32_t *localFlag, uint32_t thresh
     constexpr uint32_t kFenceInterval = 64;
     while (true) {
         __asm__ __volatile__("" ::: "memory");
-        dcci(reinterpret_cast<__gm__ void *>(const_cast<__gm__ uint32_t *>(p)), SINGLE_CACHE_LINE);
+        dcci(reinterpret_cast<__gm__ void *>(const_cast<__gm__ uint32_t *>(p)), cache_line_t::SINGLE_CACHE_LINE);
         __asm__ __volatile__("" ::: "memory");
         if (*p >= threshold) {
             return true;
@@ -560,7 +560,7 @@ inline AICORE void MockSetFault(__gm__ uint32_t *faultFlag, uint32_t faultCode)
         __asm__ __volatile__("" ::: "memory");
         *ptr = faultCode;
         __asm__ __volatile__("" ::: "memory");
-        dcci(reinterpret_cast<__gm__ void *>(const_cast<__gm__ uint32_t *>(ptr)), SINGLE_CACHE_LINE);
+        dcci(reinterpret_cast<__gm__ void *>(const_cast<__gm__ uint32_t *>(ptr)), cache_line_t::SINGLE_CACHE_LINE);
         dsb(DSB_DDR);
     }
 }


### PR DESCRIPTION
## Summary
- Qualify dcci cache line selectors with the cache_line_t enum in grid intrinsic helpers
- Update the MSCATTER documentation example to match the qualified cache_line_t usage