### PR TITLE
fix(a2a3): give the V2C ring its own base in a bidirectional TPipe

### DIFF
--- a/include/pto/npu/a2a3/TPush.hpp
+++ b/include/pto/npu/a2a3/TPush.hpp
@@ -462,6 +462,20 @@ struct TPipe {
     PTO_INTERNAL explicit TPipe(__gm__ void* GM_SLOT_BUFFER, uint32_t C2V_CONSUMER_BUF, uint32_t V2C_CONSUMER_BUF)
         : fifo(GM_SLOT_BUFFER, C2V_CONSUMER_BUF, V2C_CONSUMER_BUF), prod(), cons()
     {
+        // Bidirectional: the two rings must NOT overlap. Both directions index the shared GM
+        // buffer as (tileIndex % SlotNum) * SlotSize, so without a per-direction base the C2V
+        // and V2C rings alias the same slots and silently corrupt each other's tiles. Place
+        // V2C after C2V, exactly as the ISA reference specifies
+        // (`v2c_ring_buf = GM_SLOT_BUFFER + SLOT_NUM * SLOT_SIZE`).
+        if constexpr (is_both) {
+            constexpr int V2C_ENTRY_OFFSET = static_cast<int>(SlotNum) * static_cast<int>(SlotSize);
+#ifdef __DAV_CUBE__
+            cons.setEntryOffset(V2C_ENTRY_OFFSET); // Cube consumes V2C
+#endif
+#ifdef __DAV_VEC__
+            prod.setEntryOffset(V2C_ENTRY_OFFSET); // Vector produces V2C
+#endif
+        }
         for (uint32_t i = 0; i < SyncPeriod; ++i) {
             cons.free();
         }

--- a/tests/npu/a2a3/src/st/testcase/tpushpop_dir_both/main.cpp
+++ b/tests/npu/a2a3/src/st/testcase/tpushpop_dir_both/main.cpp
@@ -44,7 +44,10 @@ void TPushPopDirBothTestFunc(uint32_t M, uint32_t K, uint32_t N)
     size_t dFileSize = K * N * sizeof(T);
     size_t fFileSize = M * N * sizeof(T);
     size_t outFileSize = M * N * sizeof(T);
-    size_t fifoFileSize = 2 * M * N * sizeof(T);
+    // A DIR_BOTH pipe is two rings in GM: C2V at offset 0 and V2C at SLOT_NUM * SLOT_SIZE.
+    // SLOT_SIZE = M * N * sizeof(T) and SLOT_NUM = FIFO_DEPTH = 2 in the kernel, so the
+    // buffer must be 2 * SLOT_NUM * SLOT_SIZE.
+    size_t fifoFileSize = 4 * M * N * sizeof(T);
 
     aclInit(nullptr);
     aclrtSetDevice(0);


### PR DESCRIPTION
## Background

`Fixes #226`. On A2A3 both directions of a `DIR_BOTH` `TPipe` address the shared GM buffer as `(tileIndex % SLOT_NUM) * SLOT_SIZE + entryOffset`, and `entryOffset` is never set for that mode, so the C2V and V2C rings occupy the same slots and silently overwrite each other's tiles once more than one tile is in flight. Issue #226 has the full analysis, a minimal repro and the hardware numbers; it supersedes the withdrawn #195.

## Goal

Make the implementation match the A2A3 GM layout this repo already specifies in `docs/HL_ptoisa_newfeature20260306_TPUSH_TPOP.md` — C2V ring at offset 0, V2C ring at `SLOT_NUM * SLOT_SIZE`, total `2 * SLOT_NUM * SLOT_SIZE` (`:169`, `:222-223`, `:288`).

## Design

In the `TPipe` constructor, for `is_both` only, set the V2C entry offset on whichever endpoint owns the V2C direction on this core — the consumer under `__DAV_CUBE__`, the producer under `__DAV_VEC__` — ahead of the existing `SyncPeriod` credit-priming loop. Both terms are compile-time constants, so the generated address arithmetic is unchanged in cost. Unidirectional pipes and `DIR_V2C_CTRL` (which uses `CTRL_SLOT_BUFFER`) are untouched.

The bidirectional ST case allocated `2 * M * N * sizeof(T)` — with `SLOT_SIZE = M * N * sizeof(T)` and `SLOT_NUM = FIFO_DEPTH = 2`, exactly one ring. It is sized for two, which it now needs.

| File | Change |
|---|---|
| `include/pto/npu/a2a3/TPush.hpp` | Set the V2C ring base in the `TPipe` ctor for `DIR_BOTH` |
| `tests/npu/a2a3/src/st/testcase/tpushpop_dir_both/main.cpp` | GM buffer `2 * M*N*T` → `4 * M*N*T` (two rings) |

## Compatibility — please read before merging

The frontend allocating `GM_SLOT_BUFFER` must now provide `2 * SLOT_NUM * SLOT_SIZE` for a bidirectional pipe, as the design doc has always specified. pypto sized it as one ring; that is fixed in hw-native-sys/pypto#2269, which **must ship first**. With an unfixed frontend this patch writes the V2C ring past the end of the allocation. Any other frontend or hand-written kernel using a `DIR_BOTH` GM pipe needs the same doubling. This probably deserves a `ReleaseNote.md` entry and a minimum pypto version — happy to add both if you tell me the wording you want.

## Validation

Atlas A2/A3, fp32, at the **stock** ring depth of 4, no DSL overrides, with the pypto half applied:

| Check | Before | After |
|---|---|---|
| Minimal repro (issue #226), C=16, N ∈ {2,4,5,6,7,8,16} × 3 dispatches | 12/21 corrupted | **21/21 clean** |
| Same kernel at 4 KiB slots, N ∈ {4,8,16,32} | corrupt at every N and every ring depth (4/8/16/32) | **clean** |
| GLA/ZeCO fused forward, C ∈ {16,32} × P ∈ {1,2,4} × N ∈ {2,4,8,16} | 5/12 fail at C=16, 6/12 at C=32 | **24/24 pass**, max abs err ≤ 3.1e-5 |
| Downstream regression suites | 4 / 3 / 3 pass | **4 / 3 / 3 pass** |

Two caveats, stated plainly. Validation ran on `83d01313` (the revision our runtime pins), not on `main`: the patch is rebased onto `e8f558d5` and applies cleanly, and every symbol it touches is unchanged there — `is_both`, `SlotNum`/`SlotSize`, `Producer::setEntryOffset` (`:88`), `Consumer::setEntryOffset` (`:308`) and the `(tileIndex % SLOT_NUM) * SLOT_SIZE + entryOffset` addressing (`:155`, `:187`, `:252`, `:398`, `:420`) — but I have not re-run the hardware suite against `main`'s ISA headers. And `clang-format` is not installed in my environment, so the added lines were matched to the file's style by hand (ColumnLimit 120, 4-space indent, nothing over 120 chars) rather than machine-formatted; please flag anything the CI formatter objects to.

## Two questions

1. **`entryOffset` is doing double duty.** Manual kernels use `setEntryOffset` for intra-slot addressing (`kernels/manual/a5/flash_atten/fa_performance_kernel.cpp:436` and friends — on `TMPipe`, so nothing in-tree collides today). But once the ctor writes a direction base there, any `DIR_BOTH` user calling `setEntryOffset` would silently clobber it. The same fix can instead be a separate compile-time `V2C_RING_BASE` added alongside `entryOffset` in the addressing expressions, leaving `entryOffset` purely caller-owned — behaviourally identical, same codegen. Say which you prefer and I will reshape it and re-validate on hardware.
2. **a5 `DIR_BOTH_GM` looks like the same bug.** `include/pto/npu/a5/TPush.hpp:290`, `:319`, `:399`, `:655` all use `GM_SLOT_BUFFER + entryBase + entryOffset`, and the a5 ctor (`:704`) is empty. a5's plain `DIR_BOTH` is fine (each direction has its own consumer SRAM) but `DIR_BOTH_GM` puts both in GM. I have no A5 hardware, so I have not touched it — same PR, or a separate issue?

## Suggested follow-up test

A `tpushpop_dir_both_loop` ST case that runs N iterations with both directions in flight — the vector pushing `V2C[k]` while the cube is still consuming `V2C[k-1]` and producing `C2V[k-1]` — with `SLOT_NUM` small enough to wrap. That is the traffic shape that exposes this; the current single-shot case cannot, because the cube cannot push its result before it has popped its input. Glad to add it here if you want it in this PR.
